### PR TITLE
docs(agents): add Lemonade fork stewardship docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,17 @@ This file provides guidance to agent driven code reviews when working with this 
 
 Lemonade is a local LLM server providing GPU and NPU acceleration for running large language models on consumer hardware. It exposes OpenAI-compatible, Ollama-compatible, and Anthropic-compatible REST APIs, plus a WebSocket Realtime API. It supports multiple backends: llama.cpp, FastFlowLM, RyzenAI, whisper.cpp, stable-diffusion.cpp, and Kokoro TTS.
 
+## Fork Stewardship
+
+This repository is `nisavid/lemonade`, a fork of upstream Lemonade (`lemonade-sdk/lemonade`) at <https://github.com/lemonade-sdk/lemonade> and <https://lemonade-server.ai/>. Upstream maintainers own the product language, architecture, conventions, and public documentation unless this fork intentionally diverges.
+
+- Treat upstream docs, source, release notes, and website as the canonical source for Lemonade behavior. Use [CONTEXT.md](CONTEXT.md) as a compact scout map and glossary, not as a replacement for upstream sources.
+- Before finalizing specs, plans, or implementations, scout the relevant upstream docs and code paths, infer the maintainers' intent, and record durable findings in the narrowest useful agent-facing doc.
+- By default, changes in this repo are fork-local and should be pushed only to this fork's origin. Do not open upstream PRs, create upstream issues, or assume upstream submission intent unless the user explicitly says so.
+- Preserve upstream commit identity and history shape during fork sync work. Do not use rebase, force-push, or history-replacing sync flows for upstream updates unless the user explicitly requests that behavior.
+- Keep the fork owner in the role of intent, taste, UX feedback, pragmatic judgment, engineering management, and architectural discretion. Agents are expected to do the research, source reading, implementation planning, validation, and documentation needed to make that judgment actionable.
+- Keep agent-facing docs progressive and scout-oriented: capture non-obvious policy, source maps, vocabulary, and false-assumption guardrails; avoid duplicating large sections of upstream documentation that agents can re-read directly.
+
 ## Architecture
 
 ### Executables
@@ -56,9 +67,9 @@ All core endpoints are registered under **4 path prefixes**:
 
 **WebSocket Realtime API**: OpenAI-compatible Realtime protocol for real-time audio transcription. Binds to an OS-assigned port (9000+), exposed via the `websocket_port` field in the `/health` endpoint response.
 
-**Internal endpoints:** `POST /internal/shutdown`
+**Internal endpoints:** `POST /internal/shutdown`, `POST /internal/set`, `GET /internal/config`, `POST /internal/cleanup-cache`
 
-Optional API key auth via `LEMONADE_API_KEY` env var (regular API endpoints) or `LEMONADE_ADMIN_API_KEY` env var (full access including internal endpoints). Clients prefer `LEMONADE_ADMIN_API_KEY` if set. CORS enabled on all routes.
+Optional API key auth via `LEMONADE_API_KEY` env var (regular API endpoints) or `LEMONADE_ADMIN_API_KEY` env var (regular plus internal endpoints). Clients prefer `LEMONADE_ADMIN_API_KEY` if set. Internal endpoints remain restricted to loopback regardless of API key. CORS enabled on all routes.
 
 ### Desktop & Web App
 
@@ -199,3 +210,30 @@ These MUST be maintained in all changes:
 - UI/frontend changes are handled by core maintainers only
 - Python formatting with Black is required
 - PRs trigger CI for linting, formatting, and integration tests
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `nisavid/lemonade`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The repo uses the default five-label triage vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repo with upstream-derived vocabulary and source maps. See `CONTEXT.md`, `docs/agents/domain.md`, `docs/agents/fork-stewardship.md`, `docs/agents/research-map.md`, and `docs/agents/architecture-map.md`.
+
+## Operating Policy
+
+- This repository uses agentic engineering and operations. Agents should perform assigned tasks autonomously until they reach a boundary that requires stakeholder policy or an unavailable control surface.
+- The user reserves authority over project initiatives and over initiation or continuation of work sessions. Within an active user-directed session, agents should drive execution, review loops, commits, publication steps, and cleanup unless escalation is required.
+- Escalate when a decision or action impacts stakeholder concerns and the stakeholder's policy is unknown or uncertain.
+- Escalate when an action must be taken but the agent lacks an autonomous control surface for it.
+- When escalating a decision and a set of plausible, distinct choices is known, use a multiple-choice input tool if one is available in the interactive context. Include a way for the human operator to provide custom input.
+- When escalating an action with a known prescribed path, present the steps clearly for the human operator to perform. Prefer fewer steps; present commands in easily copyable blocks, and prefer a single one-line command when practical.
+- For every escalation, make the return contract clear: state exactly what result, confirmation, artifact, or output is needed to hand control back to the agent, and make it easy to validate.
+- Prefer verified repository facts over guesses or aspirational guidance.
+- When adding new agent-facing instructions, ask whether the information is durable, non-obvious, and useful before scouting a task.
+- Remove guidance that becomes redundant with ordinary file discovery.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,275 @@
+# Lemonade Fork Context
+
+This context records an upstream-derived working vocabulary for agents operating in the `nisavid/lemonade` fork. Upstream Lemonade owns the canonical product language and architecture; use this file to find and apply that language, then verify against current upstream docs and source before making durable plans or changes.
+
+## Source Authority
+
+- Upstream source: <https://github.com/lemonade-sdk/lemonade>
+- Upstream website and docs: <https://lemonade-server.ai/> and <https://lemonade-server.ai/docs/>
+- Local fork policy: `AGENTS.md` and `docs/agents/`
+- Local scout map: `docs/agents/research-map.md`
+
+## Language
+
+### Product and Runtime
+
+**Lemonade**:
+The local AI runtime and project that makes local text, vision, image, transcription, and speech capabilities available through standard APIs.
+_Avoid_: Treating Lemonade as only a chat UI or only an LLM runner.
+
+**Lemonade Server**:
+The installable local service experience that exposes Lemonade capabilities to users, apps, and tools.
+_Avoid_: Using this term when only the `lemond` executable is meant.
+
+**Embeddable Lemonade**:
+A portable `lemond` release artifact that app builders bundle privately into their own applications.
+_Avoid_: Assuming it is the same deployment shape as the globally installed Lemonade Server service.
+
+**lemond**:
+The pure HTTP server process that loads configuration, registers routes, and delegates inference to backend subprocesses.
+_Avoid_: `lemonade-server` when referring to the current server executable.
+
+**lemonade CLI**:
+The command-line client for controlling a running Lemonade service.
+_Avoid_: Treating the CLI as the server process.
+
+**Lemonade desktop app**:
+The Tauri-based thin client that manages models and chats with a separately running `lemond`.
+_Avoid_: Assuming the desktop app owns the server lifecycle.
+
+**Lemonade web app**:
+The browser build of the shared React renderer served by `lemond` for `/app`.
+_Avoid_: Consolidating its package metadata with the desktop app.
+
+**Tray app**:
+The lightweight macOS/Linux tray client that connects to a running `lemond`.
+_Avoid_: Confusing it with Windows `LemonadeServer.exe`.
+
+**LemonadeServer.exe**:
+The Windows GUI process that embeds `lemond` and shows the system tray icon.
+_Avoid_: Treating it as the on-demand Tauri desktop app.
+
+**Local server**:
+Server software running on client hardware rather than cloud infrastructure.
+_Avoid_: Assuming "local" always means "same process" or "same client machine."
+
+### API and Client Integration
+
+**OpenAI-compatible API**:
+The primary standards-compatible API surface for chat, completions, embeddings, responses, audio, image, models, and realtime behavior.
+_Avoid_: Treating Lemonade-specific lifecycle APIs as part of OpenAI compatibility.
+
+**Ollama-compatible API**:
+The `/api/*` compatibility surface for Ollama-oriented clients.
+_Avoid_: Assuming unsupported Ollama create/copy/push flows are implemented.
+
+**Anthropic-compatible API**:
+The Messages-style compatibility endpoint for Claude-oriented clients.
+_Avoid_: Assuming every Anthropic-specific field is fully implemented.
+
+**Lemonade-specific API**:
+The local-first lifecycle and management API for model pull/delete/load/unload, health, stats, system info, backend install, and logs.
+_Avoid_: Exposing local management behavior through cloud API assumptions.
+
+**Realtime API**:
+The OpenAI-compatible WebSocket surface for real-time audio transcription.
+_Avoid_: Assuming it shares the main HTTP server port.
+
+**OmniRouter**:
+Lemonade's approach to multimodal agentic workflows using standard model endpoints as OpenAI-compatible tools.
+_Avoid_: Describing it as a proprietary agent runtime.
+
+**Collection**:
+A preconfigured multi-model bundle sized for a hardware tier and used by OmniRouter workflows.
+_Avoid_: Calling user-facing collections "bundles" unless quoting internal code or history.
+
+**Tool definition**:
+A JSON schema entry that maps an OmniRouter tool name to a Lemonade endpoint and required model labels.
+_Avoid_: Hand-authoring divergent tool schemas when the app's canonical JSON exists.
+
+### Models, Recipes, and Backends
+
+**Model registry**:
+The built-in `server_models.json` catalog of Lemonade model entries.
+_Avoid_: Treating it as a complete list of every possible Hugging Face model.
+
+**Model name**:
+The identifier used by APIs and CLI commands to refer to a registered, user, extra, or collection model.
+_Avoid_: Confusing model names with Hugging Face checkpoint ids.
+
+**Built-in model**:
+A model shipped in the upstream registry.
+_Avoid_: Editing built-in entries without checking recipe integrity and hardware filtering.
+
+**User model**:
+A custom model registered under the `user.` namespace.
+_Avoid_: Storing the `user.` prefix inside `user_models.json` keys.
+
+**Extra model**:
+A GGUF model discovered from `extra_models_dir` under the `extra.` namespace.
+_Avoid_: Deleting extra models through the API; those files are user-managed.
+
+**Checkpoint**:
+The Hugging Face repository, file, variant, or local path used to locate model artifacts.
+_Avoid_: Assuming every checkpoint is a single GGUF file.
+
+**Variant**:
+The checkpoint suffix selecting a quantization, file, or sharded folder.
+_Avoid_: Assuming omitted variants are always unambiguous.
+
+**Recipe**:
+The Lemonade model execution family, such as `llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `sd-cpp`, `kokoro`, or `collection`.
+_Avoid_: Using "recipe" and "backend" interchangeably.
+
+**Backend**:
+The concrete engine implementation or acceleration choice used by a recipe, such as Vulkan, ROCm, Metal, CPU, or NPU.
+_Avoid_: Assuming all recipes expose the same backend choices.
+
+**Backend version pin**:
+The `backend_versions.json` entry that selects the upstream backend artifact Lemonade downloads.
+_Avoid_: Updating backend pins without checking the corresponding recipe behavior and package/runtime effects.
+
+**Recipe options**:
+Per-model or global runtime settings that shape how a recipe launches and runs.
+_Avoid_: Treating recipe options as model registry identity.
+
+**NPU exclusivity**:
+The rule that exclusive NPU recipes evict other NPU models before loading.
+_Avoid_: Assuming FLM coexistence rules apply to RyzenAI or whisper.cpp NPU models.
+
+### Hardware and Engines
+
+**CPU**:
+The universal fallback device for supported x86_64 execution paths.
+_Avoid_: Treating CPU support as a performance target for every model size.
+
+**GPU**:
+The graphics processor used through backends such as Vulkan, ROCm, Metal, vLLM ROCm, or sd-cpp ROCm.
+_Avoid_: Assuming all GPU backends support the same vendors or operating systems.
+
+**NPU**:
+The neural processing unit targeted by RyzenAI and FastFlowLM paths.
+_Avoid_: Assuming NPU behavior is cross-platform or unconstrained.
+
+**Ryzen AI**:
+AMD's AI PC platform and NPU software ecosystem used by Lemonade NPU and hybrid paths.
+_Avoid_: Assuming every Ryzen CPU has the same NPU capability.
+
+**XDNA2 NPU**:
+The NPU family targeted by current Lemonade FastFlowLM and RyzenAI NPU support.
+_Avoid_: Generalizing to older Ryzen AI NPUs without source evidence.
+
+**llama.cpp**:
+The primary LLM inference recipe family for GGUF models across CPU, Vulkan, ROCm, Metal, and system backends.
+_Avoid_: Assuming llama.cpp itself downloads models at request time.
+
+**FastFlowLM**:
+The `flm` recipe family for NPU LLM, embedding, reranking, and audio paths.
+_Avoid_: Applying non-FLM model download assumptions to FLM models.
+
+**RyzenAI**:
+The `ryzenai-llm` recipe family for Windows NPU and hybrid model execution.
+_Avoid_: Assuming it is the Linux NPU path.
+
+**vLLM**:
+The experimental ROCm-on-Linux recipe for high-concurrency LLM inference on supported AMD GPUs.
+_Avoid_: Treating it as broadly validated outside the documented GPU targets.
+
+**whisper.cpp**:
+The speech-to-text recipe family for audio transcription.
+_Avoid_: Treating text-to-speech behavior as whisper.cpp behavior.
+
+**stable-diffusion.cpp**:
+The `sd-cpp` recipe family for image generation, editing, variations, and upscaling.
+_Avoid_: Calling the recipe `stable-diffusion.cpp` in JSON where `sd-cpp` is expected.
+
+**Kokoro**:
+The text-to-speech recipe family.
+_Avoid_: Confusing Kokoro TTS with whisper.cpp speech-to-text.
+
+**GGUF**:
+The common llama.cpp model artifact format used for many LLM, embedding, reranking, and vision models.
+_Avoid_: Assuming GGUF implies text-only.
+
+**ONNX**:
+The model artifact family used by RyzenAI/OGA-style optimized model paths.
+_Avoid_: Treating ONNX models as llama.cpp-compatible.
+
+**Hugging Face cache**:
+The primary model storage layout Lemonade uses for downloaded model artifacts.
+_Avoid_: Replacing cache path logic with host-specific hardcoded paths.
+
+### Design Tenets
+
+**Foundation, not the house**:
+Lemonade should let users start in the app, connect other apps, and eventually embed Lemonade invisibly.
+_Avoid_: Making the GUI the center of every workflow.
+
+**Happy path**:
+The default user journey should stay simple even when advanced configuration exists.
+_Avoid_: Exposing advanced backend complexity before users need it.
+
+**Standards are intuitive**:
+Prefer existing standards such as OpenAI APIs, Ollama conventions, and familiar GUI patterns.
+_Avoid_: Inventing a Lemonade-specific concept when a standard one fits.
+
+**Automate the documentation away**:
+Complex documentation is treated as a signal that a feature may need more automation.
+_Avoid_: Solving user confusion only by adding more prose.
+
+**User error is a bug**:
+Common user mistakes should drive UX, validation, and documentation improvements.
+_Avoid_: Blaming users for plausible input.
+
+**Backends are fungible**:
+Users and builders should be able to switch viable backend choices with minimal friction.
+_Avoid_: Promoting one backend as intrinsically superior across all contexts.
+
+**Design for agility**:
+The project values day-0 model and engine access, with features designed to accelerate future development.
+_Avoid_: Hardcoding assumptions that slow backend/model refreshes.
+
+### Fork Operation
+
+**Upstream Lemonade**:
+The `lemonade-sdk/lemonade` project, website, maintainers, docs, and release stream that define the baseline product.
+_Avoid_: Treating fork-local agent notes as upstream authority.
+
+**Fork origin**:
+The `nisavid/lemonade` repository where this work is pushed by default.
+_Avoid_: Assuming a change is intended for upstream submission.
+
+**Fork-local change**:
+A change intended to help this fork's operation, exploration, packaging, or agent guidance without upstream submission.
+_Avoid_: Reframing fork-local work as an upstream contribution.
+
+**Upstream contribution exception**:
+An explicit user-directed change in which upstream submission, upstream issues, or upstream PRs are in scope.
+_Avoid_: Opening upstream-facing artifacts without the user's explicit direction.
+
+## Relationships
+
+- **Lemonade Server** runs **lemond**, and clients interact with **lemond** over HTTP or WebSocket APIs.
+- The **lemonade CLI**, **Lemonade desktop app**, **Lemonade web app**, **tray app**, and third-party apps are clients of **lemond**.
+- **lemond** delegates model lifecycle and inference work to backend subprocesses.
+- A **model name** resolves to model metadata, a **recipe**, **checkpoints**, labels, loaded-model category, and recipe options.
+- A **recipe** selects the execution family; a **backend** selects the concrete engine or device path inside that family.
+- Loaded-model categories control per-type LRU slots; **NPU exclusivity** controls cross-type NPU eviction.
+- **OmniRouter** uses **Collections** and **tool definitions** to expose multi-modal endpoints through the standard tool-calling loop.
+- **Fork-local changes** target **fork origin** unless the user declares an **upstream contribution exception**.
+
+## Example dialogue
+
+> **Agent:** "Should this plan add a new Lemonade model registry entry or just document a custom Hugging Face pull flow?"
+> **Fork owner:** "Check upstream intent first. If upstream already treats `lemonade pull owner/repo` as the happy path, prefer docs or UX around that path. Do not make a registry change unless the source evidence says a built-in model entry is appropriate."
+>
+> **Agent:** "Should I file this against upstream?"
+> **Fork owner:** "No. Treat it as fork-local unless I explicitly say upstream is in scope."
+
+## Flagged ambiguities
+
+- "Server" may mean **Lemonade Server**, **lemond**, `LemonadeServer.exe`, or a backend subprocess. Name the specific process or product surface.
+- "Backend" may mean a recipe family, an acceleration option, or an upstream executable. Use **recipe** for Lemonade model execution families and **backend** for the concrete engine/device choice.
+- "App" may mean the Tauri desktop app, the browser web app, a tray client, or a third-party client. Name the client surface.
+- "Local" means local-first and user-controlled, not necessarily same-process or same-machine.
+- "Collection" is the current user-facing term for OmniRouter multi-model bundles; use older names only when reading internal identifiers or historical commits.

--- a/docs/agents/architecture-map.md
+++ b/docs/agents/architecture-map.md
@@ -1,0 +1,56 @@
+# Architecture Map
+
+This file captures implementation landmarks that are useful before changing Lemonade, but too implementation-specific for `CONTEXT.md`.
+
+## Process Topology
+
+- `lemond` is the pure HTTP server process.
+- `lemonade` is the CLI client.
+- `LemonadeServer.exe` embeds `lemond` on Windows and provides the always-on tray icon.
+- `lemonade-tray` is the macOS/Linux tray client.
+- `lemonade-server` is a deprecated compatibility shim.
+- Backends run as subprocesses; do not move inference engines in-process without an explicit architecture decision.
+
+## Server Core
+
+- `src/cpp/server/server.cpp` registers HTTP routes, serves the web app, applies auth, and owns endpoint handlers.
+- Core API endpoints are registered under `/api/v0/`, `/api/v1/`, `/v0/`, and `/v1/`.
+- Ollama-compatible routes live under `/api/` without the Lemonade/OpenAI version prefix.
+- Internal endpoints live under `/internal/`: `shutdown`, `set`, `config`, and `cleanup-cache`. They are loopback-restricted admin/local lifecycle, configuration, and cache-management APIs, not OpenAI-compatible routes.
+
+## Model Lifecycle
+
+- `Router` (`src/cpp/server/router.cpp`) selects loaded servers, applies model-type LRU, enforces NPU constraints, and forwards inference.
+- `WrappedServer` (`src/cpp/include/lemon/wrapped_server.h`) is the in-process abstraction for one backend subprocess.
+- `ModelManager` (`src/cpp/server/model_manager.cpp`) loads built-in and user registries, resolves paths, registers user models, discovers extra GGUF models, and downloads artifacts.
+- `server_models.json` is the built-in model registry.
+- `backend_versions.json` pins downloadable backend artifact versions.
+- `recipe_options.json` stores per-model runtime options in the Lemonade cache.
+
+## Cache and Eviction
+
+- Model type controls the LRU bucket: LLM, embedding, reranking, audio, image, or TTS.
+- `max_loaded_models` applies per model type, not globally.
+- Busy `WrappedServer` instances are protected from eviction until their active request ends.
+- Non-file-not-found load failures trigger an evict-all-and-retry path.
+- Exclusive NPU recipes evict other NPU users; FLM has recipe-specific coexistence rules.
+
+## Frontend Split
+
+- `src/app/src/renderer/` is the shared React renderer.
+- The Tauri desktop app uses `src/app/src-tauri/` and installs `window.api` through `tauriShim.ts`.
+- The browser web app in `src/web-app/` reuses the shared renderer with a separate package/dependency tree.
+- Do not consolidate `src/app/package.json` and `src/web-app/package.json`; the split supports Debian native packaging with system Node modules.
+
+## OmniRouter
+
+- `docs/dev/omni-router.md` explains the upstream design intent.
+- `src/app/src/renderer/utils/toolDefinitions.json` is the canonical local source for tool definitions.
+- Collections are virtual multi-model entries. They are hidden from the default `/v1/models` response and surfaced through `?show_all=true` for the app.
+
+## Before Changing Architecture
+
+1. Read the relevant user-facing docs first to infer intended behavior.
+2. Read the source paths above.
+3. Check whether the behavior is an upstream invariant, a fork-local policy, or an implementation accident.
+4. If the change deliberately alters architecture, record the decision in `docs/adr/` when it is hard to reverse, surprising, and trade-off driven.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,43 @@
+# Domain Docs
+
+This is a single-context repo whose domain language and architecture are upstream-derived. Engineering skills should use the repo-level domain and architecture documentation before making context-sensitive changes, then verify against current upstream sources when details may have drifted.
+
+## Before exploring, read these
+
+- `AGENTS.md` for current repo guidance, critical invariants, build commands, and test commands.
+- `CONTEXT.md` at the repo root for upstream-derived Lemonade vocabulary, relationships, and flagged ambiguities.
+- `docs/agents/fork-stewardship.md` for fork-local operating policy.
+- `docs/agents/research-map.md` for source maps, scout routes, and common false assumptions.
+- `docs/agents/architecture-map.md` for compact implementation landmarks and architecture guardrails.
+- `docs/adr/` for architectural decisions that touch the area being changed, when present.
+- Existing docs under `docs/` for user-facing, developer-facing, API, integration, and platform-specific behavior.
+
+If `docs/adr/` does not exist, proceed silently. Do not flag the absence or suggest creating it upfront. Producer skills create ADRs when architectural decisions need a durable home.
+
+## File structure
+
+Expected single-context layout:
+
+```text
+/
+├── AGENTS.md
+├── CONTEXT.md
+├── docs/
+│   ├── agents/
+│   ├── adr/
+│   ├── api/
+│   ├── dev/
+│   ├── guide/
+│   └── integrations/
+└── src/
+```
+
+## Use project vocabulary
+
+When output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term as defined by the repo docs. Avoid introducing alternate names for existing concepts.
+
+If the needed concept is not documented yet, inspect upstream docs and source first. Add stable, upstream-derived terminology to `CONTEXT.md`; note uncertain or fork-local terminology as an open gap instead of canonizing it.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface the conflict explicitly and identify the ADR.

--- a/docs/agents/fork-stewardship.md
+++ b/docs/agents/fork-stewardship.md
@@ -1,0 +1,68 @@
+# Fork Stewardship
+
+This repo is a fork of upstream Lemonade. Agents should treat upstream as the source of product truth and this fork as the default destination for local work.
+
+## Current Policy
+
+- Upstream project: `lemonade-sdk/lemonade`
+- Fork origin: `nisavid/lemonade`
+- Product site: <https://lemonade-server.ai/>
+- Upstream docs: <https://lemonade-server.ai/docs/>
+- Default change target: fork origin only
+
+Do not open upstream pull requests, create upstream issues, or shape work as upstream-bound unless the user explicitly says upstream is in scope.
+
+## Authority Order
+
+Use this order when sources disagree:
+
+1. Explicit user direction for this fork.
+2. Current upstream source, website, docs, release notes, and maintainer-authored contribution guidance.
+3. Fork-local `AGENTS.md`, `CONTEXT.md`, and `docs/agents/`.
+4. Inferences from source structure and tests.
+5. Prior agent notes, only after checking that they still match current upstream and local files.
+
+When an inference matters, label it as an inference. Do not present inferred architecture intent as upstream-stated fact.
+
+## Before Specs, Plans, or Implementation
+
+For any non-trivial change:
+
+1. Read `AGENTS.md`, `CONTEXT.md`, `docs/agents/domain.md`, and `docs/agents/research-map.md`.
+2. Identify the relevant upstream docs and source paths.
+3. Verify current upstream state when drift could affect the task.
+4. Record durable discoveries in the narrowest useful place:
+   - `CONTEXT.md` for stable vocabulary and relationships.
+   - `docs/agents/research-map.md` for source maps and scout routes.
+   - `docs/agents/fork-stewardship.md` for fork operating policy.
+   - `AGENTS.md` for always-loaded, high-impact rules.
+
+Prefer short entries that tell future agents where to look and which false assumptions to avoid.
+
+## Fork Sync and Upstream History
+
+Preserve upstream commit identity when bringing upstream changes into this fork. Patch-equivalent content is not enough if upstream ancestry is lost.
+
+For upstream sync work:
+
+```bash
+git merge-base --is-ancestor upstream/main HEAD
+```
+
+Use the equivalent check against the fetched upstream ref if an `upstream` remote is not configured. Avoid rebase, force-push, `gh repo sync --force`, and other history-replacing flows unless the user explicitly requests that behavior.
+
+## Documentation Shape
+
+Keep documentation progressive:
+
+- Put always-needed operating rules in `AGENTS.md`.
+- Put vocabulary in `CONTEXT.md`.
+- Put source maps and research routes in `docs/agents/research-map.md`.
+- Link to upstream docs instead of copying them.
+- Capture likely mistakes and non-obvious source relationships.
+
+Do not create large fork-local rewrites of upstream user docs unless the task is explicitly to author fork-specific user documentation.
+
+## Role Boundary
+
+The fork owner supplies intent, taste, UX feedback, pragmatic judgment, engineering management, and architectural discretion. Agents are responsible for source reading, architecture inference, validation, and making implementation-ready artifacts that respect upstream intent.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,25 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live in GitHub Issues for `nisavid/lemonade`. Use the `gh` CLI for issue operations.
+
+This is the fork's issue tracker. Create or update upstream `lemonade-sdk/lemonade` issues only when the user explicitly says upstream issue work is in scope.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --repo nisavid/lemonade --title "..." --body "..."`
+- **Read an issue**: `gh issue view <number> --repo nisavid/lemonade --comments`
+- **List issues**: `gh issue list --repo nisavid/lemonade --state open --json number,title,body,labels,comments`
+- **Comment on an issue**: `gh issue comment <number> --repo nisavid/lemonade --body "..."`
+- **Apply a label**: `gh issue edit <number> --repo nisavid/lemonade --add-label "..."`
+- **Remove a label**: `gh issue edit <number> --repo nisavid/lemonade --remove-label "..."`
+- **Close an issue**: `gh issue close <number> --repo nisavid/lemonade --comment "..."`
+
+When a skill needs filtered issue data, prefer `--json` plus `--jq` over parsing human-formatted output.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `nisavid/lemonade`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --repo nisavid/lemonade --comments`.

--- a/docs/agents/research-map.md
+++ b/docs/agents/research-map.md
@@ -1,0 +1,96 @@
+# Lemonade Research Map
+
+Use this map to scout Lemonade without bloating every future prompt. It records where to look, what each source is good for, and which assumptions need checking.
+
+Initial scout date: 2026-05-14. The local fork base matched upstream `lemonade-sdk/lemonade` `main` at commit `bdd642230172e917f01e92849ca14e19eb2e897a` before fork-local agent guidance changes.
+
+## Live Primary Sources
+
+- Product site: <https://lemonade-server.ai/>
+- Documentation root: <https://lemonade-server.ai/docs/>
+- Upstream source: <https://github.com/lemonade-sdk/lemonade>
+- Latest releases: <https://github.com/lemonade-sdk/lemonade/releases>
+
+Prefer live upstream sources for time-sensitive details such as latest releases, supported platforms, backend pins, model lists, or current website language.
+
+## Local Source Routes
+
+### Product shape and philosophy
+
+- `README.md`: product overview, supported configurations, model library, roadmap, integration examples, maintainer contacts, privacy policy.
+- `docs/README.md`: documentation entrypoint for users, contributors, builders, and embedders.
+- `docs/dev/philosophy.md`: mission and design tenets.
+- `docs/dev/contribute.md`: upstream contribution process, reviewer expectations, maintainer areas.
+
+### User, CLI, and configuration behavior
+
+- `docs/guide/README.md`: user-guide entrypoint.
+- `docs/guide/concepts.md`: local server and OpenAI-standard framing.
+- `docs/guide/cli.md`: `lemonade` CLI commands and options.
+- `docs/guide/configuration/README.md`: `config.json`, API keys, remote access, backend binary selection.
+- `docs/guide/configuration/custom-models.md`: `user_models.json`, `recipe_options.json`, checkpoints, labels.
+- `docs/guide/configuration/multi-model.md`: model type slots, LRU, and device constraints.
+- `docs/guide/configuration/llamacpp.md`: llama.cpp backend choices and ROCm channels.
+- `docs/guide/configuration/vllm.md`: experimental vLLM ROCm path and gotchas.
+
+### API surfaces
+
+- `docs/api/README.md`: endpoint families and design philosophy.
+- `docs/api/openai.md`: OpenAI-compatible endpoints and request/response shapes.
+- `docs/api/ollama.md`: Ollama compatibility surface and unsupported routes.
+- `docs/api/anthropic.md`: Anthropic Messages compatibility scope.
+- `docs/api/lemonade.md`: Lemonade-specific lifecycle, model, backend, health, stats, and system endpoints.
+- `docs/api/llamacpp.md`: llama.cpp-specific compatibility behavior.
+
+### Embeddable and app surfaces
+
+- `docs/embeddable/README.md`: embeddable artifact, customization, and deployment-ready layout.
+- `docs/embeddable/runtime.md`: subprocess runtime expectations for embedded `lemond`.
+- `docs/embeddable/backends.md`: backend deployment timing and installation strategy.
+- `docs/embeddable/models.md`: bundled, shared, and private model behavior.
+- `docs/dev/app.md`: Tauri desktop app topology and thin-client constraints.
+- `docs/dev/web-ui.md`: browser web app build split and Debian native packaging constraint.
+
+### C++ server architecture
+
+- `src/cpp/server/server.cpp`: HTTP route registration, auth, web app serving, handlers.
+- `src/cpp/server/router.cpp` and `src/cpp/include/lemon/router.h`: model routing, LRU eviction, NPU exclusivity, busy protection.
+- `src/cpp/server/model_manager.cpp` and `src/cpp/include/lemon/model_manager.h`: registry loading, user models, extra models, path resolution, downloads.
+- `src/cpp/include/lemon/wrapped_server.h`: backend subprocess abstraction.
+- `src/cpp/include/lemon/server_capabilities.h`: completion, embedding, reranking, audio, image, TTS, and slots capability interfaces.
+- `src/cpp/include/lemon/model_types.h`: model type and device type classification.
+- `src/cpp/resources/server_models.json`: built-in model registry.
+- `src/cpp/resources/backend_versions.json`: backend artifact version pins.
+
+### Frontend architecture
+
+- `src/app/src/renderer/`: shared React renderer for desktop and web.
+- `src/app/src/renderer/tauriShim.ts`: desktop `window.api` bridge.
+- `src/app/src/renderer/utils/toolDefinitions.json`: canonical OmniRouter tool definitions.
+- `src/app/src-tauri/`: Tauri Rust host, settings, beacon discovery, window and event plumbing.
+- `src/web-app/`: browser build wrapper around the shared renderer.
+
+For architecture relationships that should not live in the domain glossary, see `docs/agents/architecture-map.md`.
+
+## Common False Assumptions
+
+- Do not assume `lemonade-server` is the current server executable; `lemond` is the server and `lemonade-server` is a deprecated compatibility shim.
+- Do not assume the desktop app starts or owns `lemond`; it is a thin client for a separately running server.
+- Do not consolidate `src/app/package.json` and `src/web-app/package.json`; the split supports Debian native packaging.
+- Do not register new HTTP endpoints under only one version prefix; OpenAI-compatible routes use `/api/v0/`, `/api/v1/`, `/v0/`, and `/v1/`.
+- Do not assume `Lemonade Server`, `lemond`, `LemonadeServer.exe`, and backend subprocesses are interchangeable.
+- Do not treat `recipe` and `backend` as synonyms.
+- Do not assume all NPU recipes can coexist; read the router's recipe-aware NPU rules.
+- Do not assume model names and Hugging Face checkpoint ids are the same identifier.
+- Do not assume `Collection` entries are real single models in OpenAI-compatible model listings.
+- Do not push, file, or describe work as upstream-bound unless the user explicitly asks for an upstream contribution.
+
+## When Research Produces Durable Knowledge
+
+Update the smallest durable surface:
+
+- Stable vocabulary or relationships: `CONTEXT.md`.
+- A new source route or likely false assumption: this file.
+- A compact implementation relationship or architecture guardrail: `docs/agents/architecture-map.md`.
+- A fork policy rule: `docs/agents/fork-stewardship.md`, with a short pointer in `AGENTS.md` if it must always load.
+- A hard-to-reverse, surprising trade-off decision: `docs/adr/`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -2,7 +2,7 @@
 
 The skills use five canonical triage roles. This file maps those roles to the label strings used in this repo's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| Canonical skill role       | Label in our tracker | Meaning                                  |
 | -------------------------- | -------------------- | ---------------------------------------- |
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills use five canonical triage roles. This file maps those roles to the label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a triage role, use the corresponding label string from this table.


### PR DESCRIPTION
## Summary

- Adds fork-local agent guidance for `nisavid/lemonade` so future work treats upstream Lemonade as canonical and defaults changes to this fork's origin.
- Captures an initial upstream-derived Lemonade glossary plus scout maps for architecture, source routes, issue tracking, and fork stewardship.
- Copies the shared Operating Policy into `AGENTS.md` and adds a compact Agent skills block for future agents.

## Changes

- `AGENTS.md`: adds fork stewardship rules, agent skill pointers, the copied Operating Policy, and current internal endpoint/auth guardrails.
- `CONTEXT.md`: adds the initial Ubiquitous Language glossary, relationships, example dialogue, and ambiguity notes for Lemonade terms.
- `docs/agents/`: adds progressive-disclosure docs for architecture landmarks, domain discovery, fork stewardship, issue tracker usage, research routes, and triage labels.

## Review Path

- Start with `AGENTS.md` for always-loaded behavior and policy.
- Review `CONTEXT.md` for vocabulary scope and whether it stays glossary-focused.
- Review `docs/agents/research-map.md`, `docs/agents/architecture-map.md`, and `docs/agents/fork-stewardship.md` for whether source-map detail is discoverable without duplicating upstream docs.

## Verification

- `git diff --check HEAD~1 HEAD` passed.
- Ralph review loop completed through a clean final pass.
- Source/doc greps confirmed the internal endpoint list and loopback restriction match current Lemonade source and docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated agent governance and operating guidance, including fork stewardship and escalation/execution guidelines.
  * Added a fork-local context document defining canonical terminology, API/compatibility surfaces, and fork-operation rules.
  * Added an architecture reference, domain guidance, research-navigation map, issue-tracker workflow, and triage label conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/1)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->