### PR TITLE
Enforce GPU memory occupancy budget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,8 @@ include_directories(
 set(SOURCES_CORE
     src/cpp/server/server.cpp
     src/cpp/server/router.cpp
+    src/cpp/server/gpu_memory_planner.cpp
+    src/cpp/server/gguf_metadata.cpp
     src/cpp/server/cli_parser.cpp
     src/cpp/server/config_file.cpp
     src/cpp/server/model_manager.cpp

--- a/docs/agents/architecture-map.md
+++ b/docs/agents/architecture-map.md
@@ -31,6 +31,7 @@ This file captures implementation landmarks that are useful before changing Lemo
 
 - Model type controls the LRU bucket: LLM, embedding, reranking, audio, image, or TTS.
 - `max_loaded_models` applies per model type, not globally.
+- `max_gpu_memory_occupancy_gb` applies across loaded GPU models. Router dry-runs largest-to-smallest GPU evictions and leaves existing models loaded when the requested model cannot fit.
 - Busy `WrappedServer` instances are protected from eviction until their active request ends.
 - Non-file-not-found load failures trigger an evict-all-and-retry path.
 - Exclusive NPU recipes evict other NPU users; FLM has recipe-specific coexistence rules.

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -566,6 +566,7 @@ A pure HTTP server that:
 - Separate LRU caches for LLM, embedding, reranking, and audio model types
 - NPU exclusivity: only one model can use NPU at a time
 - Configurable limits via `--max-loaded-models N` (default: 1)
+- Configurable GPU memory budget via `max_gpu_memory_occupancy_gb` (default: auto-detected capacity)
 - Automatic eviction of least-recently-used models when limits reached
 - Thread-safe model loading with serialization to prevent races
 - Protection against evicting models actively serving inference requests
@@ -645,6 +646,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | Key | Type |
 |-----|------|
 | `max_loaded_models` | int (-1 or positive) |
+| `max_gpu_memory_occupancy_gb` | number (-1 or positive) |
 | `ctx_size` | int (positive) |
 | `llamacpp_backend` | string |
 | `llamacpp_args` | string |

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -155,6 +155,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | Key | Type |
 |-----|------|
 | `max_loaded_models` | int (-1 or positive) |
+| `max_gpu_memory_occupancy_gb` | number (-1 or positive) |
 | `ctx_size` | int (positive) |
 | `llamacpp_backend` | string |
 | `llamacpp_args` | string |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -26,6 +26,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
   "log_level": "info",
   "global_timeout": 300,
   "max_loaded_models": 1,
+  "max_gpu_memory_occupancy_gb": -1.0,
   "no_broadcast": false,
   "extra_models_dir": "",
   "models_dir": "auto",
@@ -82,6 +83,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 | `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
 | `global_timeout` | int | 300 | Timeout in seconds for HTTP, inference, and readiness checks |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
+| `max_gpu_memory_occupancy_gb` | number | -1.0 | Max GPU memory occupancy in GB. Use -1 for auto, which uses detected GPU capacity |
 | `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |
 | `extra_models_dir` | string | "" | Secondary directory to scan for GGUF model files |
 | `models_dir` | string | "auto" | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default |

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -4,9 +4,11 @@ Lemonade supports loading multiple models simultaneously, allowing you to keep f
 
 ## Configuration
 
-Configure via `lemonade config set max_loaded_models=N`. See [Server Configuration](./README.md).
+Configure the per-type slot limit via `lemonade config set max_loaded_models=N`. Configure the GPU memory budget via `lemonade config set max_gpu_memory_occupancy_gb=N`. See [Server Configuration](./README.md).
 
 **Default:** `1` (one model of each type). Use `-1` for unlimited.
+
+`max_gpu_memory_occupancy_gb` defaults to `-1`, which means Lemonade uses the detected total GPU capacity. At load time, Lemonade uses the smaller of the configured budget and the memory currently available to Lemonade: free GPU memory plus the GPU memory already occupied by loaded Lemonade models.
 
 ## Model Types
 
@@ -27,7 +29,8 @@ Each type has its own independent LRU cache, all sharing the same slot limit set
     - `flm` supports loading 1 ASR model, 1 LLM, and 1 embedding model on the NPU at the same time.
     - `ryzenai-llm` supports loading exactly 1 LLM, which uses the entire NPU.
     - `whispercpp` supports loading exactly 1 ASR model at a time, which uses the entire NPU.
-- **CPU/GPU:** No inherent limits beyond available RAM. Multiple models can coexist on CPU or GPU.
+- **GPU:** Lemonade predicts the requested model's GPU occupancy before starting the backend. If the projected occupancy exceeds the active GPU memory budget, loaded GPU models are evicted from largest to smallest until the requested model fits.
+- **CPU:** No inherent limit beyond available RAM.
 
 ## Eviction Policy
 
@@ -35,6 +38,11 @@ When a model slot is full:
 1. The least recently used model of that type is evicted
 2. The new model is loaded
 3. If loading fails (except file-not-found errors), all models are evicted and the load is retried
+
+When a GPU memory budget would be exceeded:
+1. Lemonade dry-runs the eviction plan before unloading anything
+2. Loaded GPU models are selected from largest to smallest predicted or measured occupancy
+3. If the requested model cannot fit even after evicting all eligible models, the load fails and existing models remain loaded
 
 Models currently processing inference requests cannot be evicted until they finish.
 

--- a/src/cpp/Multi-Model-Spec.md
+++ b/src/cpp/Multi-Model-Spec.md
@@ -24,6 +24,16 @@ Examples:
 
 ModelInfo and WrappedServer include an explicit enum field for tracking the model type. This field is used throughout the codebase (e.g., in `llamacpp_server.cpp`) to adjust settings based on model type.
 
+### GPU Memory Occupancy
+
+The `max_gpu_memory_occupancy_gb` config key controls the maximum GPU memory Lemonade may occupy. Use `-1` for auto, which uses detected GPU capacity. For each load, the active capacity is the minimum of:
+- the configured capacity, or detected total capacity when configured as auto
+- free GPU memory plus the GPU memory currently occupied by loaded Lemonade models
+
+Before loading a GPU model, Router predicts the candidate model's occupancy. It uses GGUF metadata for llama.cpp models when available, including layer count, KV head count, key/value length, and configured context size for a conservative KV-cache estimate. If metadata is missing, it falls back to model size plus overhead.
+
+If projected occupancy exceeds the active capacity, Router dry-runs a largest-to-smallest eviction plan using loaded models' measured occupancy. If the candidate fits after the planned evictions, Router evicts those models and proceeds. If the candidate cannot fit even after evicting all eligible loaded GPU models, the load fails without evicting anything.
+
 ### Least Recently Used Cache
 
 When loading a new WrappedServer of a given TYPE:
@@ -50,7 +60,7 @@ Only one model can occupy the NPU at a time. The following recipes use the NPU:
 
 When loading a WrappedServer with an NPU recipe, any existing NPU-using WrappedServer is evicted regardless of type or `--max-loaded-models` settings.
 
-> Note: CPU and GPU have no inherent model limit beyond available RAM. Since RAM usage is not tracked, the error handling policy (evict-all-on-failure) serves as the fallback mechanism.
+> Note: CPU memory is not tracked. GPU loads are constrained by `max_gpu_memory_occupancy_gb` when GPU capacity can be detected.
 
 **Recipe to Device Mapping:**
 | Recipe | Device(s) |

--- a/src/cpp/include/lemon/gguf_metadata.h
+++ b/src/cpp/include/lemon/gguf_metadata.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace lemon {
+
+struct GgufMetadata {
+    std::string architecture;
+    int64_t context_length = 0;
+    int64_t block_count = 0;
+    int64_t embedding_length = 0;
+    int64_t head_count = 0;
+    int64_t head_count_kv = 0;
+    int64_t key_length = 0;
+    int64_t value_length = 0;
+    int64_t sliding_window = 0;
+};
+
+std::optional<GgufMetadata> read_gguf_metadata(const std::string& path);
+
+} // namespace lemon

--- a/src/cpp/include/lemon/gpu_memory_planner.h
+++ b/src/cpp/include/lemon/gpu_memory_planner.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lemon {
+
+struct GpuMemoryResident {
+    std::string model_name;
+    double occupancy_gb = 0.0;
+};
+
+struct GpuMemoryAdmissionInputs {
+    // Negative configured capacity means auto: use total_capacity_gb.
+    double configured_capacity_gb = -1.0;
+    double total_capacity_gb = 0.0;
+    double free_capacity_gb = 0.0;
+    double lemonade_occupancy_gb = 0.0;
+    double candidate_occupancy_gb = 0.0;
+    std::vector<GpuMemoryResident> residents;
+};
+
+struct GpuMemoryAdmissionPlan {
+    bool can_fit = true;
+    double effective_capacity_gb = 0.0;
+    double projected_occupancy_gb = 0.0;
+    std::vector<std::string> models_to_evict;
+    std::string rejection_reason;
+};
+
+GpuMemoryAdmissionPlan plan_gpu_memory_admission(const GpuMemoryAdmissionInputs& inputs);
+
+} // namespace lemon

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -123,6 +123,8 @@ inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
         return DEVICE_CPU;  // Default; SDServer::load() overrides to DEVICE_GPU for rocm/vulkan backends
     } else if (recipe == "kokoro") {
         return DEVICE_CPU;  // Kokoros runs on CPU
+    } else if (recipe == "vllm") {
+        return DEVICE_GPU;
     } else if (recipe == "collection") {
         return DEVICE_NONE;  // Experience recipes orchestrate multiple component models
     }

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -140,7 +140,8 @@ private:
     bool should_enforce_gpu_memory_capacity(const ModelInfo& model_info,
                                             const RecipeOptions& options) const;
     void enforce_gpu_memory_capacity(const ModelInfo& model_info,
-                                     const RecipeOptions& options);
+                                     const RecipeOptions& options,
+                                     const WrappedServer* replacement_server = nullptr);
 
     // Generic inference wrapper that handles locking and busy state
     template<typename Func>

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -4,9 +4,11 @@
 #include <memory>
 #include <mutex>
 #include <condition_variable>
+#include <functional>
 #include <vector>
 #include <nlohmann/json.hpp>
 #include <httplib.h>
+#include "gpu_memory_planner.h"
 #include "wrapped_server.h"
 #include "model_manager.h"
 #include "backend_manager.h"
@@ -24,7 +26,8 @@ class Router {
 public:
     Router(RuntimeConfig* config,
            ModelManager* model_manager,
-           BackendManager* backend_manager);
+           BackendManager* backend_manager,
+           std::function<double()> gpu_memory_sampler = nullptr);
 
     ~Router();
 
@@ -108,6 +111,7 @@ private:
     RuntimeConfig* config_;
     ModelManager* model_manager_;  // Non-owning pointer to ModelManager
     BackendManager* backend_manager_;  // Non-owning pointer to BackendManager
+    std::function<double()> gpu_memory_sampler_;
 
     // Concurrency control for load operations
     mutable std::mutex load_mutex_;              // Protects loading state and loaded_servers_
@@ -128,6 +132,15 @@ private:
     void evict_all_servers();
     std::unique_ptr<WrappedServer> create_backend_server(const ModelInfo& model_info);
     std::string resolve_model_name(const std::string& model_name) const;
+    double estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,
+                                            const RecipeOptions& options) const;
+    double get_total_gpu_capacity_gb() const;
+    double sample_total_gpu_occupancy_gb() const;
+    double get_lemonade_gpu_occupancy_gb() const;
+    bool should_enforce_gpu_memory_capacity(const ModelInfo& model_info,
+                                            const RecipeOptions& options) const;
+    void enforce_gpu_memory_capacity(const ModelInfo& model_info,
+                                     const RecipeOptions& options);
 
     // Generic inference wrapper that handles locking and busy state
     template<typename Func>

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -137,6 +137,7 @@ private:
     double get_total_gpu_capacity_gb() const;
     double sample_total_gpu_occupancy_gb() const;
     double get_lemonade_gpu_occupancy_gb() const;
+    bool is_gpu_resident_server(const WrappedServer& server) const;
     bool should_enforce_gpu_memory_capacity(const ModelInfo& model_info,
                                             const RecipeOptions& options) const;
     void enforce_gpu_memory_capacity(const ModelInfo& model_info,

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -29,6 +29,7 @@ public:
     bool no_broadcast() const;
     long global_timeout() const;
     int max_loaded_models() const;
+    double max_gpu_memory_occupancy_gb() const;
     std::string models_dir() const;
     int ctx_size() const;
 

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <chrono>
 #include <mutex>
+#include <atomic>
 #include <nlohmann/json.hpp>
 #include <httplib.h>
 #include "utils/process_manager.h"
@@ -125,8 +126,8 @@ public:
     DeviceType get_device_type() const { return device_type_; }
     RecipeOptions get_recipe_options() const { return recipe_options_; }
     int get_process_id() const { return process_handle_.pid; }
-    double get_gpu_memory_occupancy_gb() const { return gpu_memory_occupancy_gb_; }
-    void set_gpu_memory_occupancy_gb(double value) { gpu_memory_occupancy_gb_ = value; }
+    double get_gpu_memory_occupancy_gb() const { return gpu_memory_occupancy_gb_.load(); }
+    void set_gpu_memory_occupancy_gb(double value) { gpu_memory_occupancy_gb_.store(value); }
 
     // Load a model and start the server
     virtual void load(const std::string& model_name,
@@ -210,7 +211,7 @@ protected:
     DeviceType device_type_ = DEVICE_NONE;
     std::chrono::steady_clock::time_point last_access_time_;
     RecipeOptions recipe_options_;
-    double gpu_memory_occupancy_gb_ = 0.0;
+    std::atomic<double> gpu_memory_occupancy_gb_{0.0};
 
     // Busy state tracking (for safe eviction)
     mutable std::mutex busy_mutex_;

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -125,6 +125,8 @@ public:
     DeviceType get_device_type() const { return device_type_; }
     RecipeOptions get_recipe_options() const { return recipe_options_; }
     int get_process_id() const { return process_handle_.pid; }
+    double get_gpu_memory_occupancy_gb() const { return gpu_memory_occupancy_gb_; }
+    void set_gpu_memory_occupancy_gb(double value) { gpu_memory_occupancy_gb_ = value; }
 
     // Load a model and start the server
     virtual void load(const std::string& model_name,
@@ -208,6 +210,7 @@ protected:
     DeviceType device_type_ = DEVICE_NONE;
     std::chrono::steady_clock::time_point last_access_time_;
     RecipeOptions recipe_options_;
+    double gpu_memory_occupancy_gb_ = 0.0;
 
     // Busy state tracking (for safe eviction)
     mutable std::mutex busy_mutex_;

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -6,6 +6,7 @@
   "log_level": "info",
   "global_timeout": 300,
   "max_loaded_models": 1,
+  "max_gpu_memory_occupancy_gb": -1.0,
   "no_broadcast": false,
   "extra_models_dir": "",
   "models_dir": "auto",

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -159,6 +159,7 @@ static const EnvMapping env_mappings[] = {
     {"LEMONADE_LOG_LEVEL",               "log_level",                nullptr},
     {"LEMONADE_GLOBAL_TIMEOUT",          "global_timeout",           nullptr},
     {"LEMONADE_MAX_LOADED_MODELS",       "max_loaded_models",        nullptr},
+    {"LEMONADE_MAX_GPU_MEMORY_OCCUPANCY_GB", "max_gpu_memory_occupancy_gb", nullptr},
     {"LEMONADE_NO_BROADCAST",            "no_broadcast",             nullptr},
     {"LEMONADE_EXTRA_MODELS_DIR",        "extra_models_dir",         nullptr},
     {"LEMONADE_CTX_SIZE",                "ctx_size",                 nullptr},

--- a/src/cpp/server/gguf_metadata.cpp
+++ b/src/cpp/server/gguf_metadata.cpp
@@ -1,0 +1,186 @@
+#include "lemon/gguf_metadata.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+
+namespace fs = std::filesystem;
+
+namespace lemon {
+namespace {
+
+template <typename T>
+bool read_le(std::istream& in, T& value) {
+    in.read(reinterpret_cast<char*>(&value), sizeof(T));
+    return static_cast<bool>(in);
+}
+
+bool read_gguf_string(std::istream& in, std::string& value) {
+    uint64_t len = 0;
+    if (!read_le(in, len)) return false;
+    if (len > 1024 * 1024) return false;
+    value.assign(static_cast<size_t>(len), '\0');
+    if (len == 0) return true;
+    in.read(&value[0], static_cast<std::streamsize>(len));
+    return static_cast<bool>(in);
+}
+
+bool skip_bytes(std::istream& in, uint64_t bytes) {
+    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
+    in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
+    return static_cast<bool>(in);
+}
+
+uint64_t gguf_scalar_size(uint32_t type) {
+    switch (type) {
+        case 0:
+        case 1:
+        case 7:
+            return 1;
+        case 2:
+        case 3:
+            return 2;
+        case 4:
+        case 5:
+        case 6:
+            return 4;
+        case 10:
+        case 11:
+        case 12:
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+bool skip_gguf_value(std::istream& in, uint32_t type);
+
+bool read_gguf_integer_value(std::istream& in, uint32_t type, int64_t& value) {
+    switch (type) {
+        case 0: { uint8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 1: { int8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 2: { uint16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 3: { int16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 4: { uint32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 5: { int32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 10: {
+            uint64_t v = 0;
+            if (!read_le(in, v)) return false;
+            if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return false;
+            value = static_cast<int64_t>(v);
+            return true;
+        }
+        case 11: { int64_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        default:
+            return false;
+    }
+}
+
+bool skip_gguf_value(std::istream& in, uint32_t type) {
+    if (type == 8) {
+        std::string ignored;
+        return read_gguf_string(in, ignored);
+    }
+
+    if (type == 9) {
+        uint32_t elem_type = 0;
+        uint64_t count = 0;
+        if (!read_le(in, elem_type) || !read_le(in, count)) return false;
+
+        if (elem_type == 8) {
+            for (uint64_t i = 0; i < count; ++i) {
+                std::string ignored;
+                if (!read_gguf_string(in, ignored)) return false;
+            }
+            return true;
+        }
+
+        if (elem_type == 9) return false;
+        uint64_t elem_size = gguf_scalar_size(elem_type);
+        if (elem_size == 0) return false;
+        if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
+        return skip_bytes(in, count * elem_size);
+    }
+
+    uint64_t size = gguf_scalar_size(type);
+    return size > 0 && skip_bytes(in, size);
+}
+
+bool set_integer_field(GgufMetadata& metadata, const std::string& suffix, int64_t value) {
+    if (value <= 0) return true;
+    if (suffix == ".context_length") metadata.context_length = value;
+    else if (suffix == ".block_count") metadata.block_count = value;
+    else if (suffix == ".embedding_length") metadata.embedding_length = value;
+    else if (suffix == ".attention.head_count") metadata.head_count = value;
+    else if (suffix == ".attention.head_count_kv") metadata.head_count_kv = value;
+    else if (suffix == ".attention.key_length") metadata.key_length = value;
+    else if (suffix == ".attention.value_length") metadata.value_length = value;
+    else if (suffix == ".attention.sliding_window") metadata.sliding_window = value;
+    else return false;
+    return true;
+}
+
+std::string strip_arch_prefix(const std::string& key, const std::string& architecture) {
+    if (!architecture.empty()) {
+        const std::string prefix = architecture + ".";
+        if (key.rfind(prefix, 0) == 0) {
+            return "." + key.substr(prefix.size());
+        }
+    }
+
+    const size_t first_dot = key.find('.');
+    if (first_dot == std::string::npos) return "";
+    return key.substr(first_dot);
+}
+
+} // namespace
+
+std::optional<GgufMetadata> read_gguf_metadata(const std::string& path) {
+    std::ifstream in(fs::u8path(path), std::ios::binary);
+    if (!in) return std::nullopt;
+
+    char magic[4] = {};
+    in.read(magic, sizeof(magic));
+    if (!in || std::memcmp(magic, "GGUF", 4) != 0) return std::nullopt;
+
+    uint32_t version = 0;
+    uint64_t tensor_count = 0;
+    uint64_t kv_count = 0;
+    if (!read_le(in, version) || !read_le(in, tensor_count) || !read_le(in, kv_count)) {
+        return std::nullopt;
+    }
+    (void)version;
+    (void)tensor_count;
+
+    GgufMetadata metadata;
+
+    for (uint64_t i = 0; i < kv_count; ++i) {
+        std::string key;
+        uint32_t type = 0;
+        if (!read_gguf_string(in, key) || !read_le(in, type)) return std::nullopt;
+
+        if (key == "general.architecture" && type == 8) {
+            if (!read_gguf_string(in, metadata.architecture)) return std::nullopt;
+            continue;
+        }
+
+        const std::string suffix = strip_arch_prefix(key, metadata.architecture);
+        if (!suffix.empty()) {
+            int64_t value = 0;
+            if (read_gguf_integer_value(in, type, value)) {
+                set_integer_field(metadata, suffix, value);
+                continue;
+            } else {
+                if (!skip_gguf_value(in, type)) return std::nullopt;
+                continue;
+            }
+        }
+
+        if (!skip_gguf_value(in, type)) return std::nullopt;
+    }
+
+    return metadata;
+}
+
+} // namespace lemon

--- a/src/cpp/server/gpu_memory_planner.cpp
+++ b/src/cpp/server/gpu_memory_planner.cpp
@@ -1,0 +1,53 @@
+#include "lemon/gpu_memory_planner.h"
+
+#include <algorithm>
+#include <sstream>
+#include <utility>
+
+namespace lemon {
+
+GpuMemoryAdmissionPlan plan_gpu_memory_admission(const GpuMemoryAdmissionInputs& inputs) {
+    GpuMemoryAdmissionPlan plan;
+
+    const double configured_capacity =
+        inputs.configured_capacity_gb < 0.0 ? inputs.total_capacity_gb : inputs.configured_capacity_gb;
+    const double memory_available_to_lemonade =
+        std::max(0.0, inputs.free_capacity_gb) + std::max(0.0, inputs.lemonade_occupancy_gb);
+
+    plan.effective_capacity_gb = std::min(configured_capacity, memory_available_to_lemonade);
+    plan.projected_occupancy_gb =
+        std::max(0.0, inputs.lemonade_occupancy_gb) + std::max(0.0, inputs.candidate_occupancy_gb);
+
+    if (plan.projected_occupancy_gb <= plan.effective_capacity_gb) {
+        return plan;
+    }
+
+    auto candidates = inputs.residents;
+    std::sort(candidates.begin(), candidates.end(),
+              [](const GpuMemoryResident& a, const GpuMemoryResident& b) {
+                  if (a.occupancy_gb == b.occupancy_gb) return a.model_name < b.model_name;
+                  return a.occupancy_gb > b.occupancy_gb;
+              });
+
+    double projected_after_eviction = plan.projected_occupancy_gb;
+    std::vector<std::string> evictions;
+    for (const auto& resident : candidates) {
+        projected_after_eviction -= std::max(0.0, resident.occupancy_gb);
+        evictions.push_back(resident.model_name);
+        if (projected_after_eviction <= plan.effective_capacity_gb) {
+            plan.projected_occupancy_gb = projected_after_eviction;
+            plan.models_to_evict = std::move(evictions);
+            return plan;
+        }
+    }
+
+    plan.can_fit = false;
+    std::ostringstream message;
+    message << "Predicted GPU memory occupancy "
+            << inputs.candidate_occupancy_gb << " GB for requested model cannot fit within effective capacity "
+            << plan.effective_capacity_gb << " GB";
+    plan.rejection_reason = message.str();
+    return plan;
+}
+
+} // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1,4 +1,5 @@
 #include <lemon/model_manager.h>
+#include <lemon/gguf_metadata.h>
 #include <lemon/runtime_config.h>
 #include <lemon/hf_variants.h>
 #include <lemon/utils/json_utils.h>
@@ -13,8 +14,6 @@
 #include <fstream>
 #include <algorithm>
 #include <cstdlib>
-#include <cstdint>
-#include <cstring>
 #include <sstream>
 #include <thread>
 #include <chrono>
@@ -22,7 +21,6 @@
 #include <tuple>
 #include <unordered_set>
 #include <iomanip>
-#include <limits>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
@@ -89,148 +87,9 @@ static bool has_label(const ModelInfo& info, const std::string& label) {
     return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
 }
 
-template <typename T>
-static bool read_le(std::istream& in, T& value) {
-    in.read(reinterpret_cast<char*>(&value), sizeof(T));
-    return static_cast<bool>(in);
-}
-
-static bool read_gguf_string(std::istream& in, std::string& value) {
-    uint64_t len = 0;
-    if (!read_le(in, len)) return false;
-    if (len > 1024 * 1024) return false;
-    value.assign(static_cast<size_t>(len), '\0');
-    if (len == 0) return true;
-    in.read(&value[0], static_cast<std::streamsize>(len));
-    return static_cast<bool>(in);
-}
-
-static bool skip_bytes(std::istream& in, uint64_t bytes) {
-    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
-    in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
-    return static_cast<bool>(in);
-}
-
-static uint64_t gguf_scalar_size(uint32_t type) {
-    switch (type) {
-        case 0:  // UINT8
-        case 1:  // INT8
-        case 7:  // BOOL
-            return 1;
-        case 2:  // UINT16
-        case 3:  // INT16
-            return 2;
-        case 4:  // UINT32
-        case 5:  // INT32
-        case 6:  // FLOAT32
-            return 4;
-        case 10: // UINT64
-        case 11: // INT64
-        case 12: // FLOAT64
-            return 8;
-        default:
-            return 0;
-    }
-}
-
-static bool skip_gguf_value(std::istream& in, uint32_t type);
-
-static bool read_gguf_integer_value(std::istream& in, uint32_t type, int64_t& value) {
-    switch (type) {
-        case 0: { uint8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 1: { int8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 2: { uint16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 3: { int16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 4: { uint32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 5: { int32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 10: {
-            uint64_t v = 0;
-            if (!read_le(in, v)) return false;
-            if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return false;
-            value = static_cast<int64_t>(v);
-            return true;
-        }
-        case 11: { int64_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        default:
-            return skip_gguf_value(in, type) && false;
-    }
-}
-
-static bool skip_gguf_value(std::istream& in, uint32_t type) {
-    if (type == 8) {  // STRING
-        std::string ignored;
-        return read_gguf_string(in, ignored);
-    }
-
-    if (type == 9) {  // ARRAY
-        uint32_t elem_type = 0;
-        uint64_t count = 0;
-        if (!read_le(in, elem_type) || !read_le(in, count)) return false;
-
-        if (elem_type == 8) {
-            for (uint64_t i = 0; i < count; ++i) {
-                std::string ignored;
-                if (!read_gguf_string(in, ignored)) return false;
-            }
-            return true;
-        }
-
-        if (elem_type == 9) return false;
-        uint64_t elem_size = gguf_scalar_size(elem_type);
-        if (elem_size == 0) return false;
-        if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
-        return skip_bytes(in, count * elem_size);
-    }
-
-    uint64_t size = gguf_scalar_size(type);
-    return size > 0 && skip_bytes(in, size);
-}
-
 static int64_t read_gguf_context_length(const std::string& path) {
-    std::ifstream in(path_from_utf8(path), std::ios::binary);
-    if (!in) return 0;
-
-    char magic[4] = {};
-    in.read(magic, sizeof(magic));
-    if (!in || std::memcmp(magic, "GGUF", 4) != 0) return 0;
-
-    uint32_t version = 0;
-    uint64_t tensor_count = 0;
-    uint64_t kv_count = 0;
-    if (!read_le(in, version) || !read_le(in, tensor_count) || !read_le(in, kv_count)) return 0;
-    (void)version;
-    (void)tensor_count;
-
-    std::string architecture;
-    int64_t pending_context_length = 0;
-
-    for (uint64_t i = 0; i < kv_count; ++i) {
-        std::string key;
-        uint32_t type = 0;
-        if (!read_gguf_string(in, key) || !read_le(in, type)) return 0;
-
-        if (key == "general.architecture" && type == 8) {
-            if (!read_gguf_string(in, architecture)) return 0;
-            if (pending_context_length > 0) return pending_context_length;
-            continue;
-        }
-
-        const bool context_key = !architecture.empty() && key == architecture + ".context_length";
-        const bool possible_context_key = architecture.empty() && key.size() > std::strlen(".context_length") &&
-                                          ends_with_ignore_case(key, ".context_length");
-        if (context_key || possible_context_key) {
-            int64_t value = 0;
-            if (!read_gguf_integer_value(in, type, value)) return 0;
-            if (value <= 0) return 0;
-            if (context_key) return value;
-            pending_context_length = value;
-            continue;
-        }
-
-        if (!skip_gguf_value(in, type)) return 0;
-    }
-
-    return pending_context_length;
+    auto metadata = read_gguf_metadata(path);
+    return metadata ? metadata->context_length : 0;
 }
 
 // Candidate roots that FLM may use to store models. FLM resolves its model

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -329,18 +329,23 @@ double Router::estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,
             auto metadata = read_gguf_metadata(path);
             if (metadata && metadata->block_count > 0) {
                 int64_t ctx_size = options.get_option("ctx_size").get<int64_t>();
+                if (ctx_size <= 0) {
+                    ctx_size = model_info.max_context_window > 0 ? model_info.max_context_window : 4096;
+                }
                 if (model_info.type == ModelType::EMBEDDING && ctx_size < 8192) {
                     ctx_size = 8192;
                 }
+                const int64_t block_count = std::max<int64_t>(0, metadata->block_count);
+                const int64_t embedding_length = std::max<int64_t>(0, metadata->embedding_length);
                 const int64_t head_count = metadata->head_count > 0 ? metadata->head_count : 1;
                 const int64_t kv_heads = metadata->head_count_kv > 0 ? metadata->head_count_kv : head_count;
                 const int64_t key_length = metadata->key_length > 0
                     ? metadata->key_length
-                    : (metadata->embedding_length > 0 ? metadata->embedding_length / head_count : 128);
+                    : (embedding_length > 0 ? embedding_length / head_count : 128);
                 const int64_t value_length = metadata->value_length > 0 ? metadata->value_length : key_length;
                 const double kv_bytes =
                     static_cast<double>(ctx_size) *
-                    static_cast<double>(metadata->block_count) *
+                    static_cast<double>(block_count) *
                     static_cast<double>(kv_heads) *
                     static_cast<double>(key_length + value_length) *
                     2.0;

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -297,22 +297,24 @@ double Router::get_total_gpu_capacity_gb() const {
     }
 
     const json& devices = system_info["devices"];
-    double total_capacity_gb = 0.0;
+    double single_device_capacity_gb = 0.0;
 
     auto accumulate_gpu_capacity = [&](const std::string& key, bool include_virtual_memory) {
         if (!devices.contains(key)) return;
         json dev_list = devices[key].is_array() ? devices[key] : json::array({devices[key]});
         for (const auto& device : dev_list) {
             if (!device.is_object() || !device.value("available", false)) continue;
-            total_capacity_gb += gpu_capacity_from_device_json(device, include_virtual_memory);
+            single_device_capacity_gb = std::max(single_device_capacity_gb,
+                                                 gpu_capacity_from_device_json(device, include_virtual_memory));
         }
     };
 
-    // Server::get_vram_usage() currently samples AMD DRM counters, so keep
-    // planner capacity in the same telemetry domain.
+    // Lemonade does not track per-request GPU placement, so do not treat memory
+    // as pooled across cards. The sampler provides aggregate pressure; this
+    // capacity is the largest single observable AMD device.
     accumulate_gpu_capacity("amd_gpu", config_->enable_dgpu_gtt());
 
-    return total_capacity_gb;
+    return single_device_capacity_gb;
 }
 
 double Router::estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -8,15 +8,30 @@
 #include "lemon/backends/vllm_server.h"
 #include "lemon/server_capabilities.h"
 #include "lemon/error_types.h"
+#include "lemon/gguf_metadata.h"
 #include "lemon/recipe_options.h"
+#include "lemon/system_info.h"
 #include <iostream>
 #include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <sstream>
+#include <system_error>
+#include <utility>
 #include <lemon/utils/aixlog.hpp>
+
+namespace fs = std::filesystem;
 
 namespace lemon {
 
-Router::Router(RuntimeConfig* config, ModelManager* model_manager, BackendManager* backend_manager)
-    : config_(config), model_manager_(model_manager), backend_manager_(backend_manager) {
+Router::Router(RuntimeConfig* config,
+               ModelManager* model_manager,
+               BackendManager* backend_manager,
+               std::function<double()> gpu_memory_sampler)
+    : config_(config),
+      model_manager_(model_manager),
+      backend_manager_(backend_manager),
+      gpu_memory_sampler_(std::move(gpu_memory_sampler)) {
 
     int max = config_->max_loaded_models();
     if (max == -1) {
@@ -216,6 +231,174 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     return new_server;
 }
 
+static bool starts_with(const std::string& value, const std::string& prefix) {
+    return value.rfind(prefix, 0) == 0;
+}
+
+bool Router::should_enforce_gpu_memory_capacity(const ModelInfo& model_info,
+                                                const RecipeOptions& options) const {
+    if (model_info.recipe == "llamacpp") {
+        std::string backend = options.get_option("llamacpp_backend");
+        return backend != "cpu";
+    }
+    if (model_info.recipe == "sd-cpp") {
+        std::string backend = options.get_option("sd-cpp_backend");
+        return backend == "vulkan" || starts_with(backend, "rocm");
+    }
+    if (model_info.recipe == "whispercpp") {
+        std::string backend = options.get_option("whispercpp_backend");
+        return backend == "vulkan";
+    }
+    return (model_info.device & DEVICE_GPU) != 0;
+}
+
+double Router::sample_total_gpu_occupancy_gb() const {
+    if (!gpu_memory_sampler_) return -1.0;
+    try {
+        return gpu_memory_sampler_();
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Router") << "Failed to sample GPU memory occupancy: " << e.what() << std::endl;
+        return -1.0;
+    }
+}
+
+double Router::get_lemonade_gpu_occupancy_gb() const {
+    double total = 0.0;
+    for (const auto& server : loaded_servers_) {
+        if (server->get_device_type() & DEVICE_GPU) {
+            total += std::max(0.0, server->get_gpu_memory_occupancy_gb());
+        }
+    }
+    return total;
+}
+
+static double gpu_capacity_from_device_json(const json& device, bool include_virtual_memory) {
+    double vram_gb = device.value("vram_gb", 0.0);
+    double virtual_mem_gb = device.value("virtual_mem_gb", 0.0);
+    if (include_virtual_memory) {
+        return vram_gb + virtual_mem_gb;
+    }
+    return vram_gb > 0.0 ? vram_gb : virtual_mem_gb;
+}
+
+double Router::get_total_gpu_capacity_gb() const {
+    json system_info = SystemInfoCache::get_system_info_with_cache();
+    if (!system_info.contains("devices") || !system_info["devices"].is_object()) {
+        return 0.0;
+    }
+
+    const json& devices = system_info["devices"];
+    double largest_capacity_gb = 0.0;
+
+    auto accumulate_gpu_capacity = [&](const std::string& key, bool include_virtual_memory) {
+        if (!devices.contains(key)) return;
+        json dev_list = devices[key].is_array() ? devices[key] : json::array({devices[key]});
+        for (const auto& device : dev_list) {
+            if (!device.is_object() || !device.value("available", false)) continue;
+            largest_capacity_gb = std::max(largest_capacity_gb,
+                                           gpu_capacity_from_device_json(device, include_virtual_memory));
+        }
+    };
+
+    accumulate_gpu_capacity("amd_gpu", config_->enable_dgpu_gtt());
+    accumulate_gpu_capacity("nvidia_gpu", config_->enable_dgpu_gtt());
+    accumulate_gpu_capacity("metal", true);
+
+    return largest_capacity_gb;
+}
+
+double Router::estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,
+                                                const RecipeOptions& options) const {
+    const double model_size_gb = std::max(0.0, model_info.size);
+    if (model_size_gb <= 0.0) {
+        return 1.0;
+    }
+
+    if (model_info.recipe == "llamacpp") {
+        const std::string path = model_info.resolved_path();
+        std::error_code ec;
+        if (!path.empty() && fs::exists(fs::u8path(path), ec)) {
+            auto metadata = read_gguf_metadata(path);
+            if (metadata && metadata->block_count > 0) {
+                int64_t ctx_size = options.get_option("ctx_size").get<int64_t>();
+                if (model_info.type == ModelType::EMBEDDING && ctx_size < 8192) {
+                    ctx_size = 8192;
+                }
+                const int64_t head_count = metadata->head_count > 0 ? metadata->head_count : 1;
+                const int64_t kv_heads = metadata->head_count_kv > 0 ? metadata->head_count_kv : head_count;
+                const int64_t key_length = metadata->key_length > 0
+                    ? metadata->key_length
+                    : (metadata->embedding_length > 0 ? metadata->embedding_length / head_count : 128);
+                const int64_t value_length = metadata->value_length > 0 ? metadata->value_length : key_length;
+                const double kv_bytes =
+                    static_cast<double>(ctx_size) *
+                    static_cast<double>(metadata->block_count) *
+                    static_cast<double>(kv_heads) *
+                    static_cast<double>(key_length + value_length) *
+                    2.0;
+                const double kv_gb = kv_bytes / (1024.0 * 1024.0 * 1024.0);
+                return model_size_gb * 1.05 + kv_gb + 1.0;
+            }
+        }
+    }
+
+    return model_size_gb * 1.20 + 1.0;
+}
+
+void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
+                                         const RecipeOptions& options) {
+    if (!should_enforce_gpu_memory_capacity(model_info, options)) return;
+
+    const double total_capacity_gb = get_total_gpu_capacity_gb();
+    if (total_capacity_gb <= 0.0) {
+        LOG(DEBUG, "Router") << "Skipping GPU memory capacity check: total GPU capacity unavailable" << std::endl;
+        return;
+    }
+
+    const double total_gpu_occupancy_gb = sample_total_gpu_occupancy_gb();
+    const double lemonade_occupancy_gb = get_lemonade_gpu_occupancy_gb();
+    const double free_capacity_gb = total_gpu_occupancy_gb >= 0.0
+        ? std::max(0.0, total_capacity_gb - total_gpu_occupancy_gb)
+        : std::max(0.0, total_capacity_gb - lemonade_occupancy_gb);
+
+    GpuMemoryAdmissionInputs inputs;
+    inputs.configured_capacity_gb = config_->max_gpu_memory_occupancy_gb();
+    inputs.total_capacity_gb = total_capacity_gb;
+    inputs.free_capacity_gb = free_capacity_gb;
+    inputs.lemonade_occupancy_gb = lemonade_occupancy_gb;
+    inputs.candidate_occupancy_gb = estimate_gpu_memory_occupancy_gb(model_info, options);
+    for (const auto& server : loaded_servers_) {
+        if (server->get_device_type() & DEVICE_GPU) {
+            inputs.residents.push_back({
+                server->get_model_name(),
+                server->get_gpu_memory_occupancy_gb()
+            });
+        }
+    }
+
+    GpuMemoryAdmissionPlan plan = plan_gpu_memory_admission(inputs);
+    if (!plan.can_fit) {
+        throw std::runtime_error(plan.rejection_reason);
+    }
+
+    for (const auto& model_to_evict : plan.models_to_evict) {
+        WrappedServer* server = find_server_by_model_name(model_to_evict);
+        if (server) {
+            LOG(INFO, "Router") << "GPU memory budget requires evicting "
+                                << model_to_evict
+                                << " (" << server->get_gpu_memory_occupancy_gb() << " GB)"
+                                << std::endl;
+            evict_server(server);
+        }
+    }
+
+    if (!plan.models_to_evict.empty()) {
+        LOG(INFO, "Router") << "GPU memory budget projected occupancy after eviction: "
+                            << plan.projected_occupancy_gb << " GB / "
+                            << plan.effective_capacity_gb << " GB" << std::endl;
+    }
+}
+
 void Router::load_model(const std::string& model_name,
                        const ModelInfo& model_info,
                        RecipeOptions options,
@@ -249,14 +432,16 @@ void Router::load_model(const std::string& model_name,
             << ", device: " << device_type_to_string(model_info.device) << ")" << std::endl;
 
     try {
+        WrappedServer* reload_existing = nullptr;
+
         // Check if model is already loaded
         WrappedServer* existing = find_server_by_model_name(canonical_model_name);
         if (existing) {
             if (allow_reload_on_option_change &&
                 existing->get_recipe_options().to_json() != effective_options.to_json()) {
                 LOG(INFO, "Router") << "Options changed, reloading model: " << canonical_model_name << std::endl;
-                evict_server(existing);
-                // Fall through to create and load with new options
+                reload_existing = existing;
+                // Fall through to admission checks before unloading the existing instance.
             } else {
                 LOG(INFO, "Router") << "Model already loaded, updating access time" << std::endl;
                 existing->update_access_time();
@@ -312,6 +497,15 @@ void Router::load_model(const std::string& model_name,
             }
         }
 
+        enforce_gpu_memory_capacity(model_info, effective_options);
+
+        if (reload_existing) {
+            WrappedServer* server_to_reload = find_server_by_model_name(canonical_model_name);
+            if (server_to_reload) {
+                evict_server(server_to_reload);
+            }
+        }
+
         // LRU EVICTION CHECK (from spec: Least Recently Used Cache)
         // Skip eviction if unlimited (-1)
         int current_count = count_servers_by_type(model_type);
@@ -333,6 +527,9 @@ void Router::load_model(const std::string& model_name,
         new_server->update_access_time();
 
         // CRITICAL: Release lock before slow backend startup
+        const double predicted_gpu_occupancy_gb =
+            estimate_gpu_memory_occupancy_gb(model_info, effective_options);
+        const double gpu_occupancy_before_load = sample_total_gpu_occupancy_gb();
         lock.unlock();
 
         // Load the backend (this can take 30-60 seconds)
@@ -360,6 +557,16 @@ void Router::load_model(const std::string& model_name,
             new_server->update_access_time();
 
             // Add to loaded servers
+            double gpu_occupancy_gb = predicted_gpu_occupancy_gb;
+            const double gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
+            if (gpu_occupancy_before_load >= 0.0 &&
+                gpu_occupancy_after_load >= gpu_occupancy_before_load) {
+                double measured_delta = gpu_occupancy_after_load - gpu_occupancy_before_load;
+                if (measured_delta > 0.0) {
+                    gpu_occupancy_gb = measured_delta;
+                }
+            }
+            new_server->set_gpu_memory_occupancy_gb(gpu_occupancy_gb);
             loaded_servers_.push_back(std::move(new_server));
 
             is_loading_ = false;
@@ -395,6 +602,7 @@ void Router::load_model(const std::string& model_name,
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
             retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
             retry_server->update_access_time();
+            const double retry_gpu_occupancy_before_load = sample_total_gpu_occupancy_gb();
 
             lock.unlock();
 
@@ -404,6 +612,16 @@ void Router::load_model(const std::string& model_name,
 
                 lock.lock();
 
+                double retry_gpu_occupancy_gb = predicted_gpu_occupancy_gb;
+                const double retry_gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
+                if (retry_gpu_occupancy_before_load >= 0.0 &&
+                    retry_gpu_occupancy_after_load >= retry_gpu_occupancy_before_load) {
+                    double measured_delta = retry_gpu_occupancy_after_load - retry_gpu_occupancy_before_load;
+                    if (measured_delta > 0.0) {
+                        retry_gpu_occupancy_gb = measured_delta;
+                    }
+                }
+                retry_server->set_gpu_memory_occupancy_gb(retry_gpu_occupancy_gb);
                 loaded_servers_.push_back(std::move(retry_server));
                 is_loading_ = false;
                 load_cv_.notify_all();
@@ -479,6 +697,7 @@ json Router::get_all_loaded_models() const {
         model_info["device"] = device_type_to_string(server->get_device_type());
         model_info["backend_url"] = server->get_address();  // For debugging port issues
         model_info["pid"] = server->get_process_id();
+        model_info["gpu_memory_occupancy_gb"] = server->get_gpu_memory_occupancy_gb();
         RecipeOptions recipe_options =  server->get_recipe_options();
         model_info["recipe"] = recipe_options.get_recipe();
         model_info["recipe_options"] = recipe_options.to_json();

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -252,6 +252,15 @@ bool Router::should_enforce_gpu_memory_capacity(const ModelInfo& model_info,
     return (model_info.device & DEVICE_GPU) != 0;
 }
 
+bool Router::is_gpu_resident_server(const WrappedServer& server) const {
+    ModelInfo server_model_info;
+    RecipeOptions options = server.get_recipe_options();
+    server_model_info.recipe = options.get_recipe();
+    server_model_info.device = server.get_device_type();
+    return (server.get_device_type() & DEVICE_GPU) &&
+           should_enforce_gpu_memory_capacity(server_model_info, options);
+}
+
 double Router::sample_total_gpu_occupancy_gb() const {
     if (!gpu_memory_sampler_) return -1.0;
     try {
@@ -265,7 +274,7 @@ double Router::sample_total_gpu_occupancy_gb() const {
 double Router::get_lemonade_gpu_occupancy_gb() const {
     double total = 0.0;
     for (const auto& server : loaded_servers_) {
-        if (server->get_device_type() & DEVICE_GPU) {
+        if (is_gpu_resident_server(*server)) {
             total += std::max(0.0, server->get_gpu_memory_occupancy_gb());
         }
     }
@@ -356,7 +365,7 @@ void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
     }
 
     const double replacement_occupancy_gb =
-        replacement_server && (replacement_server->get_device_type() & DEVICE_GPU)
+        replacement_server && is_gpu_resident_server(*replacement_server)
             ? std::max(0.0, replacement_server->get_gpu_memory_occupancy_gb())
             : 0.0;
     const double total_gpu_occupancy_gb = sample_total_gpu_occupancy_gb();
@@ -376,7 +385,7 @@ void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
     inputs.candidate_occupancy_gb = estimate_gpu_memory_occupancy_gb(model_info, options);
     for (const auto& server : loaded_servers_) {
         if (server.get() == replacement_server) continue;
-        if (server->get_device_type() & DEVICE_GPU) {
+        if (is_gpu_resident_server(*server)) {
             inputs.residents.push_back({
                 server->get_model_name(),
                 server->get_gpu_memory_occupancy_gb()
@@ -567,7 +576,7 @@ void Router::load_model(const std::string& model_name,
             new_server->update_access_time();
 
             // Add to loaded servers
-            if (new_server->get_device_type() & DEVICE_GPU) {
+            if (is_gpu_resident_server(*new_server)) {
                 double gpu_occupancy_gb = predicted_gpu_occupancy_gb;
                 const double gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
                 if (gpu_occupancy_before_load >= 0.0 &&
@@ -624,7 +633,7 @@ void Router::load_model(const std::string& model_name,
 
                 lock.lock();
 
-                if (retry_server->get_device_type() & DEVICE_GPU) {
+                if (is_gpu_resident_server(*retry_server)) {
                     double retry_gpu_occupancy_gb = predicted_gpu_occupancy_gb;
                     const double retry_gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
                     if (retry_gpu_occupancy_before_load >= 0.0 &&

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -243,11 +243,11 @@ bool Router::should_enforce_gpu_memory_capacity(const ModelInfo& model_info,
     }
     if (model_info.recipe == "sd-cpp") {
         std::string backend = options.get_option("sd-cpp_backend");
-        return backend == "vulkan" || starts_with(backend, "rocm");
+        return backend.empty() || backend == "vulkan" || starts_with(backend, "rocm");
     }
     if (model_info.recipe == "whispercpp") {
         std::string backend = options.get_option("whispercpp_backend");
-        return backend == "vulkan";
+        return backend.empty() || backend == "vulkan";
     }
     return (model_info.device & DEVICE_GPU) != 0;
 }
@@ -308,9 +308,9 @@ double Router::get_total_gpu_capacity_gb() const {
         }
     };
 
+    // Server::get_vram_usage() currently samples AMD DRM counters, so keep
+    // planner capacity in the same telemetry domain.
     accumulate_gpu_capacity("amd_gpu", config_->enable_dgpu_gtt());
-    accumulate_gpu_capacity("nvidia_gpu", config_->enable_dgpu_gtt());
-    accumulate_gpu_capacity("metal", true);
 
     return total_capacity_gb;
 }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -288,15 +288,14 @@ double Router::get_total_gpu_capacity_gb() const {
     }
 
     const json& devices = system_info["devices"];
-    double largest_capacity_gb = 0.0;
+    double total_capacity_gb = 0.0;
 
     auto accumulate_gpu_capacity = [&](const std::string& key, bool include_virtual_memory) {
         if (!devices.contains(key)) return;
         json dev_list = devices[key].is_array() ? devices[key] : json::array({devices[key]});
         for (const auto& device : dev_list) {
             if (!device.is_object() || !device.value("available", false)) continue;
-            largest_capacity_gb = std::max(largest_capacity_gb,
-                                           gpu_capacity_from_device_json(device, include_virtual_memory));
+            total_capacity_gb += gpu_capacity_from_device_json(device, include_virtual_memory);
         }
     };
 
@@ -304,7 +303,7 @@ double Router::get_total_gpu_capacity_gb() const {
     accumulate_gpu_capacity("nvidia_gpu", config_->enable_dgpu_gtt());
     accumulate_gpu_capacity("metal", true);
 
-    return largest_capacity_gb;
+    return total_capacity_gb;
 }
 
 double Router::estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,
@@ -346,7 +345,8 @@ double Router::estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,
 }
 
 void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
-                                         const RecipeOptions& options) {
+                                         const RecipeOptions& options,
+                                         const WrappedServer* replacement_server) {
     if (!should_enforce_gpu_memory_capacity(model_info, options)) return;
 
     const double total_capacity_gb = get_total_gpu_capacity_gb();
@@ -355,11 +355,18 @@ void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
         return;
     }
 
+    const double replacement_occupancy_gb =
+        replacement_server && (replacement_server->get_device_type() & DEVICE_GPU)
+            ? std::max(0.0, replacement_server->get_gpu_memory_occupancy_gb())
+            : 0.0;
     const double total_gpu_occupancy_gb = sample_total_gpu_occupancy_gb();
-    const double lemonade_occupancy_gb = get_lemonade_gpu_occupancy_gb();
-    const double free_capacity_gb = total_gpu_occupancy_gb >= 0.0
+    const double current_lemonade_occupancy_gb = get_lemonade_gpu_occupancy_gb();
+    const double lemonade_occupancy_gb =
+        std::max(0.0, current_lemonade_occupancy_gb - replacement_occupancy_gb);
+    double free_capacity_gb = total_gpu_occupancy_gb >= 0.0
         ? std::max(0.0, total_capacity_gb - total_gpu_occupancy_gb)
-        : std::max(0.0, total_capacity_gb - lemonade_occupancy_gb);
+        : std::max(0.0, total_capacity_gb - current_lemonade_occupancy_gb);
+    free_capacity_gb += replacement_occupancy_gb;
 
     GpuMemoryAdmissionInputs inputs;
     inputs.configured_capacity_gb = config_->max_gpu_memory_occupancy_gb();
@@ -368,6 +375,7 @@ void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
     inputs.lemonade_occupancy_gb = lemonade_occupancy_gb;
     inputs.candidate_occupancy_gb = estimate_gpu_memory_occupancy_gb(model_info, options);
     for (const auto& server : loaded_servers_) {
+        if (server.get() == replacement_server) continue;
         if (server->get_device_type() & DEVICE_GPU) {
             inputs.residents.push_back({
                 server->get_model_name(),
@@ -497,7 +505,8 @@ void Router::load_model(const std::string& model_name,
             }
         }
 
-        enforce_gpu_memory_capacity(model_info, effective_options);
+        const bool requested_gpu = should_enforce_gpu_memory_capacity(model_info, effective_options);
+        enforce_gpu_memory_capacity(model_info, effective_options, reload_existing);
 
         if (reload_existing) {
             WrappedServer* server_to_reload = find_server_by_model_name(canonical_model_name);
@@ -527,9 +536,10 @@ void Router::load_model(const std::string& model_name,
         new_server->update_access_time();
 
         // CRITICAL: Release lock before slow backend startup
-        const double predicted_gpu_occupancy_gb =
-            estimate_gpu_memory_occupancy_gb(model_info, effective_options);
-        const double gpu_occupancy_before_load = sample_total_gpu_occupancy_gb();
+        const double predicted_gpu_occupancy_gb = requested_gpu
+            ? estimate_gpu_memory_occupancy_gb(model_info, effective_options)
+            : 0.0;
+        const double gpu_occupancy_before_load = requested_gpu ? sample_total_gpu_occupancy_gb() : -1.0;
         lock.unlock();
 
         // Load the backend (this can take 30-60 seconds)
@@ -557,16 +567,16 @@ void Router::load_model(const std::string& model_name,
             new_server->update_access_time();
 
             // Add to loaded servers
-            double gpu_occupancy_gb = predicted_gpu_occupancy_gb;
-            const double gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
-            if (gpu_occupancy_before_load >= 0.0 &&
-                gpu_occupancy_after_load >= gpu_occupancy_before_load) {
-                double measured_delta = gpu_occupancy_after_load - gpu_occupancy_before_load;
-                if (measured_delta > 0.0) {
-                    gpu_occupancy_gb = measured_delta;
-                }
-            }
             if (new_server->get_device_type() & DEVICE_GPU) {
+                double gpu_occupancy_gb = predicted_gpu_occupancy_gb;
+                const double gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
+                if (gpu_occupancy_before_load >= 0.0 &&
+                    gpu_occupancy_after_load >= gpu_occupancy_before_load) {
+                    double measured_delta = gpu_occupancy_after_load - gpu_occupancy_before_load;
+                    if (measured_delta > 0.0) {
+                        gpu_occupancy_gb = measured_delta;
+                    }
+                }
                 new_server->set_gpu_memory_occupancy_gb(gpu_occupancy_gb);
             }
             loaded_servers_.push_back(std::move(new_server));
@@ -604,7 +614,7 @@ void Router::load_model(const std::string& model_name,
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
             retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
             retry_server->update_access_time();
-            const double retry_gpu_occupancy_before_load = sample_total_gpu_occupancy_gb();
+            const double retry_gpu_occupancy_before_load = requested_gpu ? sample_total_gpu_occupancy_gb() : -1.0;
 
             lock.unlock();
 
@@ -614,16 +624,16 @@ void Router::load_model(const std::string& model_name,
 
                 lock.lock();
 
-                double retry_gpu_occupancy_gb = predicted_gpu_occupancy_gb;
-                const double retry_gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
-                if (retry_gpu_occupancy_before_load >= 0.0 &&
-                    retry_gpu_occupancy_after_load >= retry_gpu_occupancy_before_load) {
-                    double measured_delta = retry_gpu_occupancy_after_load - retry_gpu_occupancy_before_load;
-                    if (measured_delta > 0.0) {
-                        retry_gpu_occupancy_gb = measured_delta;
-                    }
-                }
                 if (retry_server->get_device_type() & DEVICE_GPU) {
+                    double retry_gpu_occupancy_gb = predicted_gpu_occupancy_gb;
+                    const double retry_gpu_occupancy_after_load = sample_total_gpu_occupancy_gb();
+                    if (retry_gpu_occupancy_before_load >= 0.0 &&
+                        retry_gpu_occupancy_after_load >= retry_gpu_occupancy_before_load) {
+                        double measured_delta = retry_gpu_occupancy_after_load - retry_gpu_occupancy_before_load;
+                        if (measured_delta > 0.0) {
+                            retry_gpu_occupancy_gb = measured_delta;
+                        }
+                    }
                     retry_server->set_gpu_memory_occupancy_gb(retry_gpu_occupancy_gb);
                 }
                 loaded_servers_.push_back(std::move(retry_server));

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -566,7 +566,9 @@ void Router::load_model(const std::string& model_name,
                     gpu_occupancy_gb = measured_delta;
                 }
             }
-            new_server->set_gpu_memory_occupancy_gb(gpu_occupancy_gb);
+            if (new_server->get_device_type() & DEVICE_GPU) {
+                new_server->set_gpu_memory_occupancy_gb(gpu_occupancy_gb);
+            }
             loaded_servers_.push_back(std::move(new_server));
 
             is_loading_ = false;
@@ -621,7 +623,9 @@ void Router::load_model(const std::string& model_name,
                         retry_gpu_occupancy_gb = measured_delta;
                     }
                 }
-                retry_server->set_gpu_memory_occupancy_gb(retry_gpu_occupancy_gb);
+                if (retry_server->get_device_type() & DEVICE_GPU) {
+                    retry_server->set_gpu_memory_occupancy_gb(retry_gpu_occupancy_gb);
+                }
                 loaded_servers_.push_back(std::move(retry_server));
                 is_loading_ = false;
                 load_cv_.notify_all();

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -162,6 +162,11 @@ int RuntimeConfig::max_loaded_models() const {
     return config_["max_loaded_models"].get<int>();
 }
 
+double RuntimeConfig::max_gpu_memory_occupancy_gb() const {
+    std::shared_lock lock(mutex_);
+    return config_["max_gpu_memory_occupancy_gb"].get<double>();
+}
+
 std::string RuntimeConfig::models_dir() const {
     std::shared_lock lock(mutex_);
     return config_["models_dir"].get<std::string>();
@@ -349,6 +354,15 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         if (m < -1 || m == 0) {
             throw std::invalid_argument(
                 "'max_loaded_models' must be -1 (unlimited) or a positive integer");
+        }
+    } else if (key == "max_gpu_memory_occupancy_gb") {
+        if (!value.is_number()) {
+            throw std::invalid_argument("'max_gpu_memory_occupancy_gb' must be a number");
+        }
+        double gb = value.get<double>();
+        if (gb == 0.0 || (gb < 0.0 && gb != -1.0)) {
+            throw std::invalid_argument(
+                "'max_gpu_memory_occupancy_gb' must be -1 (auto) or a positive number");
         }
     } else if (key == "ctx_size") {
         if (!value.is_number_integer()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3488,6 +3488,7 @@ double Server::get_vram_usage() {
             return -1.0;
         }
 
+        bool found_memory_info = false;
         uint64_t total_memory = 0;
 
         for (const auto& entry : fs::directory_iterator(drm_path)) {
@@ -3503,10 +3504,12 @@ double Server::get_vram_usage() {
 
             // Read VRAM used
             uint64_t vram_used = 0;
+            bool found_card_memory_info = false;
             std::ifstream vram_file(device_path + "/mem_info_vram_used");
             if (vram_file.is_open()) {
                 vram_file >> vram_used;
                 vram_file.close();
+                found_card_memory_info = true;
             }
 
             // Read GTT used
@@ -3515,19 +3518,21 @@ double Server::get_vram_usage() {
             if (gtt_file.is_open()) {
                 gtt_file >> gtt_used;
                 gtt_file.close();
+                found_card_memory_info = true;
             }
 
             // Skip if no memory info found
-            if (vram_used == 0 && gtt_used == 0) {
+            if (!found_card_memory_info) {
                 continue;
             }
 
             // Calculate memory for this card
+            found_memory_info = true;
             const bool include_gtt = !is_dgpu || (config_ && config_->enable_dgpu_gtt());
             total_memory += include_gtt ? (vram_used + gtt_used) : vram_used;
         }
 
-        return total_memory > 0
+        return found_memory_info
             ? total_memory / (1024.0 * 1024.0 * 1024.0)
             : -1.0;
     } catch (...) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -139,7 +139,8 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
 
     router_ = std::make_unique<Router>(config_.get(),
                                        model_manager_.get(),
-                                       backend_manager_.get());
+                                       backend_manager_.get(),
+                                       [this]() { return get_vram_usage(); });
 
     LOG(DEBUG, "Server") << "Debug logging enabled - subprocess output will be visible" << std::endl;
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3478,9 +3478,9 @@ double Server::get_gpu_usage() {
 double Server::get_vram_usage() {
 #ifdef __linux__
     // Linux: Read from AMD sysfs
-    // For dGPU: return VRAM used
+    // For dGPU: return VRAM used unless dGPU GTT is enabled
     // For APU: return VRAM + GTT used
-    // On multi-GPU systems, return memory from GPU with highest utilization
+    // On multi-GPU systems, return total memory across all visible GPUs
     try {
         std::string drm_path = "/sys/class/drm";
 
@@ -3488,9 +3488,7 @@ double Server::get_vram_usage() {
             return -1.0;
         }
 
-        double highest_usage = -1.0;
-        std::string highest_card;
-        double highest_card_memory = 0.0;
+        uint64_t total_memory = 0;
 
         for (const auto& entry : fs::directory_iterator(drm_path)) {
             std::string card_name = entry.path().filename().string();
@@ -3499,14 +3497,6 @@ double Server::get_vram_usage() {
             }
 
             std::string device_path = entry.path().string() + "/device";
-
-            // Read GPU utilization to find the most active GPU
-            double gpu_usage = 0.0;
-            std::ifstream busy_file(device_path + "/gpu_busy_percent");
-            if (busy_file.is_open()) {
-                busy_file >> gpu_usage;
-                busy_file.close();
-            }
 
             // Check if this is a dGPU (has board_info) or APU (no board_info)
             bool is_dgpu = fs::exists(device_path + "/board_info");
@@ -3533,17 +3523,13 @@ double Server::get_vram_usage() {
             }
 
             // Calculate memory for this card
-            uint64_t card_memory = is_dgpu ? vram_used : (vram_used + gtt_used);
-
-            // Track the GPU with highest utilization
-            if (gpu_usage > highest_usage || highest_usage < 0) {
-                highest_usage = gpu_usage;
-                highest_card = card_name;
-                highest_card_memory = card_memory / (1024.0 * 1024.0 * 1024.0); // Convert to GB
-            }
+            const bool include_gtt = !is_dgpu || (config_ && config_->enable_dgpu_gtt());
+            total_memory += include_gtt ? (vram_used + gtt_used) : vram_used;
         }
 
-        return highest_card_memory > 0 ? highest_card_memory : -1.0;
+        return total_memory > 0
+            ? total_memory / (1024.0 * 1024.0 * 1024.0)
+            : -1.0;
     } catch (...) {
         return -1.0;
     }

--- a/test/cpp/test_gguf_metadata.cpp
+++ b/test/cpp/test_gguf_metadata.cpp
@@ -1,12 +1,15 @@
 #include "lemon/gguf_metadata.h"
 
-#include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <string>
 
 using lemon::read_gguf_metadata;
+
+namespace fs = std::filesystem;
 
 template <typename T>
 static void write_le(std::ofstream& out, T value) {
@@ -31,7 +34,35 @@ static void write_u32_kv(std::ofstream& out, const std::string& key, uint32_t va
 }
 
 int main() {
-    const std::string path = "/tmp/lemonade-test-metadata.gguf";
+    int failures = 0;
+    auto expect_true = [&failures](bool condition, const char* name) {
+        std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+        if (!condition) ++failures;
+    };
+    auto expect_eq_i64 = [&failures](int64_t actual, int64_t expected, const char* name) {
+        bool ok = actual == expected;
+        std::printf("[%s] %s  (got=%lld, want=%lld)\n",
+                    ok ? "PASS" : "FAIL",
+                    name,
+                    static_cast<long long>(actual),
+                    static_cast<long long>(expected));
+        if (!ok) ++failures;
+    };
+    auto expect_eq_string = [&failures](const std::string& actual,
+                                        const std::string& expected,
+                                        const char* name) {
+        bool ok = actual == expected;
+        std::printf("[%s] %s  (got=%s, want=%s)\n",
+                    ok ? "PASS" : "FAIL",
+                    name,
+                    actual.c_str(),
+                    expected.c_str());
+        if (!ok) ++failures;
+    };
+
+    auto unique_suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+    const fs::path path = fs::temp_directory_path() /
+        ("lemonade-test-metadata-" + std::to_string(unique_suffix) + ".gguf");
     {
         std::ofstream out(path, std::ios::binary);
         out.write("GGUF", 4);
@@ -50,18 +81,23 @@ int main() {
         write_u32_kv(out, "qwen3.attention.sliding_window", 32768);
     }
 
-    auto metadata = read_gguf_metadata(path);
-    assert(metadata.has_value());
-    assert(metadata->architecture == "qwen3");
-    assert(metadata->context_length == 262144);
-    assert(metadata->block_count == 80);
-    assert(metadata->embedding_length == 8192);
-    assert(metadata->head_count == 64);
-    assert(metadata->head_count_kv == 8);
-    assert(metadata->key_length == 128);
-    assert(metadata->value_length == 128);
-    assert(metadata->sliding_window == 32768);
+    auto metadata = read_gguf_metadata(path.string());
+    expect_true(metadata.has_value(), "metadata parsed");
+    if (metadata) {
+        expect_eq_string(metadata->architecture, "qwen3", "architecture");
+        expect_eq_i64(metadata->context_length, 262144, "context_length");
+        expect_eq_i64(metadata->block_count, 80, "block_count");
+        expect_eq_i64(metadata->embedding_length, 8192, "embedding_length");
+        expect_eq_i64(metadata->head_count, 64, "head_count");
+        expect_eq_i64(metadata->head_count_kv, 8, "head_count_kv");
+        expect_eq_i64(metadata->key_length, 128, "key_length");
+        expect_eq_i64(metadata->value_length, 128, "value_length");
+        expect_eq_i64(metadata->sliding_window, 32768, "sliding_window");
+    }
 
-    std::printf("GGUF metadata parsing passed\n");
-    return 0;
+    std::error_code ec;
+    fs::remove(path, ec);
+
+    std::printf("\nGGUF metadata parsing %s\n", failures == 0 ? "passed" : "failed");
+    return failures == 0 ? 0 : 1;
 }

--- a/test/cpp/test_gguf_metadata.cpp
+++ b/test/cpp/test_gguf_metadata.cpp
@@ -1,0 +1,67 @@
+#include "lemon/gguf_metadata.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+using lemon::read_gguf_metadata;
+
+template <typename T>
+static void write_le(std::ofstream& out, T value) {
+    out.write(reinterpret_cast<const char*>(&value), sizeof(T));
+}
+
+static void write_string(std::ofstream& out, const std::string& value) {
+    write_le<uint64_t>(out, value.size());
+    out.write(value.data(), static_cast<std::streamsize>(value.size()));
+}
+
+static void write_string_kv(std::ofstream& out, const std::string& key, const std::string& value) {
+    write_string(out, key);
+    write_le<uint32_t>(out, 8);
+    write_string(out, value);
+}
+
+static void write_u32_kv(std::ofstream& out, const std::string& key, uint32_t value) {
+    write_string(out, key);
+    write_le<uint32_t>(out, 4);
+    write_le<uint32_t>(out, value);
+}
+
+int main() {
+    const std::string path = "/tmp/lemonade-test-metadata.gguf";
+    {
+        std::ofstream out(path, std::ios::binary);
+        out.write("GGUF", 4);
+        write_le<uint32_t>(out, 3);
+        write_le<uint64_t>(out, 0);
+        write_le<uint64_t>(out, 10);
+        write_string_kv(out, "general.architecture", "qwen3");
+        write_u32_kv(out, "qwen3.unknown_integer_field", 1234);
+        write_u32_kv(out, "qwen3.context_length", 262144);
+        write_u32_kv(out, "qwen3.block_count", 80);
+        write_u32_kv(out, "qwen3.embedding_length", 8192);
+        write_u32_kv(out, "qwen3.attention.head_count", 64);
+        write_u32_kv(out, "qwen3.attention.head_count_kv", 8);
+        write_u32_kv(out, "qwen3.attention.key_length", 128);
+        write_u32_kv(out, "qwen3.attention.value_length", 128);
+        write_u32_kv(out, "qwen3.attention.sliding_window", 32768);
+    }
+
+    auto metadata = read_gguf_metadata(path);
+    assert(metadata.has_value());
+    assert(metadata->architecture == "qwen3");
+    assert(metadata->context_length == 262144);
+    assert(metadata->block_count == 80);
+    assert(metadata->embedding_length == 8192);
+    assert(metadata->head_count == 64);
+    assert(metadata->head_count_kv == 8);
+    assert(metadata->key_length == 128);
+    assert(metadata->value_length == 128);
+    assert(metadata->sliding_window == 32768);
+
+    std::printf("GGUF metadata parsing passed\n");
+    return 0;
+}

--- a/test/cpp/test_gpu_memory_planner.cpp
+++ b/test/cpp/test_gpu_memory_planner.cpp
@@ -1,0 +1,86 @@
+#include "lemon/gpu_memory_planner.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using lemon::GpuMemoryAdmissionInputs;
+using lemon::GpuMemoryResident;
+using lemon::plan_gpu_memory_admission;
+
+static void expect_evictions(const char* name,
+                             const std::vector<std::string>& actual,
+                             const std::vector<std::string>& expected) {
+    bool ok = actual == expected;
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got:");
+        for (const auto& value : actual) std::printf(" %s", value.c_str());
+        std::printf("\n want:");
+        for (const auto& value : expected) std::printf(" %s", value.c_str());
+        std::printf("\n");
+    }
+    assert(ok);
+}
+
+int main() {
+    {
+        GpuMemoryAdmissionInputs inputs;
+        inputs.configured_capacity_gb = 12.0;
+        inputs.total_capacity_gb = 16.0;
+        inputs.free_capacity_gb = 4.0;
+        inputs.lemonade_occupancy_gb = 8.0;
+        inputs.candidate_occupancy_gb = 11.0;
+        inputs.residents = {
+            {"small", 1.0},
+            {"large", 5.0},
+            {"medium", 3.0},
+        };
+
+        auto plan = plan_gpu_memory_admission(inputs);
+        assert(plan.can_fit);
+        expect_evictions("evicts largest residents first until candidate fits",
+                         plan.models_to_evict,
+                         {"large", "medium"});
+        assert(plan.effective_capacity_gb == 12.0);
+    }
+
+    {
+        GpuMemoryAdmissionInputs inputs;
+        inputs.configured_capacity_gb = 16.0;
+        inputs.total_capacity_gb = 16.0;
+        inputs.free_capacity_gb = 2.0;
+        inputs.lemonade_occupancy_gb = 4.0;
+        inputs.candidate_occupancy_gb = 10.0;
+        inputs.residents = {
+            {"resident", 4.0},
+        };
+
+        auto plan = plan_gpu_memory_admission(inputs);
+        assert(!plan.can_fit);
+        expect_evictions("does not evict when candidate cannot fit after dry run",
+                         plan.models_to_evict,
+                         {});
+        assert(plan.effective_capacity_gb == 6.0);
+    }
+
+    {
+        GpuMemoryAdmissionInputs inputs;
+        inputs.configured_capacity_gb = -1.0;
+        inputs.total_capacity_gb = 24.0;
+        inputs.free_capacity_gb = 20.0;
+        inputs.lemonade_occupancy_gb = 2.0;
+        inputs.candidate_occupancy_gb = 4.0;
+
+        auto plan = plan_gpu_memory_admission(inputs);
+        assert(plan.can_fit);
+        assert(plan.effective_capacity_gb == 22.0);
+        expect_evictions("auto capacity uses current memory available to Lemonade",
+                         plan.models_to_evict,
+                         {});
+    }
+
+    std::printf("\nAll GPU memory planner cases passed\n");
+    return 0;
+}

--- a/test/cpp/test_model_type_classifier.cpp
+++ b/test/cpp/test_model_type_classifier.cpp
@@ -9,7 +9,9 @@
 #include <vector>
 
 using lemon::ModelType;
+using lemon::DEVICE_GPU;
 using lemon::get_model_type_from_labels;
+using lemon::get_device_type_from_recipe;
 using lemon::model_type_to_string;
 
 struct Case {
@@ -64,5 +66,12 @@ int main() {
     }
 
     std::printf("\n%d/%zu cases passed\n", static_cast<int>(cases.size() - failures), cases.size());
+    if (get_device_type_from_recipe("vllm") != DEVICE_GPU) {
+        std::printf("[FAIL] vllm device type should be GPU\n");
+        ++failures;
+    } else {
+        std::printf("[PASS] vllm device type is GPU\n");
+    }
+
     return failures == 0 ? 0 : 1;
 }

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -163,6 +163,7 @@ class TestConfigEnvVars(unittest.TestCase):
         self.assertEqual(self.snapshot["max_loaded_models"], 3)
 
     def test_max_gpu_memory_occupancy_gb(self):
+        self.assertIsInstance(self.snapshot["max_gpu_memory_occupancy_gb"], float)
         self.assertEqual(self.snapshot["max_gpu_memory_occupancy_gb"], 12.5)
 
     def test_max_loaded_models_in_health(self):
@@ -423,6 +424,7 @@ class TestDefaults(unittest.TestCase):
         self.assertEqual(self.snapshot["max_loaded_models"], 1)
 
     def test_default_max_gpu_memory_occupancy_gb(self):
+        self.assertIsInstance(self.snapshot["max_gpu_memory_occupancy_gb"], float)
         self.assertEqual(self.snapshot["max_gpu_memory_occupancy_gb"], -1.0)
 
     def test_default_ctx_size(self):

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -119,6 +119,7 @@ class TestConfigEnvVars(unittest.TestCase):
             "LEMONADE_EXTRA_MODELS_DIR": "/tmp/lemon_extra_models_test",
             "LEMONADE_GLOBAL_TIMEOUT": "999",
             "LEMONADE_MAX_LOADED_MODELS": "3",
+            "LEMONADE_MAX_GPU_MEMORY_OCCUPANCY_GB": "12.5",
             # Recipe-option env vars
             "LEMONADE_CTX_SIZE": "2048",
         }
@@ -160,6 +161,9 @@ class TestConfigEnvVars(unittest.TestCase):
 
     def test_max_loaded_models(self):
         self.assertEqual(self.snapshot["max_loaded_models"], 3)
+
+    def test_max_gpu_memory_occupancy_gb(self):
+        self.assertEqual(self.snapshot["max_gpu_memory_occupancy_gb"], 12.5)
 
     def test_max_loaded_models_in_health(self):
         health = requests.get(HEALTH, timeout=TIMEOUT_DEFAULT).json()
@@ -417,6 +421,9 @@ class TestDefaults(unittest.TestCase):
 
     def test_default_max_loaded_models(self):
         self.assertEqual(self.snapshot["max_loaded_models"], 1)
+
+    def test_default_max_gpu_memory_occupancy_gb(self):
+        self.assertEqual(self.snapshot["max_gpu_memory_occupancy_gb"], -1.0)
 
     def test_default_ctx_size(self):
         self.assertEqual(self.snapshot["ctx_size"], 4096)


### PR DESCRIPTION
## Summary

- Adds `max_gpu_memory_occupancy_gb` so Lemonade can cap its GPU memory footprint before starting another GPU backend.
- Uses the smaller of configured capacity and memory currently available to Lemonade, defined as free GPU memory plus the GPU memory already occupied by loaded Lemonade models.
- Prevents the requested load from evicting useful GPU models when the requested model still cannot fit.

## Changes

- Adds a GPU admission planner that dry-runs largest-to-smallest GPU evictions and rejects impossible loads without unloading existing models.
- Tracks each loaded `WrappedServer` GPU occupancy using load-time GPU memory deltas, with conservative prediction as fallback.
- Adds a dependency-free GGUF metadata reader for llama.cpp models and uses layer/head/key/value metadata to estimate KV cache size conservatively.
- Adds config defaults, environment migration for `LEMONADE_MAX_GPU_MEMORY_OCCUPANCY_GB`, validation, and docs for the new setting.
- Marks `vllm` recipes as GPU-backed so they participate in the GPU budget.

## Verification

- `g++ -std=c++17 -I src/cpp/include test/cpp/test_gpu_memory_planner.cpp src/cpp/server/gpu_memory_planner.cpp -o /tmp/test_gpu_memory_planner && /tmp/test_gpu_memory_planner` passed.
- `g++ -std=c++17 -I src/cpp/include test/cpp/test_gguf_metadata.cpp src/cpp/server/gguf_metadata.cpp -o /tmp/test_gguf_metadata && /tmp/test_gguf_metadata` passed.
- `g++ -std=c++17 -I src/cpp/include test/cpp/test_model_type_classifier.cpp -o /tmp/test_model_type_classifier && /tmp/test_model_type_classifier` passed.
- `cmake --preset default` passed.
- `cmake --build --preset default --target lemond` passed. The build environment still emits existing inherited shell-function warnings for `ml` and `module`.
- `python test/server_env_vars.py --lemond-binary build/lemond` passed: 37 tests.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable GPU memory occupancy limit (max_gpu_memory_occupancy_gb, default -1)
  * Automatic GPU-model eviction (dry-run largest→smallest) when a load would exceed GPU budget
  * vLLM recipe recognized for GPU-targeting loads
  * Real-time GPU memory sampling and per-model GPU occupancy reporting; improved occupancy estimates via model metadata

* **Documentation**
  * Updated config, architecture, and multi-model guides with GPU budgeting, eviction semantics, and examples

* **Tests**
  * Added tests for GGUF metadata parsing, GPU admission planning, device-type mapping, and config exposure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/2)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->