### PR TITLE
Add active model pins

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -133,6 +133,10 @@ _Avoid_: Updating backend pins without checking the corresponding recipe behavio
 Per-model or global runtime settings that shape how a recipe launches and runs.
 _Avoid_: Treating recipe options as model registry identity.
 
+**Model pin**:
+A server-owned model lifecycle preference that asks `lemond` to keep a model resident across startup and automatic eviction pressure.
+_Avoid_: Treating it as a desktop-app-local preference or as a backend version pin.
+
 **NPU exclusivity**:
 The rule that exclusive NPU recipes evict other NPU models before loading.
 _Avoid_: Assuming FLM coexistence rules apply to RyzenAI or whisper.cpp NPU models.
@@ -254,6 +258,7 @@ _Avoid_: Opening upstream-facing artifacts without the user's explicit direction
 - **lemond** delegates model lifecycle and inference work to backend subprocesses.
 - A **model name** resolves to model metadata, a **recipe**, **checkpoints**, labels, loaded-model category, and recipe options.
 - A **recipe** selects the execution family; a **backend** selects the concrete engine or device path inside that family.
+- A **Model pin** is stored in `lemond` configuration and edited by clients through server APIs.
 - Loaded-model categories control per-type LRU slots; **NPU exclusivity** controls cross-type NPU eviction.
 - **OmniRouter** uses **Collections** and **tool definitions** to expose multi-modal endpoints through the standard tool-calling loop.
 - **Fork-local changes** target **fork origin** unless the user declares an **upstream contribution exception**.

--- a/docs/agents/architecture-map.md
+++ b/docs/agents/architecture-map.md
@@ -17,6 +17,7 @@ This file captures implementation landmarks that are useful before changing Lemo
 - Core API endpoints are registered under `/api/v0/`, `/api/v1/`, `/v0/`, and `/v1/`.
 - Ollama-compatible routes live under `/api/` without the Lemonade/OpenAI version prefix.
 - Internal endpoints live under `/internal/`: `shutdown`, `set`, `config`, and `cleanup-cache`. They are loopback-restricted admin/local lifecycle, configuration, and cache-management APIs, not OpenAI-compatible routes.
+- Model pin management belongs on narrow Lemonade API routes under the normal version prefixes, not on generic `/internal/set` config editing. The first route shape is `GET /pins`, `POST /pins`, and `DELETE /pins/{model_name}` under `/api/v0/`, `/api/v1/`, `/v0/`, and `/v1/`. `GET /pins` returns configured pins with loaded status and optional load error.
 
 ## Model Lifecycle
 
@@ -32,6 +33,17 @@ This file captures implementation landmarks that are useful before changing Lemo
 - Model type controls the LRU bucket: LLM, embedding, reranking, audio, image, or TTS.
 - `max_loaded_models` applies per model type, not globally.
 - `max_gpu_memory_occupancy_gb` applies across loaded GPU models. Router dry-runs largest-to-smallest GPU evictions and leaves existing models loaded when the requested model cannot fit.
+- Model pins are excluded from automatic eviction policies and from eviction-managed capacity counts. Their resident GPU usage still reduces physical memory available to unpinned loads.
+- Model pin loading is best-effort at `lemond` startup; failed pin loads should be logged and surfaced to clients without preventing the server from starting.
+- Pinning an already-loaded model is a live metadata/config transition; it should persist the server config and protect the current `WrappedServer` without unloading or reloading it.
+- `POST /pins` accepts loaded or loading non-collection models; it is idempotent for models that are already pinned.
+- `DELETE /pins/{model_name}` persists config and clears protection on the current `WrappedServer` if it is loaded, without unloading it.
+- Model pin configuration stores canonical model names only; recipe options remain owned by the existing recipe-options path.
+- Explicit unload affects current residency only; unpinning is the action that removes a model from pin configuration.
+- Deleting a model removes that model name from pin configuration.
+- Collection ids are not pinned; users pin the concrete loaded component models instead.
+- NPU exclusivity still applies between model pins; startup pin loading may resolve pin-to-pin NPU conflicts in configured order instead of preserving all pins resident.
+- `pinned_models` preserves insertion order and `lemond` loads pins in that order; drag-to-reorder is optional UI polish, not required for the first implementation.
 - Busy `WrappedServer` instances are protected from eviction until their active request ends.
 - Non-file-not-found load failures trigger an evict-all-and-retry path.
 - Exclusive NPU recipes evict other NPU users; FLM has recipe-specific coexistence rules.
@@ -42,6 +54,8 @@ This file captures implementation landmarks that are useful before changing Lemo
 - The Tauri desktop app uses `src/app/src-tauri/` and installs `window.api` through `tauriShim.ts`.
 - The browser web app in `src/web-app/` reuses the shared renderer with a separate package/dependency tree.
 - Do not consolidate `src/app/package.json` and `src/web-app/package.json`; the split supports Debian native packaging with system Node modules.
+- Model pin controls belong at the leading edge of active-model list rows, not in the trailing unload/action button cluster.
+- The active-model UI should surface configured pinned models even when they are not currently loaded, so users can see failed/manual-unloaded pins and unpin them.
 
 ## OmniRouter
 

--- a/docs/agents/architecture-map.md
+++ b/docs/agents/architecture-map.md
@@ -42,7 +42,7 @@ This file captures implementation landmarks that are useful before changing Lemo
 - Explicit unload affects current residency only; unpinning is the action that removes a model from pin configuration.
 - Deleting a model removes that model name from pin configuration.
 - Collection ids are not pinned; users pin the concrete loaded component models instead.
-- NPU exclusivity still applies between model pins; startup pin loading may resolve pin-to-pin NPU conflicts in configured order instead of preserving all pins resident.
+- NPU exclusivity still applies between model pins; startup pin loading processes pins in configured order, so a later conflicting pinned NPU model can evict an earlier one instead of preserving all pins resident.
 - `pinned_models` preserves insertion order and `lemond` loads pins in that order; drag-to-reorder is optional UI polish, not required for the first implementation.
 - Busy `WrappedServer` instances are protected from eviction until their active request ends.
 - Non-file-not-found load failures trigger an evict-all-and-retry path.

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1858,6 +1858,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
                         onClick={() => isPinned ? handleUnpinModel(modelName) : handlePinModel(modelName)}
                         disabled={pinDisabled}
                         title={pinTitle}
+                        aria-label={pinTitle}
                         aria-pressed={isPinned}
                       >
                         <PinIcon />

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -304,17 +304,28 @@ interface PinInfo {
   load_error: string | null;
 }
 
-async function getServerErrorMessage(response: Response, fallback: string): Promise<string> {
+interface ServerErrorDetails {
+  message: string;
+  code?: string;
+}
+
+async function getServerErrorDetails(response: Response, fallback: string): Promise<ServerErrorDetails> {
   const text = await response.text().catch(() => '');
-  if (!text) return fallback;
+  if (!text) return { message: fallback };
   try {
     const parsed = JSON.parse(text);
-    if (typeof parsed?.error === 'string') return parsed.error;
-    if (typeof parsed?.error?.message === 'string') return parsed.error.message;
+    if (typeof parsed?.error === 'string') return { message: parsed.error, code: parsed.code };
+    if (typeof parsed?.error?.message === 'string') {
+      return { message: parsed.error.message, code: parsed.error.code ?? parsed.code };
+    }
   } catch {
     // Fall through to the raw response text.
   }
-  return text;
+  return { message: text };
+}
+
+async function getServerErrorMessage(response: Response, fallback: string): Promise<string> {
+  return (await getServerErrorDetails(response, fallback)).message;
 }
 
 const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
@@ -427,12 +438,16 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
 
   useEffect(() => {
     fetchCurrentLoadedModel();
-    fetchPinnedModels();
+    if (pinsAvailable) {
+      fetchPinnedModels();
+    }
 
     // Poll for model status every 5 seconds to detect loaded models
     const interval = setInterval(() => {
       fetchCurrentLoadedModel();
-      fetchPinnedModels();
+      if (pinsAvailable) {
+        fetchPinnedModels();
+      }
     }, 5000);
 
     // === Integration API for other parts of the app ===
@@ -472,7 +487,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
         });
         // Refresh the loaded model status
         fetchCurrentLoadedModel();
-        fetchPinnedModels();
+        if (pinsAvailable) {
+          fetchPinnedModels();
+        }
       }
     };
 
@@ -485,7 +502,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
       window.removeEventListener('modelLoadEnd' as any, handleModelLoadEnd);
       delete (window as any).setModelLoading;
     };
-  }, [fetchCurrentLoadedModel, fetchPinnedModels]);
+  }, [fetchCurrentLoadedModel, fetchPinnedModels, pinsAvailable]);
 
   useEffect(() => {
     setShowFilterPanel(false);
@@ -1231,13 +1248,13 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
           break;
         }
 
-        const message = await getServerErrorMessage(response, `Failed to pin model: ${response.statusText}`);
+        const errorDetails = await getServerErrorDetails(response, `Failed to pin model: ${response.statusText}`);
         const canRetryLoadingRace =
           response.status === 400 &&
-          message.includes('loaded or loading') &&
+          errorDetails.code === 'model_not_loaded_or_loading' &&
           Date.now() < retryUntil;
         if (!canRetryLoadingRace) {
-          throw new Error(message);
+          throw new Error(errorDetails.message);
         }
 
         await delay(500);

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Boxes, Brain, ChevronRight, Cpu, Eye, Flame, Layers, ListOrdered, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
+import { Boxes, Brain, ChevronRight, Cpu, EjectIcon, Eye, Flame, Layers, ListOrdered, PinIcon, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
 import { ModelInfo } from './utils/modelData';
 import { ToastContainer, useToast } from './Toast';
 import { useConfirmDialog } from './ConfirmDialog';
@@ -17,7 +17,6 @@ import BackendManager from './BackendManager';
 import ConnectedBackendRow from './components/ConnectedBackendRow';
 import MarketplacePanel, { MarketplaceCategory } from './MarketplacePanel';
 import { RECIPE_DISPLAY_NAMES } from './utils/recipeNames';
-import { EjectIcon } from './components/Icons';
 import { getCollectionComponents, isCollectionFullyDownloaded, isCollectionModel, isModelEffectivelyDownloaded, isModelEffectivelyLoaded } from './utils/collectionModels';
 
 interface ModelFamily {
@@ -299,6 +298,27 @@ interface ModelJSON {
   image_defaults?: []
 }
 
+interface PinInfo {
+  model_name: string;
+  loaded: boolean;
+  load_error: string | null;
+}
+
+async function getServerErrorMessage(response: Response, fallback: string): Promise<string> {
+  const text = await response.text().catch(() => '');
+  if (!text) return fallback;
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed?.error === 'string') return parsed.error;
+    if (typeof parsed?.error?.message === 'string') return parsed.error.message;
+  } catch {
+    // Fall through to the raw response text.
+  }
+  return text;
+}
+
+const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
 export type LeftPanelView = 'models' | 'backends' | 'marketplace' | 'settings';
 
 
@@ -312,9 +332,14 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
   const [organizationMode, setOrganizationMode] = useState<'recipe' | 'category'>('recipe');
   const [showDownloadedOnly, setShowDownloadedOnly] = useState(false);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
-const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
   const [loadedModels, setLoadedModels] = useState<Set<string>>(new Set());
   const [loadingModels, setLoadingModels] = useState<Set<string>>(new Set());
+  const [pinnedModels, setPinnedModels] = useState<Set<string>>(new Set());
+  const [pinnedModelOrder, setPinnedModelOrder] = useState<string[]>([]);
+  const [pinLoadErrors, setPinLoadErrors] = useState<Record<string, string | null>>({});
+  const [pinsAvailable, setPinsAvailable] = useState(true);
+  const [pinningModels, setPinningModels] = useState<Set<string>>(new Set());
   const [hoveredModel, setHoveredModel] = useState<string | null>(null);
   const [optionsModel, setOptionsModel] = useState<string | null>(null);
   const [showModelOptionsModal, setShowModelOptionsModal] = useState(false);
@@ -363,6 +388,37 @@ const [searchQuery, setSearchQuery] = useState('');
     }
   }, []);
 
+  const fetchPinnedModels = useCallback(async () => {
+    try {
+      const response = await serverFetch('/pins');
+      if (!response.ok) {
+        if (response.status === 404) {
+          setPinsAvailable(false);
+          setPinnedModels(new Set());
+          setPinnedModelOrder([]);
+          setPinLoadErrors({});
+          return;
+        }
+        throw new Error(await getServerErrorMessage(response, `Failed to fetch pins: ${response.statusText}`));
+      }
+
+      setPinsAvailable(true);
+      const data = await response.json();
+      const pins: PinInfo[] = Array.isArray(data?.data) ? data.data : [];
+      const pinNames = pins
+        .map((pin) => pin.model_name)
+        .filter((modelName): modelName is string => typeof modelName === 'string' && modelName.length > 0);
+
+      setPinnedModels(new Set(pinNames));
+      setPinnedModelOrder(pinNames);
+      setPinLoadErrors(Object.fromEntries(
+        pins.map((pin) => [pin.model_name, pin.load_error ?? null])
+      ));
+    } catch (error) {
+      console.error('Failed to fetch pinned models:', error);
+    }
+  }, []);
+
   // Load system info on mount so recipe categories (e.g., FLM) can appear
   // even when the backend isn't installed yet
   useEffect(() => {
@@ -371,10 +427,12 @@ const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
     fetchCurrentLoadedModel();
+    fetchPinnedModels();
 
     // Poll for model status every 5 seconds to detect loaded models
     const interval = setInterval(() => {
       fetchCurrentLoadedModel();
+      fetchPinnedModels();
     }, 5000);
 
     // === Integration API for other parts of the app ===
@@ -414,6 +472,7 @@ const [searchQuery, setSearchQuery] = useState('');
         });
         // Refresh the loaded model status
         fetchCurrentLoadedModel();
+        fetchPinnedModels();
       }
     };
 
@@ -426,7 +485,7 @@ const [searchQuery, setSearchQuery] = useState('');
       window.removeEventListener('modelLoadEnd' as any, handleModelLoadEnd);
       delete (window as any).setModelLoading;
     };
-  }, [fetchCurrentLoadedModel]);
+  }, [fetchCurrentLoadedModel, fetchPinnedModels]);
 
   useEffect(() => {
     setShowFilterPanel(false);
@@ -644,24 +703,55 @@ const [searchQuery, setSearchQuery] = useState('');
   // get an `isLoading` flag so the UI can render a pending indicator.
   // Skip collection entries themselves — only show component models.
   const loadedModelEntries = (() => {
-    const entries: Array<{ modelName: string; isLoading: boolean }> = [];
+    const entries: Array<{
+      modelName: string;
+      isLoading: boolean;
+      isLoaded: boolean;
+      isPinned: boolean;
+      loadError: string | null;
+    }> = [];
     const seen = new Set<string>();
     for (const modelName of loadedModels) {
       if (isCollectionModel(modelsData[modelName])) continue;
       if (seen.has(modelName)) continue;
       seen.add(modelName);
-      entries.push({ modelName, isLoading: false });
+      entries.push({
+        modelName,
+        isLoading: false,
+        isLoaded: true,
+        isPinned: pinnedModels.has(modelName),
+        loadError: pinLoadErrors[modelName] ?? null,
+      });
     }
     for (const modelName of loadingModels) {
       if (isCollectionModel(modelsData[modelName])) continue;
       if (seen.has(modelName)) continue;
       seen.add(modelName);
-      entries.push({ modelName, isLoading: true });
+      entries.push({
+        modelName,
+        isLoading: true,
+        isLoaded: false,
+        isPinned: pinnedModels.has(modelName),
+        loadError: pinLoadErrors[modelName] ?? null,
+      });
     }
-    return entries.sort((a, b) =>
+    const activeEntries = entries.sort((a, b) =>
       getModelDisplayName(a.modelName).localeCompare(getModelDisplayName(b.modelName)) ||
       a.modelName.localeCompare(b.modelName)
     );
+    for (const modelName of pinnedModelOrder) {
+      if (seen.has(modelName)) continue;
+      if (isCollectionModel(modelsData[modelName])) continue;
+      seen.add(modelName);
+      activeEntries.push({
+        modelName,
+        isLoading: false,
+        isLoaded: false,
+        isPinned: true,
+        loadError: pinLoadErrors[modelName] ?? null,
+      });
+    }
+    return activeEntries;
   })();
 
 
@@ -1031,6 +1121,7 @@ const [searchQuery, setSearchQuery] = useState('');
         }
 
         await fetchCurrentLoadedModel();
+        await fetchPinnedModels();
         window.dispatchEvent(new CustomEvent('modelLoadEnd', { detail: { modelId: modelName } }));
         window.dispatchEvent(new CustomEvent('modelsUpdated'));
         return;
@@ -1048,6 +1139,7 @@ const [searchQuery, setSearchQuery] = useState('');
       });
 
       await fetchCurrentLoadedModel();
+      await fetchPinnedModels();
       window.dispatchEvent(new CustomEvent('modelLoadEnd', { detail: { modelId: modelName } }));
       window.dispatchEvent(new CustomEvent('modelsUpdated'));
     } catch (error) {
@@ -1092,6 +1184,7 @@ const [searchQuery, setSearchQuery] = useState('');
           }
         }
         await fetchCurrentLoadedModel();
+        await fetchPinnedModels();
         window.dispatchEvent(new CustomEvent('modelUnload'));
         return;
       }
@@ -1108,12 +1201,91 @@ const [searchQuery, setSearchQuery] = useState('');
 
       // Refresh current loaded model status
       await fetchCurrentLoadedModel();
+      await fetchPinnedModels();
 
       // Dispatch event to notify other components (e.g., ChatWindow) that model was unloaded
       window.dispatchEvent(new CustomEvent('modelUnload'));
     } catch (error) {
       console.error('Error unloading model:', error);
       showError(`Failed to unload model: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  };
+
+  const handlePinModel = async (modelName: string) => {
+    if (!pinsAvailable) {
+      showWarning('Pins require a newer Lemonade server.');
+      return;
+    }
+
+    setPinningModels(prev => new Set(prev).add(modelName));
+    try {
+      const retryUntil = loadingModels.has(modelName) ? Date.now() + 120_000 : Date.now();
+      while (true) {
+        const response = await serverFetch('/pins', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model_name: modelName })
+        });
+
+        if (response.ok) {
+          break;
+        }
+
+        const message = await getServerErrorMessage(response, `Failed to pin model: ${response.statusText}`);
+        const canRetryLoadingRace =
+          response.status === 400 &&
+          message.includes('loaded or loading') &&
+          Date.now() < retryUntil;
+        if (!canRetryLoadingRace) {
+          throw new Error(message);
+        }
+
+        await delay(500);
+      }
+
+      await fetchPinnedModels();
+      await fetchCurrentLoadedModel();
+      showSuccess(`Pinned "${modelName}".`);
+    } catch (error) {
+      console.error('Error pinning model:', error);
+      showError(`Failed to pin model: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setPinningModels(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(modelName);
+        return newSet;
+      });
+    }
+  };
+
+  const handleUnpinModel = async (modelName: string) => {
+    if (!pinsAvailable) {
+      showWarning('Pins require a newer Lemonade server.');
+      return;
+    }
+
+    setPinningModels(prev => new Set(prev).add(modelName));
+    try {
+      const response = await serverFetch(`/pins/${encodeURIComponent(modelName)}`, {
+        method: 'DELETE'
+      });
+
+      if (!response.ok) {
+        throw new Error(await getServerErrorMessage(response, `Failed to unpin model: ${response.statusText}`));
+      }
+
+      await fetchPinnedModels();
+      await fetchCurrentLoadedModel();
+      showSuccess(`Unpinned "${modelName}".`);
+    } catch (error) {
+      console.error('Error unpinning model:', error);
+      showError(`Failed to unpin model: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setPinningModels(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(modelName);
+        return newSet;
+      });
     }
   };
 
@@ -1153,6 +1325,7 @@ const [searchQuery, setSearchQuery] = useState('');
         showSuccess(`Model "${modelName}" deleted successfully.`);
       }
       await fetchCurrentLoadedModel();
+      await fetchPinnedModels();
     } catch (error) {
       console.error('Error deleting model:', error);
       showError(`Failed to delete model: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -1663,27 +1836,47 @@ const [searchQuery, setSearchQuery] = useState('');
               <div className="loaded-model-header">
                 <div className="loaded-model-label">ACTIVE MODELS</div>
                 <div className="loaded-model-count-pill">
-                  {loadedModelEntries.filter(e => !e.isLoading).length} loaded
+                  {loadedModelEntries.filter(e => e.isLoaded).length} loaded
                 </div>
               </div>
               {loadedModelEntries.length === 0 && <div className="loaded-model-empty">No models loaded</div>}
               <div className="loaded-model-list">
-                {loadedModelEntries.map(({ modelName, isLoading }) => (
-                  <div key={modelName} className="loaded-model-info">
-                    <div className="loaded-model-details">
-                      <span
-                        className={`loaded-model-indicator${isLoading ? ' loading' : ''}`}
-                        title={isLoading ? 'Loading' : 'Loaded'}
-                      />
-                      <span className="loaded-model-name" title={modelName}>{getModelDisplayName(modelName)}</span>
-                    </div>
-                    {!isLoading && (
-                      <button className="model-action-btn unload-btn active-model-eject-button" onClick={() => handleUnloadModel(modelName)} title="Eject model">
-                        <EjectIcon />
+                {loadedModelEntries.map(({ modelName, isLoading, isLoaded, isPinned, loadError }) => {
+                  const isPinning = pinningModels.has(modelName);
+                  const pinDisabled = !pinsAvailable || isPinning || (!isPinned && !isLoaded && !isLoading);
+                  const canPinActiveModel = pinsAvailable && !isPinned && (isLoaded || isLoading);
+                  const pinTitle = !pinsAvailable
+                    ? 'Pins require a newer Lemonade server'
+                    : (isPinned ? 'Unpin model' : 'Pin model');
+                  const indicatorTitle = isLoading ? 'Loading' : (isLoaded ? 'Loaded' : (loadError || 'Pinned'));
+                  const indicatorClassName = `loaded-model-indicator${isLoading ? ' loading' : ''}${!isLoaded && !isLoading ? ' not-loaded' : ''}${loadError ? ' error' : ''}`;
+
+                  return (
+                    <div key={modelName} className={`loaded-model-info${isPinned ? ' pinned' : ''}${!isLoaded && !isLoading ? ' pinned-not-loaded' : ''}`}>
+                      <button
+                        className={`model-action-btn pin-btn${isPinned ? ' pinned' : ''}${canPinActiveModel ? ' pin-available' : ''}${isPinning ? ' pending' : ''}`}
+                        onClick={() => isPinned ? handleUnpinModel(modelName) : handlePinModel(modelName)}
+                        disabled={pinDisabled}
+                        title={pinTitle}
+                        aria-pressed={isPinned}
+                      >
+                        <PinIcon />
                       </button>
-                    )}
-                  </div>
-                ))}
+                      <div className="loaded-model-details">
+                        <span
+                          className={indicatorClassName}
+                          title={indicatorTitle}
+                        />
+                        <span className="loaded-model-name" title={modelName}>{getModelDisplayName(modelName)}</span>
+                      </div>
+                      {isLoaded && !isLoading && (
+                        <button className="model-action-btn unload-btn active-model-eject-button" onClick={() => handleUnloadModel(modelName)} title="Eject model">
+                          <EjectIcon />
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1219,7 +1219,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
 
     setPinningModels(prev => new Set(prev).add(modelName));
     try {
-      const retryUntil = loadingModels.has(modelName) ? Date.now() + 120_000 : Date.now();
+      const retryUntil = Date.now() + (loadingModels.has(modelName) ? 120_000 : 5_000);
       while (true) {
         const response = await serverFetch('/pins', {
           method: 'POST',

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -162,6 +162,13 @@ export const EjectIcon: React.FC = () => (
   </svg>
 );
 
+export const PinIcon: React.FC = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 17v5" />
+    <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+  </svg>
+);
+
 // Modality icons from lucide (https://lucide.dev) - ISC License.
 export const Brain: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1495,12 +1495,12 @@ footer {
 
 .loaded-model-info {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 22px;
+    grid-template-columns: 22px minmax(0, 1fr) 22px;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
     margin-bottom: 0;
     border-radius: 5px;
-    padding: 2px 2px 2px 1px;
+    padding: 2px;
     transition: background-color 0.15s ease;
 }
 
@@ -1555,7 +1555,6 @@ footer {
     align-items: center;
     gap: 8px;
     min-width: 0;
-    padding-left: 8px;
 }
 
 .loaded-model-indicator {
@@ -1576,6 +1575,18 @@ footer {
     background-color: #facc15;
     animation: pulse 1.5s ease-in-out infinite;
     filter: drop-shadow(0 0 2px #facc15);
+}
+
+.loaded-model-indicator.not-loaded {
+    background-color: var(--text-quaternary);
+    animation: none;
+    filter: none;
+}
+
+.loaded-model-indicator.error {
+    background-color: var(--error-color);
+    animation: none;
+    filter: drop-shadow(0 0 2px var(--error-color));
 }
 
 @keyframes pulse-glow {
@@ -1971,6 +1982,46 @@ footer {
 
 .model-action-btn.unload-btn:hover {
     color: var(--action-color);
+}
+
+.model-action-btn.pin-btn {
+    background: transparent;
+    box-shadow: none;
+    color: var(--text-quaternary);
+}
+
+.model-action-btn.pin-btn.pin-available {
+    color: var(--text-secondary);
+}
+
+.model-action-btn.pin-btn.pinned {
+    background: rgba(255, 183, 77, 0.16);
+    box-shadow: inset 0 0 0 1px rgba(255, 183, 77, 0.42);
+    color: var(--warning-color);
+}
+
+.model-action-btn.pin-btn:not(.pinned):not(:disabled):hover {
+    background: var(--bg-alpha-06);
+    color: var(--text-tertiary);
+}
+
+.model-action-btn.pin-btn.pinned:not(:disabled):hover {
+    background: rgba(255, 183, 77, 0.18);
+    color: var(--warning-color);
+}
+
+.model-action-btn.pin-btn.pending {
+    opacity: 0.65;
+}
+
+.model-action-btn.pin-btn:disabled {
+    cursor: default;
+    opacity: 0.35;
+}
+
+.model-action-btn.pin-btn:disabled:hover {
+    background: transparent;
+    color: var(--text-quaternary);
 }
 
 .model-action-btn.delete-btn:hover {

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -40,7 +40,8 @@ public:
                     const ModelInfo& model_info,
                     RecipeOptions options,
                     bool do_not_upgrade = true,
-                    bool allow_reload_on_option_change = false);
+                    bool allow_reload_on_option_change = false,
+                    bool pin_model = false);
 
     // Unload model(s)
     void unload_model(const std::string& model_name = "");  // Empty = unload all
@@ -63,6 +64,9 @@ public:
 
     // Get the recipe options for a loaded model (empty if not loaded)
     RecipeOptions get_model_recipe_options(const std::string& model_name) const;
+
+    // Mark an already-loaded model as pinned or unpinned.
+    void set_model_pinned(const std::string& model_name, bool pinned);
 
     // Get the model type for a loaded model (returns LLM if not found)
     ModelType get_model_type(const std::string& model_name = "") const;
@@ -123,13 +127,14 @@ private:
     WrappedServer* get_most_recent_server() const;
     int count_servers_by_type(ModelType type) const;
     WrappedServer* find_lru_server_by_type(ModelType type) const;
+    bool is_config_pinned(const std::string& canonical_model_name) const;
     bool has_npu_server() const;
     WrappedServer* find_npu_server() const;
     WrappedServer* find_npu_server_by_recipe(const std::string& recipe) const;
     WrappedServer* find_flm_server_by_type(ModelType type) const;
-    void evict_all_npu_servers();
+    void evict_all_npu_servers(bool include_pinned = false);
     void evict_server(WrappedServer* server);
-    void evict_all_servers();
+    void evict_all_servers(bool include_pinned = false);
     std::unique_ptr<WrappedServer> create_backend_server(const ModelInfo& model_info);
     std::string resolve_model_name(const std::string& model_name) const;
     double estimate_gpu_memory_occupancy_gb(const ModelInfo& model_info,

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <shared_mutex>
 #include <functional>
+#include <vector>
 #include <nlohmann/json.hpp>
 
 namespace lemon {
@@ -29,6 +30,7 @@ public:
     bool no_broadcast() const;
     long global_timeout() const;
     int max_loaded_models() const;
+    std::vector<std::string> pinned_models() const;
     double max_gpu_memory_occupancy_gb() const;
     std::string models_dir() const;
     int ctx_size() const;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -10,6 +10,10 @@
 #include <memory>
 #include <atomic>
 #include <chrono>
+#include <map>
+#include <mutex>
+#include <set>
+#include <vector>
 #include <httplib.h>
 #include "runtime_config.h"
 #include "router.h"
@@ -83,6 +87,9 @@ private:
     void handle_responses(const httplib::Request& req, httplib::Response& res);
     void handle_pull(const httplib::Request& req, httplib::Response& res);
     void handle_pull_variants(const httplib::Request& req, httplib::Response& res);
+    void handle_pins(const httplib::Request& req, httplib::Response& res);
+    void handle_pin_model(const httplib::Request& req, httplib::Response& res);
+    void handle_unpin_model(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);
     void handle_unload(const httplib::Request& req, httplib::Response& res);
     void handle_delete(const httplib::Request& req, httplib::Response& res);
@@ -137,6 +144,17 @@ private:
 
     // Warm model list cache in the background after startup dependencies are initialized
     void start_model_cache_warmup();
+    void start_pinned_model_loading();
+    void load_pinned_model(const std::string& model_name);
+    void set_pin_load_error(const std::string& model_name, const std::string& error);
+    std::string get_pin_load_error(const std::string& model_name);
+    void clear_pin_load_error(const std::string& model_name);
+    void mark_model_loading(const std::string& model_name);
+    void clear_model_loading(const std::string& model_name);
+    bool is_model_loading(const std::string& model_name);
+    void persist_config_snapshot();
+    void save_pinned_models(const std::vector<std::string>& pinned_models);
+    bool remove_model_pin(const std::string& model_name);
 
     // Helper function to generate detailed model error responses (not found, not supported, load failure)
     nlohmann::json create_model_error(const std::string& requested_model, const std::string& exception_msg);
@@ -153,6 +171,7 @@ private:
     std::thread http_v4_thread_;
     std::thread http_v6_thread_;
     std::thread model_cache_warmup_thread_;
+    std::thread pinned_model_loading_thread_;
 
 
     std::unique_ptr<httplib::Server> http_server_;
@@ -170,6 +189,10 @@ private:
     std::string api_key_;
     std::string admin_api_key_;
     NetworkBeacon udp_beacon_;
+    std::mutex pin_errors_mutex_;
+    std::map<std::string, std::string> pin_load_errors_;
+    std::mutex loading_models_mutex_;
+    std::set<std::string> loading_models_;
 
     // CPU usage tracking
 #if defined(__linux__) || defined(_WIN32)

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -155,6 +155,7 @@ private:
     void persist_config_snapshot();
     void save_pinned_models(const std::vector<std::string>& pinned_models);
     bool remove_model_pin(const std::string& model_name);
+    bool is_config_model_pinned(const std::string& model_name);
 
     // Helper function to generate detailed model error responses (not found, not supported, load failure)
     nlohmann::json create_model_error(const std::string& requested_model, const std::string& exception_msg);
@@ -191,6 +192,7 @@ private:
     NetworkBeacon udp_beacon_;
     std::mutex pin_errors_mutex_;
     std::map<std::string, std::string> pin_load_errors_;
+    std::mutex pinned_models_mutex_;
     std::mutex loading_models_mutex_;
     std::set<std::string> loading_models_;
 

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -128,6 +128,8 @@ public:
     int get_process_id() const { return process_handle_.pid; }
     double get_gpu_memory_occupancy_gb() const { return gpu_memory_occupancy_gb_.load(); }
     void set_gpu_memory_occupancy_gb(double value) { gpu_memory_occupancy_gb_.store(value); }
+    bool is_pinned() const { return is_pinned_.load(); }
+    void set_pinned(bool pinned) { is_pinned_.store(pinned); }
 
     // Load a model and start the server
     virtual void load(const std::string& model_name,
@@ -212,6 +214,7 @@ protected:
     std::chrono::steady_clock::time_point last_access_time_;
     RecipeOptions recipe_options_;
     std::atomic<double> gpu_memory_occupancy_gb_{0.0};
+    std::atomic<bool> is_pinned_{false};
 
     // Busy state tracking (for safe eviction)
     mutable std::mutex busy_mutex_;

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -6,6 +6,7 @@
   "log_level": "info",
   "global_timeout": 300,
   "max_loaded_models": 1,
+  "pinned_models": [],
   "max_gpu_memory_occupancy_gb": -1.0,
   "no_broadcast": false,
   "extra_models_dir": "",

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -76,7 +76,7 @@ WrappedServer* Router::get_most_recent_server() const {
 int Router::count_servers_by_type(ModelType type) const {
     int count = 0;
     for (const auto& server : loaded_servers_) {
-        if (server->get_model_type() == type) {
+        if (server->get_model_type() == type && !server->is_pinned()) {
             count++;
         }
     }
@@ -87,7 +87,7 @@ WrappedServer* Router::find_lru_server_by_type(ModelType type) const {
     WrappedServer* lru = nullptr;
 
     for (const auto& server : loaded_servers_) {
-        if (server->get_model_type() == type) {
+        if (server->get_model_type() == type && !server->is_pinned()) {
             if (!lru || server->get_last_access_time() < lru->get_last_access_time()) {
                 lru = server.get();
             }
@@ -95,6 +95,12 @@ WrappedServer* Router::find_lru_server_by_type(ModelType type) const {
     }
 
     return lru;
+}
+
+bool Router::is_config_pinned(const std::string& canonical_model_name) const {
+    auto pinned_models = config_->pinned_models();
+    return std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
+        != pinned_models.end();
 }
 
 bool Router::has_npu_server() const {
@@ -138,10 +144,15 @@ WrappedServer* Router::find_flm_server_by_type(ModelType type) const {
 }
 
 // Helper: Evict all NPU servers
-void Router::evict_all_npu_servers() {
+void Router::evict_all_npu_servers(bool include_pinned) {
     std::vector<WrappedServer*> npu_servers;
     for (const auto& server : loaded_servers_) {
         if (server->get_device_type() & DEVICE_NPU) {
+            if (server->is_pinned() && !include_pinned) {
+                throw std::runtime_error(
+                    "Pinned model requires NPU access and cannot be evicted: "
+                    + server->get_model_name());
+            }
             npu_servers.push_back(server.get());
         }
     }
@@ -176,21 +187,29 @@ void Router::evict_server(WrappedServer* server) {
     LOG(INFO, "Router") << "Evicted model: " << model_name << std::endl;
 }
 
-void Router::evict_all_servers() {
+void Router::evict_all_servers(bool include_pinned) {
     LOG(INFO, "Router") << "Evicting all models (" << loaded_servers_.size() << " total)" << std::endl;
 
     // Wait for all servers to finish (with timeout to prevent infinite hang).
     for (const auto& server : loaded_servers_) {
+        if (server->is_pinned() && !include_pinned) continue;
         server->wait_until_not_busy(EVICTION_TIMEOUT);
     }
 
     // Unload all
     for (const auto& server : loaded_servers_) {
-    LOG(INFO, "Router") << "Unloading: " << server->get_model_name() << std::endl;
+        if (server->is_pinned() && !include_pinned) continue;
+        LOG(INFO, "Router") << "Unloading: " << server->get_model_name() << std::endl;
         server->unload();
     }
 
-    loaded_servers_.clear();
+    loaded_servers_.erase(
+        std::remove_if(loaded_servers_.begin(), loaded_servers_.end(),
+                      [include_pinned](const std::unique_ptr<WrappedServer>& server) {
+                          return include_pinned || !server->is_pinned();
+                      }),
+        loaded_servers_.end()
+    );
     LOG(INFO, "Router") << "All models evicted" << std::endl;
 }
 
@@ -274,7 +293,7 @@ double Router::sample_total_gpu_occupancy_gb() const {
 double Router::get_lemonade_gpu_occupancy_gb() const {
     double total = 0.0;
     for (const auto& server : loaded_servers_) {
-        if (is_gpu_resident_server(*server)) {
+        if (!server->is_pinned() && is_gpu_resident_server(*server)) {
             total += std::max(0.0, server->get_gpu_memory_occupancy_gb());
         }
     }
@@ -392,7 +411,7 @@ void Router::enforce_gpu_memory_capacity(const ModelInfo& model_info,
     inputs.candidate_occupancy_gb = estimate_gpu_memory_occupancy_gb(model_info, options);
     for (const auto& server : loaded_servers_) {
         if (server.get() == replacement_server) continue;
-        if (is_gpu_resident_server(*server)) {
+        if (!server->is_pinned() && is_gpu_resident_server(*server)) {
             inputs.residents.push_back({
                 server->get_model_name(),
                 server->get_gpu_memory_occupancy_gb()
@@ -427,9 +446,11 @@ void Router::load_model(const std::string& model_name,
                        const ModelInfo& model_info,
                        RecipeOptions options,
                        bool do_not_upgrade,
-                       bool allow_reload_on_option_change) {
+                       bool allow_reload_on_option_change,
+                       bool pin_model) {
     const std::string canonical_model_name = resolve_model_name(model_name);
     RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options());
+    const bool model_should_be_pinned = pin_model || is_config_pinned(canonical_model_name);
 
     // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
         RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
@@ -468,6 +489,9 @@ void Router::load_model(const std::string& model_name,
                 // Fall through to admission checks before unloading the existing instance.
             } else {
                 LOG(INFO, "Router") << "Model already loaded, updating access time" << std::endl;
+                if (model_should_be_pinned) {
+                    existing->set_pinned(true);
+                }
                 existing->update_access_time();
                 is_loading_ = false;
                 load_cv_.notify_all();
@@ -491,7 +515,7 @@ void Router::load_model(const std::string& model_name,
                 if (has_npu_server()) {
                     LOG(INFO, "Router") << model_info.recipe
                               << " requires exclusive NPU access, evicting all NPU servers..." << std::endl;
-                    evict_all_npu_servers();
+                    evict_all_npu_servers(/*include_pinned=*/model_should_be_pinned);
                 }
             } else if (model_info.recipe == "flm") {
                 // FLM can coexist with other FLM types, but not with exclusive-NPU recipes
@@ -499,6 +523,11 @@ void Router::load_model(const std::string& model_name,
                 for (const std::string& exclusive_recipe : {"ryzenai-llm", "whispercpp"}) {
                     WrappedServer* exclusive_server = find_npu_server_by_recipe(exclusive_recipe);
                     if (exclusive_server) {
+                        if (exclusive_server->is_pinned() && !model_should_be_pinned) {
+                            throw std::runtime_error(
+                                "Pinned model requires NPU access and cannot be evicted: "
+                                + exclusive_server->get_model_name());
+                        }
                         LOG(INFO, "Router") << "FLM cannot coexist with " << exclusive_recipe
                                   << ", evicting: " << exclusive_server->get_model_name() << std::endl;
                         evict_server(exclusive_server);
@@ -507,6 +536,11 @@ void Router::load_model(const std::string& model_name,
                 // 2. Evict FLM of the SAME model type (max 1 per type: 1 LLM, 1 audio, 1 embed)
                 WrappedServer* same_type_flm = find_flm_server_by_type(model_type);
                 if (same_type_flm) {
+                    if (same_type_flm->is_pinned() && !model_should_be_pinned) {
+                        throw std::runtime_error(
+                            "Pinned model requires NPU access and cannot be evicted: "
+                            + same_type_flm->get_model_name());
+                    }
                     LOG(INFO, "Router") << "FLM " << model_type_to_string(model_type)
                               << " slot occupied by: " << same_type_flm->get_model_name()
                               << ", evicting..." << std::endl;
@@ -516,7 +550,7 @@ void Router::load_model(const std::string& model_name,
                 // Unknown NPU recipe - default to exclusive access
                 if (has_npu_server()) {
                     LOG(INFO, "Router") << "Unknown NPU recipe, evicting all NPU servers..." << std::endl;
-                    evict_all_npu_servers();
+                    evict_all_npu_servers(/*include_pinned=*/model_should_be_pinned);
                 }
             }
         }
@@ -549,6 +583,7 @@ void Router::load_model(const std::string& model_name,
 
         // Set model metadata
         new_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+        new_server->set_pinned(model_should_be_pinned);
         new_server->update_access_time();
 
         // CRITICAL: Release lock before slow backend startup
@@ -629,6 +664,7 @@ void Router::load_model(const std::string& model_name,
             // Create new server for retry
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
             retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+            retry_server->set_pinned(model_should_be_pinned);
             retry_server->update_access_time();
             const double retry_gpu_occupancy_before_load = requested_gpu ? sample_total_gpu_occupancy_gb() : -1.0;
 
@@ -686,7 +722,7 @@ void Router::unload_model(const std::string& model_name) {
     if (model_name.empty()) {
         // Unload all models
     LOG(INFO, "Router") << "Unload all models called" << std::endl;
-        evict_all_servers();
+        evict_all_servers(/*include_pinned=*/true);
     } else {
         // Unload specific model
     LOG(INFO, "Router") << "Unload model called: " << model_name << std::endl;
@@ -728,6 +764,7 @@ json Router::get_all_loaded_models() const {
         model_info["backend_url"] = server->get_address();  // For debugging port issues
         model_info["pid"] = server->get_process_id();
         model_info["gpu_memory_occupancy_gb"] = server->get_gpu_memory_occupancy_gb();
+        model_info["pinned"] = server->is_pinned();
         RecipeOptions recipe_options =  server->get_recipe_options();
         model_info["recipe"] = recipe_options.get_recipe();
         model_info["recipe_options"] = recipe_options.to_json();
@@ -771,6 +808,14 @@ RecipeOptions Router::get_model_recipe_options(const std::string& model_name) co
     auto* server = find_server_by_model_name(resolve_model_name(model_name));
     if (server) return server->get_recipe_options();
     return RecipeOptions();
+}
+
+void Router::set_model_pinned(const std::string& model_name, bool pinned) {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    auto* server = find_server_by_model_name(resolve_model_name(model_name));
+    if (server) {
+        server->set_pinned(pinned);
+    }
 }
 
 ModelType Router::get_model_type(const std::string& model_name) const {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -162,6 +162,20 @@ int RuntimeConfig::max_loaded_models() const {
     return config_["max_loaded_models"].get<int>();
 }
 
+std::vector<std::string> RuntimeConfig::pinned_models() const {
+    std::shared_lock lock(mutex_);
+    std::vector<std::string> result;
+    if (!config_.contains("pinned_models") || !config_["pinned_models"].is_array()) {
+        return result;
+    }
+    for (const auto& value : config_["pinned_models"]) {
+        if (value.is_string()) {
+            result.push_back(value.get<std::string>());
+        }
+    }
+    return result;
+}
+
 double RuntimeConfig::max_gpu_memory_occupancy_gb() const {
     std::shared_lock lock(mutex_);
     return config_["max_gpu_memory_occupancy_gb"].get<double>();
@@ -354,6 +368,15 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         if (m < -1 || m == 0) {
             throw std::invalid_argument(
                 "'max_loaded_models' must be -1 (unlimited) or a positive integer");
+        }
+    } else if (key == "pinned_models") {
+        if (!value.is_array()) {
+            throw std::invalid_argument("'pinned_models' must be an array");
+        }
+        for (const auto& item : value) {
+            if (!item.is_string() || item.get<std::string>().empty()) {
+                throw std::invalid_argument("'pinned_models' must contain non-empty strings");
+            }
         }
     } else if (key == "max_gpu_memory_occupancy_gb") {
         if (!value.is_number()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3161,7 +3161,11 @@ void Server::handle_pin_model(const httplib::Request& req, httplib::Response& re
 
         if (!router_->is_model_loaded(model_name) && !is_model_loading(model_name)) {
             res.status = 400;
-            nlohmann::json error = {{"error", "Only currently loaded or loading models can be pinned"}};
+            nlohmann::json error = {{"error", {
+                {"message", "Only currently loaded or loading models can be pinned"},
+                {"type", "invalid_request_error"},
+                {"code", "model_not_loaded_or_loading"}
+            }}};
             res.set_content(error.dump(), "application/json");
             return;
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -610,16 +610,7 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_pins(req, res);
     });
 
-    web_server.Post("/api/v0/pins", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_pin_model(req, res);
-    });
-    web_server.Post("/api/v1/pins", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_pin_model(req, res);
-    });
-    web_server.Post("/v0/pins", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_pin_model(req, res);
-    });
-    web_server.Post("/v1/pins", [this](const httplib::Request& req, httplib::Response& res) {
+    register_post("pins", [this](const httplib::Request& req, httplib::Response& res) {
         handle_pin_model(req, res);
     });
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -12,6 +12,7 @@
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
 #include "lemon/version.h"
+#include <cctype>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -53,6 +54,33 @@ namespace fs = std::filesystem;
 namespace lemon {
 
 namespace {
+
+int hex_value(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+std::string url_decode_path_segment(const std::string& value) {
+    std::string result;
+    result.reserve(value.size());
+
+    for (size_t i = 0; i < value.size(); ++i) {
+        if (value[i] == '%' && i + 2 < value.size()) {
+            int high = hex_value(value[i + 1]);
+            int low = hex_value(value[i + 2]);
+            if (high >= 0 && low >= 0) {
+                result.push_back(static_cast<char>((high << 4) | low));
+                i += 2;
+                continue;
+            }
+        }
+        result.push_back(value[i]);
+    }
+
+    return result;
+}
 
 bool should_disable_thinking(const json& request_json) {
     // enable_thinking takes precedence over thinking when both are present.
@@ -164,6 +192,7 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
         config_->websocket_port());
 
     start_model_cache_warmup();
+    start_pinned_model_loading();
 }
 
 void Server::start_model_cache_warmup() {
@@ -182,6 +211,140 @@ void Server::start_model_cache_warmup() {
             LOG(WARNING, "Server") << "Model list cache warmup failed with unknown error" << std::endl;
         }
     });
+}
+
+void Server::start_pinned_model_loading() {
+    if (pinned_model_loading_thread_.joinable()) {
+        return;
+    }
+
+    auto pinned_models = config_->pinned_models();
+    if (pinned_models.empty()) {
+        return;
+    }
+
+    pinned_model_loading_thread_ = std::thread([this, pinned_models]() {
+        for (const auto& model_name : pinned_models) {
+            if (should_shutdown()) {
+                return;
+            }
+
+            try {
+                load_pinned_model(model_name);
+            } catch (const std::exception& e) {
+                set_pin_load_error(model_name, e.what());
+                LOG(WARNING, "Server") << "Failed to load pinned model '"
+                                       << model_name << "': " << e.what() << std::endl;
+            } catch (...) {
+                set_pin_load_error(model_name, "Unknown error");
+                LOG(WARNING, "Server") << "Failed to load pinned model '"
+                                       << model_name << "' with unknown error" << std::endl;
+            }
+        }
+    });
+}
+
+void Server::load_pinned_model(const std::string& model_name) {
+    if (!model_manager_->model_exists(model_name)) {
+        throw std::runtime_error("Pinned model is not available: " + model_name);
+    }
+
+    auto info = model_manager_->get_model_info(model_name);
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+
+    if (info.recipe == "collection") {
+        throw std::runtime_error("Pinned model cannot be a collection: " + model_name);
+    }
+
+    if (!info.downloaded) {
+        throw std::runtime_error("Pinned model is not downloaded: " + model_name);
+    }
+
+    RecipeOptions options(info.recipe, json::object());
+    router_->load_model(canonical_model_name, info, options, true,
+                        /*allow_reload_on_option_change=*/false,
+                        /*pin_model=*/true);
+    clear_pin_load_error(canonical_model_name);
+}
+
+void Server::set_pin_load_error(const std::string& model_name, const std::string& error) {
+    std::lock_guard<std::mutex> lock(pin_errors_mutex_);
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    pin_load_errors_[canonical_model_name] = error;
+}
+
+std::string Server::get_pin_load_error(const std::string& model_name) {
+    std::lock_guard<std::mutex> lock(pin_errors_mutex_);
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    auto it = pin_load_errors_.find(canonical_model_name);
+    return it != pin_load_errors_.end() ? it->second : "";
+}
+
+void Server::clear_pin_load_error(const std::string& model_name) {
+    std::lock_guard<std::mutex> lock(pin_errors_mutex_);
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    pin_load_errors_.erase(canonical_model_name);
+}
+
+void Server::mark_model_loading(const std::string& model_name) {
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    std::lock_guard<std::mutex> lock(loading_models_mutex_);
+    loading_models_.insert(canonical_model_name);
+}
+
+void Server::clear_model_loading(const std::string& model_name) {
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    std::lock_guard<std::mutex> lock(loading_models_mutex_);
+    loading_models_.erase(canonical_model_name);
+}
+
+bool Server::is_model_loading(const std::string& model_name) {
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    std::lock_guard<std::mutex> lock(loading_models_mutex_);
+    return loading_models_.find(canonical_model_name) != loading_models_.end();
+}
+
+void Server::persist_config_snapshot() {
+    if (cache_dir_.empty()) {
+        return;
+    }
+
+    try {
+        ConfigFile::save(cache_dir_, config_->snapshot());
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Server") << "Failed to persist config.json: " << e.what() << std::endl;
+    }
+}
+
+void Server::save_pinned_models(const std::vector<std::string>& pinned_models) {
+    json pins = json::array();
+    for (const auto& model_name : pinned_models) {
+        pins.push_back(model_name);
+    }
+
+    config_->set({{"pinned_models", pins}}, [this](const json& applied) {
+        apply_config_side_effects(applied);
+    });
+    persist_config_snapshot();
+}
+
+bool Server::remove_model_pin(const std::string& model_name) {
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    auto pinned_models = config_->pinned_models();
+    auto original_size = pinned_models.size();
+
+    pinned_models.erase(
+        std::remove(pinned_models.begin(), pinned_models.end(), canonical_model_name),
+        pinned_models.end());
+
+    if (pinned_models.size() == original_size) {
+        return false;
+    }
+
+    save_pinned_models(pinned_models);
+    router_->set_model_pinned(canonical_model_name, false);
+    clear_pin_load_error(canonical_model_name);
+    return true;
 }
 
 void Server::setup_http_servers() {
@@ -425,6 +588,36 @@ void Server::setup_routes(httplib::Server &web_server) {
 
     register_post("unload", [this](const httplib::Request& req, httplib::Response& res) {
         handle_unload(req, res);
+    });
+
+    register_get("pins", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_pins(req, res);
+    });
+
+    web_server.Post("/api/v0/pins", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_pin_model(req, res);
+    });
+    web_server.Post("/api/v1/pins", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_pin_model(req, res);
+    });
+    web_server.Post("/v0/pins", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_pin_model(req, res);
+    });
+    web_server.Post("/v1/pins", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_pin_model(req, res);
+    });
+
+    web_server.Delete(R"(/api/v0/pins/(.+))", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_unpin_model(req, res);
+    });
+    web_server.Delete(R"(/api/v1/pins/(.+))", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_unpin_model(req, res);
+    });
+    web_server.Delete(R"(/v0/pins/(.+))", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_unpin_model(req, res);
+    });
+    web_server.Delete(R"(/v1/pins/(.+))", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_unpin_model(req, res);
     });
 
     register_post("delete", [this](const httplib::Request& req, httplib::Response& res) {
@@ -1101,12 +1294,15 @@ void Server::stop() {
         http_server_v6_->stop();
         http_server_->stop();
         running_ = false;
-        shutdown_requested_ = false;  // Reset for potential future use
 
         // Stop WebSocket server
         if (websocket_server_) {
             LOG(INFO, "Server") << "Stopping WebSocket server..." << std::endl;
             websocket_server_->stop();
+        }
+
+        if (pinned_model_loading_thread_.joinable()) {
+            pinned_model_loading_thread_.join();
         }
 
         // Explicitly clean up router (unload models, stop backend servers)
@@ -1124,6 +1320,12 @@ void Server::stop() {
     if (model_cache_warmup_thread_.joinable()) {
         model_cache_warmup_thread_.join();
     }
+
+    if (pinned_model_loading_thread_.joinable()) {
+        pinned_model_loading_thread_.join();
+    }
+
+    shutdown_requested_ = false;  // Reset for potential future use
 }
 
 // Generates an actionable error message for model loading failures.
@@ -2893,12 +3095,147 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
     }
 }
 
+void Server::handle_pins(const httplib::Request& req, httplib::Response& res) {
+    (void)req;
+
+    try {
+        json response = {{"data", json::array()}};
+
+        for (const auto& model_name : config_->pinned_models()) {
+            const std::string public_model_name = model_manager_->get_public_model_name(model_name);
+            const std::string load_error = get_pin_load_error(model_name);
+            response["data"].push_back({
+                {"model_name", public_model_name},
+                {"loaded", router_->is_model_loaded(model_name)},
+                {"load_error", load_error.empty() ? json(nullptr) : json(load_error)}
+            });
+        }
+
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_pins: " << e.what() << std::endl;
+        res.status = 500;
+        nlohmann::json error = {{"error", e.what()}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::handle_pin_model(const httplib::Request& req, httplib::Response& res) {
+    try {
+        auto request_json = nlohmann::json::parse(req.body);
+        std::string model_name;
+        if (request_json.contains("model_name") && request_json["model_name"].is_string()) {
+            model_name = request_json["model_name"].get<std::string>();
+        } else if (request_json.contains("model") && request_json["model"].is_string()) {
+            model_name = request_json["model"].get<std::string>();
+        } else {
+            res.status = 400;
+            nlohmann::json error = {{"error", "Missing required string field 'model_name'"}};
+            res.set_content(error.dump(), "application/json");
+            return;
+        }
+
+        if (!model_manager_->model_exists(model_name)) {
+            res.status = 404;
+            auto error_response = create_model_error(model_name, "Model not found");
+            res.set_content(error_response.dump(), "application/json");
+            return;
+        }
+
+        auto info = model_manager_->get_model_info(model_name);
+        if (info.recipe == "collection") {
+            res.status = 400;
+            nlohmann::json error = {{"error", "Collections cannot be pinned. Pin loaded component models instead."}};
+            res.set_content(error.dump(), "application/json");
+            return;
+        }
+
+        if (!router_->is_model_loaded(model_name) && !is_model_loading(model_name)) {
+            res.status = 400;
+            nlohmann::json error = {{"error", "Only currently loaded or loading models can be pinned"}};
+            res.set_content(error.dump(), "application/json");
+            return;
+        }
+
+        const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+        auto pinned_models = config_->pinned_models();
+        if (std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
+            == pinned_models.end()) {
+            pinned_models.push_back(canonical_model_name);
+            save_pinned_models(pinned_models);
+        }
+
+        router_->set_model_pinned(canonical_model_name, true);
+        clear_pin_load_error(canonical_model_name);
+
+        nlohmann::json response = {
+            {"status", "success"},
+            {"model_name", model_manager_->get_public_model_name(canonical_model_name)}
+        };
+        res.set_content(response.dump(), "application/json");
+    } catch (const nlohmann::json::parse_error&) {
+        res.status = 400;
+        nlohmann::json error = {{"error", "Invalid JSON in request body"}};
+        res.set_content(error.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_pin_model: " << e.what() << std::endl;
+        res.status = 500;
+        nlohmann::json error = {{"error", e.what()}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::handle_unpin_model(const httplib::Request& req, httplib::Response& res) {
+    try {
+        std::string model_name = req.matches.size() > 1
+            ? url_decode_path_segment(req.matches[1].str())
+            : "";
+
+        if (model_name.empty()) {
+            res.status = 400;
+            nlohmann::json error = {{"error", "Missing model name"}};
+            res.set_content(error.dump(), "application/json");
+            return;
+        }
+
+        const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+        remove_model_pin(canonical_model_name);
+
+        nlohmann::json response = {
+            {"status", "success"},
+            {"model_name", model_manager_->get_public_model_name(canonical_model_name)}
+        };
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_unpin_model: " << e.what() << std::endl;
+        res.status = 500;
+        nlohmann::json error = {{"error", e.what()}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
 void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
     auto thread_id = std::this_thread::get_id();
     LOG(DEBUG, "Server") << "===== LOAD ENDPOINT ENTERED (Thread: " << thread_id << ") =====" << std::endl;
 
     // Declare model_name outside try block so it's available in catch block
     std::string model_name;
+    std::string loading_model_name;
+    auto finish_loading = [&]() {
+        if (!loading_model_name.empty()) {
+            clear_model_loading(loading_model_name);
+            loading_model_name.clear();
+        }
+    };
+    auto apply_config_pin_if_needed = [this](const std::string& loaded_model_name) {
+        const std::string canonical_model_name = model_manager_->resolve_model_name(loaded_model_name);
+        auto pinned_models = config_->pinned_models();
+        if (std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
+            != pinned_models.end()) {
+            router_->set_model_pinned(canonical_model_name, true);
+            clear_pin_load_error(canonical_model_name);
+        }
+    };
 
     try {
         auto request_json = nlohmann::json::parse(req.body);
@@ -2929,6 +3266,11 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             model_manager_->save_model_options(info);
         }
 
+        if (info.recipe != "collection") {
+            loading_model_name = model_manager_->resolve_model_name(model_name);
+            mark_model_loading(loading_model_name);
+        }
+
         // Download model if needed (first-time use)
         if (!info.downloaded) {
             LOG(INFO, "Server") << "Model not downloaded, downloading..." << std::endl;
@@ -2949,15 +3291,28 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
                     continue;
                 }
                 auto comp_info = model_manager_->get_model_info(component);
+                mark_model_loading(component);
                 if (!comp_info.downloaded) {
-                    LOG(INFO, "Server") << "Downloading component: " << component << std::endl;
-                    model_manager_->download_registered_model(comp_info);
-                    comp_info = model_manager_->get_model_info(component);
+                    try {
+                        LOG(INFO, "Server") << "Downloading component: " << component << std::endl;
+                        model_manager_->download_registered_model(comp_info);
+                        comp_info = model_manager_->get_model_info(component);
+                    } catch (...) {
+                        clear_model_loading(component);
+                        throw;
+                    }
                 }
                 LOG(INFO, "Server") << "Loading component: " << component << std::endl;
                 RecipeOptions comp_options = RecipeOptions(comp_info.recipe, request_json);
-                router_->load_model(component, comp_info, comp_options, true,
-                                    /*allow_reload_on_option_change=*/true);
+                try {
+                    router_->load_model(component, comp_info, comp_options, true,
+                                        /*allow_reload_on_option_change=*/true);
+                    apply_config_pin_if_needed(component);
+                    clear_model_loading(component);
+                } catch (...) {
+                    clear_model_loading(component);
+                    throw;
+                }
             }
 
             nlohmann::json response = {
@@ -2972,6 +3327,8 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             // differ)
             router_->load_model(model_name, info, options, true,
                                 /*allow_reload_on_option_change=*/true);
+            apply_config_pin_if_needed(model_name);
+            finish_loading();
 
             // Return success response
             nlohmann::json response = {
@@ -2984,6 +3341,15 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         }
 
     } catch (const std::exception& e) {
+        finish_loading();
+        if (!model_name.empty()) {
+            const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+            auto pinned_models = config_->pinned_models();
+            if (std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
+                != pinned_models.end()) {
+                set_pin_load_error(canonical_model_name, e.what());
+            }
+        }
         LOG(ERROR, "Server") << "Failed to load model: " << e.what() << std::endl;
 
         // Use consistent error format
@@ -3069,6 +3435,9 @@ void Server::handle_delete(const httplib::Request& req, httplib::Response& res) 
         std::string model_name = request_json.contains("model") ?
             request_json["model"].get<std::string>() :
             request_json["model_name"].get<std::string>();
+        std::string pin_model_name = model_manager_->model_exists(model_name)
+            ? model_manager_->resolve_model_name(model_name)
+            : model_name;
 
         LOG(INFO, "Server") << "Deleting model: " << model_name << std::endl;
 
@@ -3088,6 +3457,7 @@ void Server::handle_delete(const httplib::Request& req, httplib::Response& res) 
         for (int attempt = 0; attempt <= max_retries; ++attempt) {
             try {
                 model_manager_->delete_model(model_name);
+                remove_model_pin(pin_model_name);
 
                 // Success - send response and return
                 nlohmann::json response = {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -228,6 +228,9 @@ void Server::start_pinned_model_loading() {
             if (should_shutdown()) {
                 return;
             }
+            if (!is_config_model_pinned(model_name)) {
+                continue;
+            }
 
             try {
                 load_pinned_model(model_name);
@@ -264,6 +267,10 @@ void Server::load_pinned_model(const std::string& model_name) {
     router_->load_model(canonical_model_name, info, options, true,
                         /*allow_reload_on_option_change=*/false,
                         /*pin_model=*/true);
+    if (!is_config_model_pinned(canonical_model_name)) {
+        router_->set_model_pinned(canonical_model_name, false);
+        return;
+    }
     clear_pin_load_error(canonical_model_name);
 }
 
@@ -330,6 +337,7 @@ void Server::save_pinned_models(const std::vector<std::string>& pinned_models) {
 
 bool Server::remove_model_pin(const std::string& model_name) {
     const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    std::lock_guard<std::mutex> lock(pinned_models_mutex_);
     auto pinned_models = config_->pinned_models();
     auto original_size = pinned_models.size();
 
@@ -345,6 +353,14 @@ bool Server::remove_model_pin(const std::string& model_name) {
     router_->set_model_pinned(canonical_model_name, false);
     clear_pin_load_error(canonical_model_name);
     return true;
+}
+
+bool Server::is_config_model_pinned(const std::string& model_name) {
+    const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
+    std::lock_guard<std::mutex> lock(pinned_models_mutex_);
+    auto pinned_models = config_->pinned_models();
+    return std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
+        != pinned_models.end();
 }
 
 void Server::setup_http_servers() {
@@ -1288,6 +1304,8 @@ bool Server::is_running() const {
 }
 
 void Server::stop() {
+    shutdown_requested_ = true;
+
     if (running_) {
         LOG(INFO, "Server") << "Stopping HTTP server..." << std::endl;
         udp_beacon_.stopBroadcasting();
@@ -3158,14 +3176,16 @@ void Server::handle_pin_model(const httplib::Request& req, httplib::Response& re
         }
 
         const std::string canonical_model_name = model_manager_->resolve_model_name(model_name);
-        auto pinned_models = config_->pinned_models();
-        if (std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
-            == pinned_models.end()) {
-            pinned_models.push_back(canonical_model_name);
-            save_pinned_models(pinned_models);
+        {
+            std::lock_guard<std::mutex> lock(pinned_models_mutex_);
+            auto pinned_models = config_->pinned_models();
+            if (std::find(pinned_models.begin(), pinned_models.end(), canonical_model_name)
+                == pinned_models.end()) {
+                pinned_models.push_back(canonical_model_name);
+                save_pinned_models(pinned_models);
+            }
+            router_->set_model_pinned(canonical_model_name, true);
         }
-
-        router_->set_model_pinned(canonical_model_name, true);
         clear_pin_load_error(canonical_model_name);
 
         nlohmann::json response = {
@@ -3297,7 +3317,16 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
                         LOG(INFO, "Server") << "Downloading component: " << component << std::endl;
                         model_manager_->download_registered_model(comp_info);
                         comp_info = model_manager_->get_model_info(component);
+                    } catch (const std::exception& e) {
+                        if (is_config_model_pinned(component)) {
+                            set_pin_load_error(component, e.what());
+                        }
+                        clear_model_loading(component);
+                        throw;
                     } catch (...) {
+                        if (is_config_model_pinned(component)) {
+                            set_pin_load_error(component, "Unknown error");
+                        }
                         clear_model_loading(component);
                         throw;
                     }
@@ -3309,7 +3338,16 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
                                         /*allow_reload_on_option_change=*/true);
                     apply_config_pin_if_needed(component);
                     clear_model_loading(component);
+                } catch (const std::exception& e) {
+                    if (is_config_model_pinned(component)) {
+                        set_pin_load_error(component, e.what());
+                    }
+                    clear_model_loading(component);
+                    throw;
                 } catch (...) {
+                    if (is_config_model_pinned(component)) {
+                        set_pin_load_error(component, "Unknown error");
+                    }
                     clear_model_loading(component);
                     throw;
                 }

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -21,6 +21,9 @@ Usage:
 """
 
 import platform
+import threading
+import time
+from urllib.parse import quote
 import uuid
 import requests
 from openai import NotFoundError
@@ -101,6 +104,7 @@ class EndpointTests(ServerTestBase):
             "completions",
             "embeddings",
             "models",
+            "pins",
             "responses",
             "pull",
             "delete",
@@ -622,6 +626,137 @@ class EndpointTests(ServerTestBase):
             f"[OK] /load after auto-load was a no-op and kept PID "
             f"{loaded_after['pid']}"
         )
+
+    def test_012d_pin_loaded_model_and_unpin_without_unloading(self):
+        """Pins apply to an already-loaded model and unpinning does not unload it."""
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/pins",
+                json={"model_name": ENDPOINT_TEST_MODEL},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            pins = requests.get(f"{self.base_url}/pins", timeout=TIMEOUT_DEFAULT).json()
+            pin_entry = next(
+                item for item in pins["data"] if item["model_name"] == ENDPOINT_TEST_MODEL
+            )
+            self.assertTrue(pin_entry["loaded"])
+            self.assertIsNone(pin_entry["load_error"])
+
+            loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+            self.assertTrue(loaded["pinned"])
+
+            response = requests.delete(
+                f"{self.base_url}/pins/{quote(ENDPOINT_TEST_MODEL, safe='')}",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            pins = requests.get(f"{self.base_url}/pins", timeout=TIMEOUT_DEFAULT).json()
+            self.assertNotIn(
+                ENDPOINT_TEST_MODEL,
+                {item["model_name"] for item in pins["data"]},
+            )
+
+            loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+            self.assertIsNotNone(loaded)
+            self.assertFalse(loaded["pinned"])
+        finally:
+            requests.delete(
+                f"{self.base_url}/pins/{quote(ENDPOINT_TEST_MODEL, safe='')}",
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+    def test_012e_pin_model_while_loading(self):
+        """POST /pins accepts a model while its /load request is still running."""
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        load_result = {}
+
+        def load_model():
+            load_result["response"] = requests.post(
+                f"{self.base_url}/load",
+                json={"model_name": ENDPOINT_TEST_MODEL, "ctx_size": 3072},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+
+        load_thread = threading.Thread(target=load_model)
+        load_thread.start()
+
+        try:
+            pin_response = None
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                pin_response = requests.post(
+                    f"{self.base_url}/pins",
+                    json={"model_name": ENDPOINT_TEST_MODEL},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                if pin_response.status_code == 200:
+                    break
+                if not load_thread.is_alive():
+                    break
+                time.sleep(0.05)
+
+            load_thread.join(timeout=TIMEOUT_MODEL_OPERATION)
+            self.assertFalse(load_thread.is_alive(), "/load request did not finish")
+            self.assertEqual(load_result["response"].status_code, 200)
+            if pin_response is not None and pin_response.status_code != 200:
+                pin_response = requests.post(
+                    f"{self.base_url}/pins",
+                    json={"model_name": ENDPOINT_TEST_MODEL},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            self.assertIsNotNone(pin_response)
+            self.assertEqual(pin_response.status_code, 200)
+
+            loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+            self.assertTrue(loaded["pinned"])
+        finally:
+            requests.delete(
+                f"{self.base_url}/pins/{quote(ENDPOINT_TEST_MODEL, safe='')}",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            if load_thread.is_alive():
+                load_thread.join(timeout=TIMEOUT_MODEL_OPERATION)
+
+    def test_012f_pin_rejects_idle_unloaded_model(self):
+        """POST /pins rejects models that are neither loaded nor loading."""
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/pins",
+                json={"model_name": ENDPOINT_TEST_MODEL},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 400)
+        finally:
+            requests.delete(
+                f"{self.base_url}/pins/{quote(ENDPOINT_TEST_MODEL, safe='')}",
+                timeout=TIMEOUT_DEFAULT,
+            )
 
     def test_013_unload_specific_model(self):
         """Test unloading a specific model by name."""


### PR DESCRIPTION
## Summary

- Adds server-owned model pins so loaded models can be persisted in `config.json`, loaded best-effort at `lemond` startup, and protected from automatic eviction pressure.
- Adds the active-model UI control for pin/unpin state, including pinning while a model is still loading and surfacing configured pins that are not currently loaded.
- Documents the fork-local model-pin lifecycle and adds endpoint coverage for loaded, loading, and idle-unloaded pin behavior.

## Changes

- **Server API and config**
  - Adds `pinned_models` runtime config plumbing and default config.
  - Adds `GET /pins`, `POST /pins`, and `DELETE /pins/{model_name}` under the standard Lemonade version prefixes.
  - Persists pin/unpin changes through the server config path instead of app-local settings.

- **Router lifecycle**
  - Marks loaded `WrappedServer` instances as pinned.
  - Excludes pinned models from LRU slot counts, GPU eviction candidates, and automatic evict-all cleanup paths.
  - Still allows explicit unloads and NPU pin-to-pin conflict resolution where exclusivity requires it.

- **Renderer UI**
  - Adds a leading pin button to active model rows with visible enabled and pinned states.
  - Refreshes pin state from the server and retries the narrow UI/server race where pin is clicked before `/load` reaches server-side loading state.
  - Shows configured pins that are no longer resident so users can see and unpin them.

- **Docs and tests**
  - Updates `CONTEXT.md` and `docs/agents/architecture-map.md` with model-pin terminology and lifecycle notes.
  - Extends endpoint registration and model-pin behavior tests in `test/server_endpoints.py`.

## Review Path

- Server contract and lifecycle:
  - [`src/cpp/server/server.cpp`](https://github.com/nisavid/lemonade/pull/7/files#diff-69b799dde63dbc74c434ff8c0d4df45824f2f134a059eb42f9cb6b994486d673)
  - [`src/cpp/server/router.cpp`](https://github.com/nisavid/lemonade/pull/7/files#diff-bd6e46c28596fe62518f52a0deb83609aad20f892c9e8f4bc7f02ec8056b2739)
  - [`src/cpp/server/runtime_config.cpp`](https://github.com/nisavid/lemonade/pull/7/files#diff-cd7496d4c6088a1727ade8d3e5929a2fd6730768f7e3414c639e5dab76e0d851)

- Active-model UI behavior:
  - [`src/app/src/renderer/ModelManager.tsx`](https://github.com/nisavid/lemonade/pull/7/files#diff-e96f80b04725d924f933894e5530041a7ff94e7dd044f4a6496202ce4f844f54)
  - [`src/app/styles/styles.css`](https://github.com/nisavid/lemonade/pull/7/files#diff-8403d3e53bf568bfbdf6cf15d78f94fefd5395c01236387fcf91253e9cf2a542)

- Behavior coverage and durable notes:
  - [`test/server_endpoints.py`](https://github.com/nisavid/lemonade/pull/7/files#diff-f33ada49efbb1785b7cc93d15e833ef36c13aebd83d017e0972d3265a723cef9)
  - [`docs/agents/architecture-map.md`](https://github.com/nisavid/lemonade/pull/7/files#diff-2d7e18f1d21753d29624af114998ee13c7779b707acb02ce64167fcde99dee52)
  - [`CONTEXT.md`](https://github.com/nisavid/lemonade/pull/7/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14)

## Verification

- `git diff --check HEAD^ HEAD` passed.
- `python -X pycache_prefix=/tmp/lemonade-pycache -m py_compile test/server_endpoints.py` passed.
- `cmake --build --preset default --target lemond` passed.
- `npm run build:renderer` passed in `src/app`.
- Ralph review ran until clean; Cycle 4 had no findings.

## Current Status

- Local readiness gates passed on head `c2baf6e1dfa890b460189419755148df91f438bf`.
- GitHub CodeQL checks are still in progress at PR publication time.
