### PR TITLE
Polish active model pin states

### DIFF
--- a/docs/agents/architecture-map.md
+++ b/docs/agents/architecture-map.md
@@ -56,6 +56,10 @@ This file captures implementation landmarks that are useful before changing Lemo
 - Do not consolidate `src/app/package.json` and `src/web-app/package.json`; the split supports Debian native packaging with system Node modules.
 - Model pin controls belong at the leading edge of active-model list rows, not in the trailing unload/action button cluster.
 - The active-model UI should surface configured pinned models even when they are not currently loaded, so users can see failed/manual-unloaded pins and unpin them.
+- Keep the active-model section label as "ACTIVE MODELS". Without pins, its count pill reports `N loaded`; with pins, report `N loaded · M pinned`.
+- Active-model row ordering should prioritize current and actionable runtime state: loading rows, pinned rows with load errors, loaded pinned rows, loaded unpinned rows, then pinned-not-loaded rows without errors. Preserve server pin order inside pinned buckets; sort unpinned rows by display name.
+- Avoid visible group headers or separators in the active-model list until normal usage shows the list is too long to scan by row state alone.
+- Pinned-not-loaded rows should use the trailing action slot for `Load`; pinned rows with load errors should use that slot for `Retry`.
 
 ## OmniRouter
 

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1943,7 +1943,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
                           {hasLoadError ? (
                             <RefreshIcon size={13} strokeWidth={2} />
                           ) : (
-                            <PlayIcon size={12} strokeWidth={2} />
+                            <PlayIcon size={12} />
                           )}
                         </button>
                       )}

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1896,7 +1896,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
                   const pinAriaLabel = !pinsAvailable
                     ? `Pins require a newer Lemonade server for ${displayName}`
                     : `${isPinned ? 'Unpin' : 'Pin'} ${displayName}`;
-                  const hasLoadError = Boolean(loadError) && !isLoading;
+                  const hasLoadError = Boolean(loadError) && !isLoading && !isLoaded;
                   const indicatorTitle = isLoading
                     ? 'Loading'
                     : (isLoaded ? 'Loaded' : (hasLoadError ? `Load failed: ${loadError}` : 'Pinned'));

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Boxes, Brain, ChevronRight, Cpu, EjectIcon, Eye, Flame, Layers, ListOrdered, PinIcon, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
+import { Boxes, Brain, ChevronRight, Cpu, EjectIcon, Eye, Flame, Layers, ListOrdered, PinIcon, PlayIcon, RefreshIcon, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
 import { ModelInfo } from './utils/modelData';
 import { ToastContainer, useToast } from './Toast';
 import { useConfirmDialog } from './ConfirmDialog';
@@ -302,6 +302,14 @@ interface PinInfo {
   model_name: string;
   loaded: boolean;
   load_error: string | null;
+}
+
+interface ActiveModelEntry {
+  modelName: string;
+  isLoading: boolean;
+  isLoaded: boolean;
+  isPinned: boolean;
+  loadError: string | null;
 }
 
 interface ServerErrorDetails {
@@ -715,19 +723,36 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
     }
   };
 
-  // Merge loaded and loading models so the list shows components as they
-  // start loading, not just after /health confirms them. Loading entries
-  // get an `isLoading` flag so the UI can render a pending indicator.
-  // Skip collection entries themselves — only show component models.
-  const loadedModelEntries = (() => {
-    const entries: Array<{
-      modelName: string;
-      isLoading: boolean;
-      isLoaded: boolean;
-      isPinned: boolean;
-      loadError: string | null;
-    }> = [];
+  // Merge loaded, loading, and configured pinned models so the active area can
+  // show both current residency and durable lifecycle preferences.
+  const loadedModelEntries = useMemo<ActiveModelEntry[]>(() => {
+    const entries: ActiveModelEntry[] = [];
     const seen = new Set<string>();
+    const pinOrderIndex = new Map(pinnedModelOrder.map((modelName, index) => [modelName, index]));
+    const compareByDisplayName = (a: ActiveModelEntry, b: ActiveModelEntry) =>
+      getModelDisplayName(a.modelName).localeCompare(getModelDisplayName(b.modelName)) ||
+      a.modelName.localeCompare(b.modelName);
+    const getBucket = (entry: ActiveModelEntry): number => {
+      if (entry.isLoading) return 0;
+      if (entry.isPinned && entry.loadError) return 1;
+      if (entry.isLoaded && entry.isPinned) return 2;
+      if (entry.isLoaded) return 3;
+      return 4;
+    };
+    const comparePinnedOrder = (a: ActiveModelEntry, b: ActiveModelEntry) => {
+      if (a.isPinned && b.isPinned) {
+        const pinOrderDiff = (pinOrderIndex.get(a.modelName) ?? Number.MAX_SAFE_INTEGER) -
+          (pinOrderIndex.get(b.modelName) ?? Number.MAX_SAFE_INTEGER);
+        return pinOrderDiff || compareByDisplayName(a, b);
+      }
+      if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+      return compareByDisplayName(a, b);
+    };
+    const compareActiveEntries = (a: ActiveModelEntry, b: ActiveModelEntry) => {
+      const bucketDiff = getBucket(a) - getBucket(b);
+      return bucketDiff || comparePinnedOrder(a, b);
+    };
+
     for (const modelName of loadedModels) {
       if (isCollectionModel(modelsData[modelName])) continue;
       if (seen.has(modelName)) continue;
@@ -752,15 +777,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
         loadError: pinLoadErrors[modelName] ?? null,
       });
     }
-    const activeEntries = entries.sort((a, b) =>
-      getModelDisplayName(a.modelName).localeCompare(getModelDisplayName(b.modelName)) ||
-      a.modelName.localeCompare(b.modelName)
-    );
     for (const modelName of pinnedModelOrder) {
       if (seen.has(modelName)) continue;
       if (isCollectionModel(modelsData[modelName])) continue;
       seen.add(modelName);
-      activeEntries.push({
+      entries.push({
         modelName,
         isLoading: false,
         isLoaded: false,
@@ -768,8 +789,13 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
         loadError: pinLoadErrors[modelName] ?? null,
       });
     }
-    return activeEntries;
-  })();
+    return entries.sort(compareActiveEntries);
+  }, [loadedModels, loadingModels, modelsData, pinnedModelOrder, pinnedModels, pinLoadErrors]);
+  const loadedModelCount = loadedModelEntries.filter(entry => entry.isLoaded).length;
+  const pinnedModelCount = loadedModelEntries.filter(entry => entry.isPinned).length;
+  const activeModelCountText = pinnedModelCount > 0
+    ? `${loadedModelCount} loaded · ${pinnedModelCount} pinned`
+    : `${loadedModelCount} loaded`;
 
 
 
@@ -1852,21 +1878,30 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
             <div className="loaded-model-section widget">
               <div className="loaded-model-header">
                 <div className="loaded-model-label">ACTIVE MODELS</div>
-                <div className="loaded-model-count-pill">
-                  {loadedModelEntries.filter(e => e.isLoaded).length} loaded
+                <div className="loaded-model-count-pill active-model-count-pill">
+                  {activeModelCountText}
                 </div>
               </div>
               {loadedModelEntries.length === 0 && <div className="loaded-model-empty">No models loaded</div>}
               <div className="loaded-model-list">
                 {loadedModelEntries.map(({ modelName, isLoading, isLoaded, isPinned, loadError }) => {
                   const isPinning = pinningModels.has(modelName);
+                  const displayName = getModelDisplayName(modelName);
                   const pinDisabled = !pinsAvailable || isPinning || (!isPinned && !isLoaded && !isLoading);
                   const canPinActiveModel = pinsAvailable && !isPinned && (isLoaded || isLoading);
                   const pinTitle = !pinsAvailable
                     ? 'Pins require a newer Lemonade server'
                     : (isPinned ? 'Unpin model' : 'Pin model');
-                  const indicatorTitle = isLoading ? 'Loading' : (isLoaded ? 'Loaded' : (loadError || 'Pinned'));
-                  const indicatorClassName = `loaded-model-indicator${isLoading ? ' loading' : ''}${!isLoaded && !isLoading ? ' not-loaded' : ''}${loadError ? ' error' : ''}`;
+                  const pinAriaLabel = !pinsAvailable
+                    ? `Pins require a newer Lemonade server for ${displayName}`
+                    : `${isPinned ? 'Unpin' : 'Pin'} ${displayName}`;
+                  const hasLoadError = Boolean(loadError) && !isLoading;
+                  const indicatorTitle = isLoading
+                    ? 'Loading'
+                    : (isLoaded ? 'Loaded' : (hasLoadError ? `Load failed: ${loadError}` : 'Pinned'));
+                  const indicatorClassName = `loaded-model-indicator${isLoading ? ' loading' : ''}${!isLoaded && !isLoading ? ' not-loaded' : ''}${hasLoadError ? ' error' : ''}`;
+                  const showPinnedLoadAction = isPinned && !isLoaded && !isLoading;
+                  const loadActionLabel = `${hasLoadError ? 'Retry' : 'Load'} ${displayName}`;
 
                   return (
                     <div key={modelName} className={`loaded-model-info${isPinned ? ' pinned' : ''}${!isLoaded && !isLoading ? ' pinned-not-loaded' : ''}`}>
@@ -1875,7 +1910,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
                         onClick={() => isPinned ? handleUnpinModel(modelName) : handlePinModel(modelName)}
                         disabled={pinDisabled}
                         title={pinTitle}
-                        aria-label={pinTitle}
+                        aria-label={pinAriaLabel}
                         aria-pressed={isPinned}
                       >
                         <PinIcon />
@@ -1885,11 +1920,30 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
                           className={indicatorClassName}
                           title={indicatorTitle}
                         />
-                        <span className="loaded-model-name" title={modelName}>{getModelDisplayName(modelName)}</span>
+                        <span className="loaded-model-name" title={modelName}>{displayName}</span>
                       </div>
                       {isLoaded && !isLoading && (
-                        <button className="model-action-btn unload-btn active-model-eject-button" onClick={() => handleUnloadModel(modelName)} title="Eject model">
+                        <button
+                          className="model-action-btn unload-btn active-model-eject-button"
+                          onClick={() => handleUnloadModel(modelName)}
+                          title={`Eject ${displayName}`}
+                          aria-label={`Eject ${displayName}`}
+                        >
                           <EjectIcon />
+                        </button>
+                      )}
+                      {showPinnedLoadAction && (
+                        <button
+                          className={`model-action-btn ${hasLoadError ? 'retry-btn' : 'load-btn'} active-model-load-button`}
+                          onClick={() => handleLoadModel(modelName)}
+                          title={loadActionLabel}
+                          aria-label={loadActionLabel}
+                        >
+                          {hasLoadError ? (
+                            <RefreshIcon size={13} strokeWidth={2} />
+                          ) : (
+                            <PlayIcon size={12} strokeWidth={2} />
+                          )}
                         </button>
                       )}
                     </div>
@@ -1904,7 +1958,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
               <div className="available-models-section widget">
                 <div className="available-models-header">
                   <div className="loaded-model-label">SUGGESTED MODELS</div>
-                  <div className="loaded-model-count-pill">{availableModelCount} shown</div>
+                  <div className="loaded-model-count-pill suggested-model-count-pill">{availableModelCount} shown</div>
                 </div>
                 {renderModelsView()}
               </div>

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -734,7 +734,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
       a.modelName.localeCompare(b.modelName);
     const getBucket = (entry: ActiveModelEntry): number => {
       if (entry.isLoading) return 0;
-      if (entry.isPinned && entry.loadError) return 1;
+      if (entry.isPinned && entry.loadError && !entry.isLoaded) return 1;
       if (entry.isLoaded && entry.isPinned) return 2;
       if (entry.isLoaded) return 3;
       return 4;
@@ -757,9 +757,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
       if (isCollectionModel(modelsData[modelName])) continue;
       if (seen.has(modelName)) continue;
       seen.add(modelName);
+      const isCurrentlyLoading = loadingModels.has(modelName);
       entries.push({
         modelName,
-        isLoading: false,
+        isLoading: isCurrentlyLoading,
         isLoaded: true,
         isPinned: pinnedModels.has(modelName),
         loadError: pinLoadErrors[modelName] ?? null,

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -135,15 +135,21 @@ export const PlusIcon: React.FC = () => (
   </svg>
 );
 
-export const RefreshIcon: React.FC = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+export const RefreshIcon: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
     <path
       d="M21 3V8M21 8H16M21 8L18 5.29168C16.4077 3.86656 14.3051 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.2832 21 19.8675 18.008 20.777 14"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth={strokeWidth}
       strokeLinecap="round"
       strokeLinejoin="round"
     />
+  </svg>
+);
+
+export const PlayIcon: React.FC<IconProps> = ({ size = 13, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="6 3 20 12 6 21 6 3" fill="currentColor" />
   </svg>
 );
 

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -147,8 +147,8 @@ export const RefreshIcon: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 })
   </svg>
 );
 
-export const PlayIcon: React.FC<IconProps> = ({ size = 13, strokeWidth = 2 }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+export const PlayIcon: React.FC<Pick<IconProps, 'size'>> = ({ size = 13 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none">
     <polygon points="6 3 20 12 6 21 6 3" fill="currentColor" stroke="none" />
   </svg>
 );

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -149,7 +149,7 @@ export const RefreshIcon: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 })
 
 export const PlayIcon: React.FC<IconProps> = ({ size = 13, strokeWidth = 2 }) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
-    <polygon points="6 3 20 12 6 21 6 3" fill="currentColor" />
+    <polygon points="6 3 20 12 6 21 6 3" fill="currentColor" stroke="none" />
   </svg>
 );
 

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1461,12 +1461,19 @@ footer {
     font-size: 0.57rem;
     color: var(--text-secondary);
     letter-spacing: 0.2px;
-    text-transform: uppercase;
     padding: 2px 6px;
     border-radius: 6px;
     border: 1px solid var(--border-alpha-09);
     background: var(--bg-secondary);
     flex-shrink: 0;
+}
+
+.active-model-count-pill {
+    letter-spacing: 0;
+}
+
+.suggested-model-count-pill {
+    text-transform: uppercase;
 }
 
 .loaded-model-list {
@@ -1959,13 +1966,18 @@ footer {
     color: var(--text-secondary);
     cursor: pointer;
     border-radius: 2px;
-    transition: all 0.15s ease;
+    transition: background-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease, opacity 0.15s ease;
     padding: 0;
 }
 
 .model-action-btn:hover {
     background: var(--bg-alpha-06);
     color: var(--text-tertiary);
+}
+
+.model-action-btn:focus-visible {
+    outline: 2px solid rgba(250, 204, 21, 0.55);
+    outline-offset: 1px;
 }
 
 .model-action-btn.download-btn:hover {
@@ -1984,44 +1996,53 @@ footer {
     color: var(--action-color);
 }
 
+.model-action-btn.retry-btn:hover {
+    color: var(--warning-color);
+}
+
 .model-action-btn.pin-btn {
     background: transparent;
     box-shadow: none;
-    color: var(--text-quaternary);
+    color: var(--text-secondary);
+    opacity: 0.24;
 }
 
 .model-action-btn.pin-btn.pin-available {
-    color: var(--text-secondary);
+    opacity: 0.48;
 }
 
 .model-action-btn.pin-btn.pinned {
-    background: rgba(255, 183, 77, 0.16);
-    box-shadow: inset 0 0 0 1px rgba(255, 183, 77, 0.42);
-    color: var(--warning-color);
+    background: transparent;
+    box-shadow: none;
+    color: var(--text-tertiary);
+    opacity: 0.96;
 }
 
 .model-action-btn.pin-btn:not(.pinned):not(:disabled):hover {
     background: var(--bg-alpha-06);
     color: var(--text-tertiary);
+    opacity: 0.82;
 }
 
 .model-action-btn.pin-btn.pinned:not(:disabled):hover {
-    background: rgba(255, 183, 77, 0.18);
-    color: var(--warning-color);
+    background: var(--bg-alpha-06);
+    color: var(--text-tertiary);
+    opacity: 1;
 }
 
 .model-action-btn.pin-btn.pending {
+    color: var(--text-tertiary);
     opacity: 0.65;
 }
 
 .model-action-btn.pin-btn:disabled {
     cursor: default;
-    opacity: 0.35;
+    opacity: 0.22;
 }
 
 .model-action-btn.pin-btn:disabled:hover {
     background: transparent;
-    color: var(--text-quaternary);
+    color: var(--text-secondary);
 }
 
 .model-action-btn.delete-btn:hover {


### PR DESCRIPTION
## Summary

- Polishes the Active Models pin affordance with opacity-based states that fit the existing Lemonade row-control vocabulary.
- Sorts Active Models rows by runtime/actionability state: loading first, then pinned error rows, loaded pinned rows, loaded unpinned rows, and pinned-but-not-loaded rows.
- Adds row-local `Load`/`Retry` actions for pinned models that are not currently loaded, and documents the grouping policy for future UI work.

## Before/After Review Notes

The pre-fix Impeccable critique found four reviewer-relevant gaps: loaded pinned and unpinned rows were too visually similar, pin buttons used generic accessible names, pinned-but-not-loaded rows had no direct recovery action, and the Active Models section label/count became ambiguous once durable pins appeared alongside loaded runtime state.

The post-fix Impeccable critique/audit came back clean. The updated opacity ladder keeps the pin state quiet but scannable, uses model-specific labels with `aria-pressed`, gives pinned inactive rows a direct `Load` or `Retry` path, and separates runtime residency from preference state with the `N loaded · M pinned` count. The auditor also verified the live preview across loaded and unloaded states and reported `impeccable detect --json` clean for the changed UI surface.

Follow-up review feedback was addressed after opening the PR: the filled play icon now suppresses the inherited SVG stroke, loaded pinned rows no longer sort into the error bucket when a stale load error is present, and rows that are both server-loaded and locally loading keep loading-state precedence.

## Verification

- `git diff --check HEAD`
- `python -X pycache_prefix=/tmp/lemonade-pycache -m py_compile test/server_endpoints.py`
- `cmake --build --preset default --target lemond`
- `cmake -E env npm_config_cache=/tmp/lemonade-npm-cache cmake --build --preset default --target web-app`
- `node --check build/resources/web-app/renderer.bundle.js`
- `npm run build:renderer` from `src/app`

Notes: CMake/npm subprocesses still print inherited shell-function import noise for `ml`/`module`, and webpack still reports the existing bundle-size warnings plus npm audit output. The relevant build commands completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ACTIVE MODELS list now orders by runtime state (loading, errors, loaded, pinned-not-loaded) and hides group headers.
  * Header count pill shows "N loaded · M pinned" when pins exist.

* **Style / UX**
  * Row labels display friendly model names; action buttons use clearer labels (Load, Retry) with updated icons.
  * Improved button hover/focus states, refined count-pill visuals, and clearer keyboard focus accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->