### PR TITLE
Disable upstream publish jobs on fork

### DIFF
--- a/.github/workflows/build-and-push-container.yml
+++ b/.github/workflows/build-and-push-container.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -24,7 +23,11 @@ env:
 
 jobs:
   build-and-push:
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-container:
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
   actions: read  # Required for SignPath to read workflow/job details
 
 env:
@@ -190,7 +190,9 @@ jobs:
     runs-on: windows-latest
     needs: build-lemonade-server-installer
     # Sign on tag pushes (releases) or when manually enabled via workflow_dispatch
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.enable_signing == true
+    if: >-
+      github.repository == 'lemonade-sdk/lemonade' &&
+      (startsWith(github.ref, 'refs/tags/v') || inputs.enable_signing == true)
     steps:
       - name: Sign MSI Installers with SignPath
         id: sign-msi
@@ -1841,7 +1843,9 @@ jobs:
       - test-rpm-package
       - test-embeddable-posix
       - test-embeddable-windows
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' && startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
     env:
       LEMONADE_VERSION: ${{ needs.build-lemonade-rpm.outputs.version }}
     steps:

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   prepare-matrix:
     name: Prepare matrix
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
     runs-on: ubuntu-latest
     outputs:
       package_matrix: ${{ steps.set-matrix.outputs.package_matrix }}
@@ -128,7 +129,10 @@ jobs:
     needs: [prepare-matrix, package]
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+    if: >-
+      github.repository == 'lemonade-sdk/lemonade' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      github.event_name != 'pull_request'
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/stable
@@ -142,7 +146,10 @@ jobs:
     needs: [prepare-matrix, package]
     permissions:
       contents: read
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+    if: >-
+      github.repository == 'lemonade-sdk/lemonade' &&
+      !startsWith(github.ref, 'refs/tags/v') &&
+      github.event_name != 'pull_request'
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/bleeding-edge

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -8,10 +8,16 @@ on:
   repository_dispatch:
     types: [marketplace-updated]
 
+permissions:
+  contents: read
+
 jobs:
     build-n-publish-website:
+      if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
       name: Build and publish lemonade-server.ai website
       runs-on: ubuntu-latest
+      permissions:
+        contents: write
       steps:
         - uses: actions/checkout@v5
           with:

--- a/.github/workflows/test_release_notes.yml
+++ b/.github/workflows/test_release_notes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test-release-notes:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   upload-ppa:
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
     runs-on: ubuntu-24.04
 
     name: Upload to PPA

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -13,8 +13,8 @@ on:
     - cron: "0 16 * * 0"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 env:
   LEMONADE_CI_MODE: "True"
@@ -271,8 +271,12 @@ jobs:
     needs: [get-latest-releases, validate]
     runs-on: ubuntu-latest
     if: >-
+      github.repository == 'lemonade-sdk/lemonade' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.validate.result == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -13,8 +13,8 @@ on:
     - cron: "0 18 * * 0"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 env:
   LEMONADE_CI_MODE: "True"
@@ -192,8 +192,12 @@ jobs:
     needs: [get-latest-releases, validate]
     runs-on: ubuntu-latest
     if: >-
+      github.repository == 'lemonade-sdk/lemonade' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.validate.result == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- gate PPA uploads, container pushes, website publication, MSI signing, and GitHub release creation to lemonade-sdk/lemonade
- gate automated backend update PR creation to lemonade-sdk/lemonade while keeping validation jobs readable in the fork
- reduce broad workflow token write scopes where only publish jobs need them

## Verification
- python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]"
- python -c guard assertion for 11 publish/update jobs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security by restricting automated build and release jobs to the official repository only.
  * Refined GitHub Actions permissions across build, test, and release workflows to follow least-privilege principles, reducing unnecessary write access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->