### PR TITLE
fix(server/router): include APU GTT in GPU budget capacity

### DIFF
--- a/src/cpp/include/lemon/gpu_memory_planner.h
+++ b/src/cpp/include/lemon/gpu_memory_planner.h
@@ -30,4 +30,9 @@ struct GpuMemoryAdmissionPlan {
 
 GpuMemoryAdmissionPlan plan_gpu_memory_admission(const GpuMemoryAdmissionInputs& inputs);
 
+double gpu_memory_capacity_from_pools_gb(double vram_gb,
+                                         double virtual_mem_gb,
+                                         bool is_integrated_gpu,
+                                         bool enable_discrete_gpu_gtt);
+
 } // namespace lemon

--- a/src/cpp/server/gpu_memory_planner.cpp
+++ b/src/cpp/server/gpu_memory_planner.cpp
@@ -50,4 +50,18 @@ GpuMemoryAdmissionPlan plan_gpu_memory_admission(const GpuMemoryAdmissionInputs&
     return plan;
 }
 
+double gpu_memory_capacity_from_pools_gb(double vram_gb,
+                                         double virtual_mem_gb,
+                                         bool is_integrated_gpu,
+                                         bool enable_discrete_gpu_gtt) {
+    const double safe_vram_gb = std::max(0.0, vram_gb);
+    const double safe_virtual_mem_gb = std::max(0.0, virtual_mem_gb);
+
+    if (is_integrated_gpu || enable_discrete_gpu_gtt) {
+        return safe_vram_gb + safe_virtual_mem_gb;
+    }
+
+    return safe_vram_gb;
+}
+
 } // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1,5 +1,6 @@
 #include <lemon/model_manager.h>
 #include <lemon/gguf_metadata.h>
+#include <lemon/gpu_memory_planner.h>
 #include <lemon/runtime_config.h>
 #include <lemon/hf_variants.h>
 #include <lemon/utils/json_utils.h>
@@ -1646,15 +1647,20 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         // Because we have mixed types this just makes every device_type an array.
         nlohmann::json dev_list = devices.is_array() ? devices : nlohmann::json{devices};
 
-        // Expand this later to accommodate mixed pools
-        MemoryAllocBehavior dev_mem_alloc_behavior = MemoryAllocBehavior::Hardware;
-        if (dev_type == "amd_igpu")
-            dev_mem_alloc_behavior = MemoryAllocBehavior::Largest;
-        if (enable_dgpu_gtt)
-            dev_mem_alloc_behavior = MemoryAllocBehavior::Unified;
-
         for (const auto& dev : dev_list) {
-            curr_mem_pool_gb = get_max_memory_of_device(dev, dev_mem_alloc_behavior);
+            if (dev_type == "amd_gpu") {
+                curr_mem_pool_gb = gpu_memory_capacity_from_pools_gb(
+                    dev.value("vram_gb", 0.0),
+                    dev.value("virtual_mem_gb", 0.0),
+                    dev.value("gpu_type", "") == "integrated",
+                    enable_dgpu_gtt);
+            } else {
+                // Expand this later to accommodate mixed pools
+                MemoryAllocBehavior dev_mem_alloc_behavior = MemoryAllocBehavior::Hardware;
+                if (enable_dgpu_gtt)
+                    dev_mem_alloc_behavior = MemoryAllocBehavior::Unified;
+                curr_mem_pool_gb = get_max_memory_of_device(dev, dev_mem_alloc_behavior);
+            }
             largest_mem_pool_gb = largest_mem_pool_gb < curr_mem_pool_gb ? curr_mem_pool_gb : largest_mem_pool_gb;
         }
     }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -281,15 +281,6 @@ double Router::get_lemonade_gpu_occupancy_gb() const {
     return total;
 }
 
-static double gpu_capacity_from_device_json(const json& device, bool include_virtual_memory) {
-    double vram_gb = device.value("vram_gb", 0.0);
-    double virtual_mem_gb = device.value("virtual_mem_gb", 0.0);
-    if (include_virtual_memory) {
-        return vram_gb + virtual_mem_gb;
-    }
-    return vram_gb > 0.0 ? vram_gb : virtual_mem_gb;
-}
-
 double Router::get_total_gpu_capacity_gb() const {
     json system_info = SystemInfoCache::get_system_info_with_cache();
     if (!system_info.contains("devices") || !system_info["devices"].is_object()) {
@@ -299,20 +290,25 @@ double Router::get_total_gpu_capacity_gb() const {
     const json& devices = system_info["devices"];
     double single_device_capacity_gb = 0.0;
 
-    auto accumulate_gpu_capacity = [&](const std::string& key, bool include_virtual_memory) {
+    auto accumulate_gpu_capacity = [&](const std::string& key) {
         if (!devices.contains(key)) return;
         json dev_list = devices[key].is_array() ? devices[key] : json::array({devices[key]});
         for (const auto& device : dev_list) {
             if (!device.is_object() || !device.value("available", false)) continue;
-            single_device_capacity_gb = std::max(single_device_capacity_gb,
-                                                 gpu_capacity_from_device_json(device, include_virtual_memory));
+            const bool is_integrated_gpu = device.value("gpu_type", "") == "integrated";
+            const double capacity_gb = gpu_memory_capacity_from_pools_gb(
+                device.value("vram_gb", 0.0),
+                device.value("virtual_mem_gb", 0.0),
+                is_integrated_gpu,
+                config_->enable_dgpu_gtt());
+            single_device_capacity_gb = std::max(single_device_capacity_gb, capacity_gb);
         }
     };
 
     // Lemonade does not track per-request GPU placement, so do not treat memory
     // as pooled across cards. The sampler provides aggregate pressure; this
     // capacity is the largest single observable AMD device.
-    accumulate_gpu_capacity("amd_gpu", config_->enable_dgpu_gtt());
+    accumulate_gpu_capacity("amd_gpu");
 
     return single_device_capacity_gb;
 }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -515,7 +515,8 @@ json SystemInfo::get_device_dict() {
         if (amd_igpu.available) {
             json gpu_json = {
                 {"name", amd_igpu.name},
-                {"available", amd_igpu.available}
+                {"available", amd_igpu.available},
+                {"gpu_type", "integrated"}
             };
             if (amd_igpu.vram_gb > 0) {
                 gpu_json["vram_gb"] = amd_igpu.vram_gb;
@@ -535,7 +536,8 @@ json SystemInfo::get_device_dict() {
             if (gpu.available) {
                 json gpu_json = {
                     {"name", gpu.name},
-                    {"available", gpu.available}
+                    {"available", gpu.available},
+                    {"gpu_type", "discrete"}
                 };
                 if (gpu.vram_gb > 0) {
                     gpu_json["vram_gb"] = gpu.vram_gb;

--- a/test/cpp/test_gpu_memory_planner.cpp
+++ b/test/cpp/test_gpu_memory_planner.cpp
@@ -7,6 +7,7 @@
 
 using lemon::GpuMemoryAdmissionInputs;
 using lemon::GpuMemoryResident;
+using lemon::gpu_memory_capacity_from_pools_gb;
 using lemon::plan_gpu_memory_admission;
 
 static void expect_evictions(const char* name,
@@ -20,6 +21,15 @@ static void expect_evictions(const char* name,
         std::printf("\n want:");
         for (const auto& value : expected) std::printf(" %s", value.c_str());
         std::printf("\n");
+    }
+    assert(ok);
+}
+
+static void expect_capacity(const char* name, double actual, double expected) {
+    bool ok = actual == expected;
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got: %.3f GB\n want: %.3f GB\n", actual, expected);
     }
     assert(ok);
 }
@@ -79,6 +89,24 @@ int main() {
         expect_evictions("auto capacity uses current memory available to Lemonade",
                          plan.models_to_evict,
                          {});
+    }
+
+    {
+        expect_capacity("APU capacity includes GTT when dGPU GTT is disabled",
+                        gpu_memory_capacity_from_pools_gb(0.5, 63.5, true, false),
+                        64.0);
+    }
+
+    {
+        expect_capacity("dGPU capacity ignores GTT by default",
+                        gpu_memory_capacity_from_pools_gb(16.0, 64.0, false, false),
+                        16.0);
+        expect_capacity("dGPU capacity includes GTT when enabled",
+                        gpu_memory_capacity_from_pools_gb(16.0, 64.0, false, true),
+                        80.0);
+        expect_capacity("dGPU capacity is unavailable when VRAM is unavailable and GTT is disabled",
+                        gpu_memory_capacity_from_pools_gb(0.0, 20.0, false, false),
+                        0.0);
     }
 
     std::printf("\nAll GPU memory planner cases passed\n");


### PR DESCRIPTION
## Summary
- Fix APU capacity accounting for GPU memory admission by marking AMD GPU entries as integrated or discrete in system info.
- Count `vram_gb + virtual_mem_gb` for integrated AMD GPUs even when `enable_dgpu_gtt` is false; keep discrete AMD GPUs on VRAM-only capacity unless dGPU GTT is enabled.
- Reuse the same capacity helper for router admission and model filtering.

## Verification
- `g++ -std=c++17 -Isrc/cpp/include test/cpp/test_gpu_memory_planner.cpp src/cpp/server/gpu_memory_planner.cpp -o /tmp/test_gpu_memory_planner` passed.
- `/tmp/test_gpu_memory_planner` passed.
- `git diff --check` passed.
- `cmake --build --preset default --target lemond` passed.
- `python test/server_env_vars.py` passed.
- Manual server smoke: `/api/v1/system-info` reports AMD GPU `gpu_type: integrated`, `vram_gb: 1.0`, `virtual_mem_gb: 112.0`; startup logs `Largest memory pool: 113.0`.

## Caveat
- `python test/server_endpoints.py -k system` and `python test/server_endpoints.py EndpointTests.test_018_system_info` failed before reaching the system-info assertion because test setup tried to pull `Tiny-Test-Model-GGUF` into read-only `/var/cache/hf`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GPU memory capacity calculation for AMD GPUs, with more accurate handling of integrated vs. discrete devices and fallback memory accounting.
  * Device reporting now includes GPU type (integrated/discrete) for AMD GPUs.

* **Tests**
  * Added tests validating GPU memory capacity computations across pool and flag combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/3)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->