### PR TITLE
Add zerank selected-logit reranking adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ set(SOURCES_CORE
     src/cpp/server/utils/wmi_helper.cpp
     src/cpp/server/utils/network_beacon.cpp
     src/cpp/server/backends/llamacpp_server.cpp
+    src/cpp/server/backends/llamacpp_reranking_adapter.cpp
     src/cpp/server/backends/fastflowlm_server.cpp
     src/cpp/server/backends/ryzenaiserver.cpp
     src/cpp/server/backends/whisper_server.cpp

--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -36,6 +36,9 @@ export interface LlamaOptions {
   ctxSize: NumericOption;
   llamacppBackend: StringOption;
   llamacppArgs: StringOption;
+  llamacppRerankingAdapter: StringOption;
+  llamacppRerankingTrueTokenId: NumericOption;
+  llamacppRerankingLogitScale: NumericOption;
   mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
@@ -172,6 +175,30 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
     label: 'LlamaCpp Arguments',
     description: 'Custom arguments to pass to llama-server',
   },
+  llamacppRerankingAdapter: {
+    type: 'string',
+    default: '',
+    label: 'Reranking adapter',
+    description: 'Adapter used for llama.cpp reranking models',
+  },
+  llamacppRerankingTrueTokenId: {
+    type: 'numeric',
+    default: -1,
+    min: -1,
+    max: 99999999,
+    step: 1,
+    label: 'Reranking true token ID',
+    description: 'Selected token ID used by logit-score reranking adapters',
+  },
+  llamacppRerankingLogitScale: {
+    type: 'numeric',
+    default: 5.0,
+    min: 0.000001,
+    max: 99999999,
+    step: 0.1,
+    label: 'Reranking logit scale',
+    description: 'Scale applied when converting raw logits to relevance scores',
+  },
 
   // vLLM-specific options
   vllmBackend: {
@@ -271,7 +298,7 @@ export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'ryzenai-llm' | 'sd
  * This mirrors the C++ get_keys_for_recipe() function in recipe_options.cpp
  */
 export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
-  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'mergeArgs', 'saveOptions'],
+  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'llamacppRerankingAdapter', 'llamacppRerankingTrueTokenId', 'llamacppRerankingLogitScale', 'mergeArgs', 'saveOptions'],
   'whispercpp': ['whispercppBackend', 'whispercppArgs', 'mergeArgs', 'saveOptions'],
   'flm': ['ctxSize', 'mergeArgs', 'saveOptions'],
   'ryzenai-llm': ['ctxSize', 'saveOptions'],
@@ -305,6 +332,9 @@ const FRONTEND_TO_API_MAP: Record<string, string> = {
   mergeArgs: 'merge_args',
   llamacppBackend: 'llamacpp_backend',
   llamacppArgs: 'llamacpp_args',
+  llamacppRerankingAdapter: 'llamacpp_reranking_adapter',
+  llamacppRerankingTrueTokenId: 'llamacpp_reranking_true_token_id',
+  llamacppRerankingLogitScale: 'llamacpp_reranking_logit_scale',
   whispercppBackend: 'whispercpp_backend',
   whispercppArgs: 'whispercpp_args',
   sdcppBackend: 'sd-cpp_backend',

--- a/src/cpp/include/lemon/backends/llamacpp_reranking_adapter.h
+++ b/src/cpp/include/lemon/backends/llamacpp_reranking_adapter.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../model_types.h"
+#include "../recipe_options.h"
+#include <functional>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace lemon {
+namespace backends {
+
+constexpr const char* ZEROENTROPY_LOGIT_SCORE_ADAPTER = "zeroentropy-logit-score";
+constexpr int ZEROENTROPY_TRUE_TOKEN_ID = 9454;
+constexpr double ZEROENTROPY_LOGIT_SCALE = 5.0;
+
+bool is_zeroentropy_logit_score_adapter(const RecipeOptions& options);
+bool should_launch_native_llamacpp_reranking(ModelType model_type,
+                                             const RecipeOptions& options);
+
+std::string format_zeroentropy_logit_score_prompt(const std::string& query,
+                                                  const std::string& document);
+
+json build_zeroentropy_logit_score_completion_request(const std::string& query,
+                                                      const std::string& document,
+                                                      int true_token_id);
+
+json rerank_with_zeroentropy_logit_score_adapter(
+    const json& request,
+    int true_token_id,
+    double logit_scale,
+    const std::function<json(const json&)>& completion_request);
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/include/lemon/backends/llamacpp_server.h
+++ b/src/cpp/include/lemon/backends/llamacpp_server.h
@@ -51,6 +51,9 @@ public:
 
     // ITokenizerServer implementation
     json tokenize(const json& request) override;
+
+private:
+    bool uses_zeroentropy_reranking_adapter_ = false;
 };
 
 } // namespace backends

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1109,6 +1109,20 @@
         ],
         "size": 0.0367
     },
+    "zerank-2-GGUF": {
+        "checkpoint": "mradermacher/zerank-2-GGUF:Q8_0",
+        "recipe": "llamacpp",
+        "suggested": false,
+        "labels": [
+            "reranking"
+        ],
+        "recipe_options": {
+            "llamacpp_reranking_adapter": "zeroentropy-logit-score",
+            "llamacpp_reranking_true_token_id": 9454,
+            "llamacpp_reranking_logit_scale": 5.0
+        },
+        "size": 8.1
+    },
     "Devstral-Small-2507-GGUF": {
         "checkpoint": "mistralai/Devstral-Small-2507_gguf:Q4_K_M",
         "recipe": "llamacpp",

--- a/src/cpp/server/backends/llamacpp_reranking_adapter.cpp
+++ b/src/cpp/server/backends/llamacpp_reranking_adapter.cpp
@@ -1,0 +1,163 @@
+#include "lemon/backends/llamacpp_reranking_adapter.h"
+
+#include "lemon/error_types.h"
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+
+namespace {
+
+struct ScoredDocument {
+    int index;
+    double raw_logit;
+    double relevance_score;
+};
+
+double sigmoid(double value) {
+    return 1.0 / (1.0 + std::exp(-value));
+}
+
+json invalid_request(const std::string& message) {
+    return ErrorResponse::create(message, ErrorType::INVALID_REQUEST);
+}
+
+bool parse_selected_token_logit(const json& response,
+                                int true_token_id,
+                                double& raw_logit,
+                                std::string& error_message) {
+    if (response.contains("error")) {
+        error_message = "llama.cpp selected-token-logit request failed";
+        return false;
+    }
+
+    if (!response.contains("token_logits") || !response["token_logits"].is_array()) {
+        error_message = "llama.cpp response is missing token_logits array";
+        return false;
+    }
+
+    for (const auto& item : response["token_logits"]) {
+        if (!item.is_object() || !item.contains("id") || !item["id"].is_number_integer() ||
+            !item.contains("logit") || !item["logit"].is_number()) {
+            error_message = "llama.cpp response has malformed token_logits entries";
+            return false;
+        }
+
+        if (item["id"].get<int>() == true_token_id) {
+            raw_logit = item["logit"].get<double>();
+            if (!std::isfinite(raw_logit)) {
+                error_message = "llama.cpp response returned a non-finite selected-token logit";
+                return false;
+            }
+            return true;
+        }
+    }
+
+    error_message = "llama.cpp response did not include the configured selected token id";
+    return false;
+}
+
+} // namespace
+
+bool is_zeroentropy_logit_score_adapter(const RecipeOptions& options) {
+    json adapter = options.get_option("llamacpp_reranking_adapter");
+    return adapter.is_string() && adapter.get<std::string>() == ZEROENTROPY_LOGIT_SCORE_ADAPTER;
+}
+
+bool should_launch_native_llamacpp_reranking(ModelType model_type,
+                                             const RecipeOptions& options) {
+    return model_type == ModelType::RERANKING && !is_zeroentropy_logit_score_adapter(options);
+}
+
+std::string format_zeroentropy_logit_score_prompt(const std::string& query,
+                                                  const std::string& document) {
+    return "<|im_start|>system\n" + query + "<|im_end|>\n" +
+           "<|im_start|>user\n" + document + "<|im_end|>\n" +
+           "<|im_start|>assistant\n";
+}
+
+json build_zeroentropy_logit_score_completion_request(const std::string& query,
+                                                      const std::string& document,
+                                                      int true_token_id) {
+    return {
+        {"prompt", format_zeroentropy_logit_score_prompt(query, document)},
+        {"n_predict", 1},
+        {"temperature", 0},
+        {"token_logits", json::array({true_token_id})}
+    };
+}
+
+json rerank_with_zeroentropy_logit_score_adapter(
+    const json& request,
+    int true_token_id,
+    double logit_scale,
+    const std::function<json(const json&)>& completion_request) {
+    if (true_token_id < 0) {
+        return invalid_request("ZeroEntropy reranking adapter requires llamacpp_reranking_true_token_id");
+    }
+    if (logit_scale <= 0.0 || !std::isfinite(logit_scale)) {
+        return invalid_request("ZeroEntropy reranking adapter requires a positive finite logit scale");
+    }
+    if (!request.contains("query") || !request["query"].is_string()) {
+        return invalid_request("Reranking request must include a string query");
+    }
+    if (!request.contains("documents") || !request["documents"].is_array()) {
+        return invalid_request("Reranking request must include a documents array");
+    }
+
+    const std::string query = request["query"].get<std::string>();
+    std::vector<ScoredDocument> scored_documents;
+    scored_documents.reserve(request["documents"].size());
+
+    for (size_t i = 0; i < request["documents"].size(); ++i) {
+        const auto& document_json = request["documents"][i];
+        if (!document_json.is_string()) {
+            return invalid_request("Reranking documents must be strings");
+        }
+
+        const std::string document = document_json.get<std::string>();
+        json completion_response = completion_request(
+            build_zeroentropy_logit_score_completion_request(query, document, true_token_id));
+
+        double raw_logit = 0.0;
+        std::string error_message;
+        if (!parse_selected_token_logit(completion_response, true_token_id, raw_logit, error_message)) {
+            json details = {{"document_index", i}};
+            if (completion_response.contains("error")) {
+                details["backend_error"] = completion_response["error"];
+            }
+            return ErrorResponse::create(error_message, ErrorType::BACKEND_ERROR, details);
+        }
+
+        scored_documents.push_back({
+            static_cast<int>(i),
+            raw_logit,
+            sigmoid(raw_logit / logit_scale)
+        });
+    }
+
+    std::stable_sort(scored_documents.begin(), scored_documents.end(),
+        [](const ScoredDocument& lhs, const ScoredDocument& rhs) {
+            return lhs.raw_logit > rhs.raw_logit;
+        });
+
+    json results = json::array();
+    for (const auto& scored : scored_documents) {
+        results.push_back({
+            {"index", scored.index},
+            {"relevance_score", scored.relevance_score}
+        });
+    }
+
+    json response = {{"results", results}};
+    if (request.contains("model")) {
+        response["model"] = request["model"];
+    }
+    return response;
+}
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -1,13 +1,14 @@
-#include "lemon/backends/llamacpp_server.h"
-#include "lemon/backends/backend_utils.h"
 #include "lemon/backend_manager.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/backends/llamacpp_reranking_adapter.h"
+#include "lemon/backends/llamacpp_server.h"
+#include "lemon/error_types.h"
 #include "lemon/runtime_config.h"
+#include "lemon/system_info.h"
 #include "lemon/utils/custom_args.h"
-#include "lemon/utils/process_manager.h"
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/path_utils.h"
-#include "lemon/error_types.h"
-#include "lemon/system_info.h"
+#include "lemon/utils/process_manager.h"
 #include <algorithm>
 #include <cstdlib>
 #include <filesystem>
@@ -215,6 +216,7 @@ void LlamaCppServer::load(const std::string& model_name,
                          const RecipeOptions& options,
                          bool do_not_upgrade) {
     LOG(INFO, "LlamaCpp") << "Loading model: " << model_name << std::endl;
+    uses_zeroentropy_reranking_adapter_ = false;
 
     // Llamacpp Backend logging
     LOG(DEBUG, "LlamaCpp") << "Per-model settings: " << options.to_log_string() << std::endl;
@@ -263,6 +265,8 @@ void LlamaCppServer::load(const std::string& model_name,
     // Check for embeddings and reranking support based on model type
     bool supports_embeddings = (model_info.type == ModelType::EMBEDDING);
     bool supports_reranking = (model_info.type == ModelType::RERANKING);
+    bool uses_reranking_adapter = supports_reranking && is_zeroentropy_logit_score_adapter(options);
+    bool use_native_reranking = should_launch_native_llamacpp_reranking(model_info.type, options);
 
     // For embedding models, use a larger context size to support longer individual
     // strings. Embedding requests can include multiple strings in a batch, and each
@@ -344,9 +348,11 @@ void LlamaCppServer::load(const std::string& model_name,
     push_reserved(reserved_flags, "--embeddings", std::vector<std::string>{"--embedding"});
 
     // Add reranking support if the model supports it
-    if (supports_reranking) {
+    if (use_native_reranking) {
         LOG(INFO, "LlamaCpp") << "Model supports reranking, adding --reranking flag" << std::endl;
         push_arg(args, reserved_flags, "--reranking");
+    } else if (uses_reranking_adapter) {
+        LOG(INFO, "LlamaCpp") << "Model uses ZeroEntropy logit-score reranking adapter; starting llama-server as completion backend" << std::endl;
     }
     push_reserved(reserved_flags, "--reranking", std::vector<std::string>{"--rerank"});
 
@@ -475,10 +481,12 @@ void LlamaCppServer::load(const std::string& model_name,
     }
 
     LOG(DEBUG, "LlamaCpp") << "Model loaded on port " << port_ << std::endl;
+    uses_zeroentropy_reranking_adapter_ = uses_reranking_adapter;
 }
 
 void LlamaCppServer::unload() {
     LOG(INFO, "LlamaCpp") << "Unloading model..." << std::endl;
+    uses_zeroentropy_reranking_adapter_ = false;
 #ifdef _WIN32
     if (process_handle_.handle) {
 #else
@@ -517,6 +525,17 @@ json LlamaCppServer::embeddings(const json& request) {
 }
 
 json LlamaCppServer::reranking(const json& request) {
+    if (uses_zeroentropy_reranking_adapter_) {
+        int true_token_id = recipe_options_.get_option("llamacpp_reranking_true_token_id").get<int>();
+        double logit_scale = recipe_options_.get_option("llamacpp_reranking_logit_scale").get<double>();
+        return rerank_with_zeroentropy_logit_score_adapter(
+            request,
+            true_token_id,
+            logit_scale,
+            [this](const json& completion_request) {
+                return forward_request("/completion", completion_request);
+            });
+    }
     return forward_request("/v1/rerank", request);
 }
 

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -1,5 +1,7 @@
 #include "lemon/hf_variants.h"
 
+#include "lemon/backends/llamacpp_reranking_adapter.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
@@ -292,11 +294,10 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
     // Suggested labels.
     std::vector<std::string> labels;
     if (!vset.mmproj_files.empty()) add_label(labels, "vision");
-    {
-        std::string id_lower = to_lower(checkpoint);
-        if (id_lower.find("embed") != std::string::npos) add_label(labels, "embeddings");
-        if (id_lower.find("rerank") != std::string::npos) add_label(labels, "reranking");
-    }
+    std::string id_lower = to_lower(checkpoint);
+    if (id_lower.find("embed") != std::string::npos) add_label(labels, "embeddings");
+    if (id_lower.find("rerank") != std::string::npos) add_label(labels, "reranking");
+    if (id_lower.find("zerank-2") != std::string::npos) add_label(labels, "reranking");
 
     nlohmann::json out;
     out["checkpoint"] = checkpoint;
@@ -305,6 +306,13 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
     out["suggested_name"] = suggested_name;
     out["suggested_labels"] = labels;
     out["mmproj_files"] = vset.mmproj_files;
+    if (id_lower.find("zerank-2") != std::string::npos) {
+        out["recipe_options"] = {
+            {"llamacpp_reranking_adapter", backends::ZEROENTROPY_LOGIT_SCORE_ADAPTER},
+            {"llamacpp_reranking_true_token_id", backends::ZEROENTROPY_TRUE_TOKEN_ID},
+            {"llamacpp_reranking_logit_scale", backends::ZEROENTROPY_LOGIT_SCALE}
+        };
+    }
 
     nlohmann::json variants_json = nlohmann::json::array();
     for (const auto& v : vset.variants) {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1,4 +1,5 @@
 #include <lemon/model_manager.h>
+#include <lemon/backends/llamacpp_reranking_adapter.h>
 #include <lemon/gguf_metadata.h>
 #include <lemon/gpu_memory_planner.h>
 #include <lemon/runtime_config.h>
@@ -54,7 +55,7 @@ static constexpr auto safe_dir_options = fs::directory_options::none;
 namespace lemon {
 
 // Properties which are defined by the user for model registration.
-static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components"};
+static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options"};
 
 // Helper functions for string operations
 static std::string to_lower(const std::string& str) {
@@ -81,11 +82,72 @@ static bool contains_ignore_case(const std::string& str, const std::string& subs
     return to_lower(str).find(to_lower(substr)) != std::string::npos;
 }
 
+static bool is_zerank_2_model_id(const std::string& value) {
+    return contains_ignore_case(value, "zerank-2");
+}
+
+static json zeroentropy_logit_score_recipe_options() {
+    // 9454 is the "True" token in the zerank-2 tokenizer. A 5.0 scale keeps
+    // returned scores in a useful sigmoid range while preserving raw-logit rank.
+    return {
+        {"llamacpp_reranking_adapter", backends::ZEROENTROPY_LOGIT_SCORE_ADAPTER},
+        {"llamacpp_reranking_true_token_id", backends::ZEROENTROPY_TRUE_TOKEN_ID},
+        {"llamacpp_reranking_logit_scale", backends::ZEROENTROPY_LOGIT_SCALE}
+    };
+}
+
+static void merge_zeroentropy_logit_score_recipe_options(json& recipe_options) {
+    if (!recipe_options.is_object()) {
+        recipe_options = json::object();
+    }
+    json defaults = zeroentropy_logit_score_recipe_options();
+    for (auto& [key, value] : defaults.items()) {
+        if (!recipe_options.contains(key)) {
+            recipe_options[key] = value;
+        }
+    }
+}
+
 static constexpr const char USER_MODEL_PREFIX[] = "user.";
 static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
 
 static bool has_label(const ModelInfo& info, const std::string& label) {
     return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
+}
+
+static bool is_zerank_2_model_info(const ModelInfo& info) {
+    if (info.recipe != "llamacpp") {
+        return false;
+    }
+    std::string main_path = info.resolved_path("main");
+    return is_zerank_2_model_id(info.model_name) ||
+           is_zerank_2_model_id(info.checkpoint()) ||
+           is_zerank_2_model_id(main_path) ||
+           (!main_path.empty() && is_zerank_2_model_id(fs::path(main_path).filename().string()));
+}
+
+static void normalize_zerank_2_labels(ModelInfo& info) {
+    if (!is_zerank_2_model_info(info)) {
+        return;
+    }
+
+    static const std::set<std::string> chat_labels = {
+        "chat-transcription",
+        "reasoning",
+        "tool-calling",
+        "tools",
+        "vision"
+    };
+    info.labels.erase(
+        std::remove_if(info.labels.begin(), info.labels.end(),
+                       [](const std::string& label) {
+                           return chat_labels.find(label) != chat_labels.end();
+                       }),
+        info.labels.end());
+
+    if (!has_label(info, "reranking")) {
+        info.labels.push_back("reranking");
+    }
 }
 
 // Built-ins are keyed bare in models_cache_; user.* and extra.* keys already
@@ -872,7 +934,11 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         ModelInfo info = init_extra_model_info(model_name);
         info.checkpoints["main"] = gguf_path.string();
         info.resolved_paths["main"] = gguf_path.string();
-        info.type = ModelType::LLM;
+        if (is_zerank_2_model_id(filename)) {
+            info.labels.push_back("reranking");
+        }
+        normalize_zerank_2_labels(info);
+        info.type = get_model_type_from_labels(info.labels);
 
         // Calculate size in GB
         try {
@@ -928,6 +994,9 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         info.checkpoints["main"] = dir_path;
         info.resolved_paths["main"] = main_model_path.string();
         info.size = total_size;
+        if (is_zerank_2_model_id(dir_name) || is_zerank_2_model_id(main_model_path.filename().string())) {
+            info.labels.push_back("reranking");
+        }
 
         // If mmproj found, set it and add vision label
         if (!mmproj_file.empty()) {
@@ -936,6 +1005,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
             info.labels.push_back("vision");
         }
 
+        normalize_zerank_2_labels(info);
         info.type = get_model_type_from_labels(info.labels);
 
         discovered[model_name] = info;
@@ -1352,6 +1422,7 @@ void ModelManager::build_cache() {
         }
 
         // Populate type and device fields (multi-model support)
+        normalize_zerank_2_labels(info);
         info.type = get_model_type_from_labels(info.labels);
         info.device = get_device_type_from_recipe(info.recipe);
 
@@ -1391,6 +1462,7 @@ void ModelManager::build_cache() {
         }
 
         // Populate type and device fields (multi-model support)
+        normalize_zerank_2_labels(info);
         info.type = get_model_type_from_labels(info.labels);
         info.device = get_device_type_from_recipe(info.recipe);
 
@@ -1434,6 +1506,9 @@ void ModelManager::build_cache() {
     // we translate before lookup.
     for (auto& [name, info] : all_models) {
         json jro = json_recipe_options.count(name) ? json_recipe_options[name] : json(nullptr);
+        if (is_zerank_2_model_info(info)) {
+            merge_zeroentropy_logit_score_recipe_options(jro);
+        }
         info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(name), recipe_options_);
     }
 
@@ -1557,7 +1632,6 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     parse_image_defaults(info, *model_json);
     json jro = (model_json->contains("recipe_options") && (*model_json)["recipe_options"].is_object())
         ? (*model_json)["recipe_options"] : json(nullptr);
-    info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(model_name), recipe_options_);
 
     info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", is_user_model);
     info.hf_load = JsonUtils::get_or_default<bool>(*model_json, "hf_load", false);
@@ -1570,10 +1644,14 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     }
 
     // Populate type and device fields (multi-model support)
+    resolve_all_model_paths(info);
+    normalize_zerank_2_labels(info);
+    if (is_zerank_2_model_info(info)) {
+        merge_zeroentropy_logit_score_recipe_options(jro);
+    }
+    info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(model_name), recipe_options_);
     info.type = get_model_type_from_labels(info.labels);
     info.device = get_device_type_from_recipe(info.recipe);
-
-    resolve_all_model_paths(info);
 
     // Check if it should be filtered out by backend availability
     std::map<std::string, ModelInfo> temp_map = {{model_name, info}};
@@ -2021,6 +2099,20 @@ void ModelManager::register_user_model(const std::string& model_name,
     }
     if (model_data.value("reranking", false)) {
         labels.insert("reranking");
+    }
+
+    std::string checkpoint = model_data.value("checkpoint", clean_name);
+    if (is_zerank_2_model_id(checkpoint) || is_zerank_2_model_id(clean_name)) {
+        labels.insert("reranking");
+        labels.erase("chat-transcription");
+        labels.erase("reasoning");
+        labels.erase("tool-calling");
+        labels.erase("tools");
+        labels.erase("vision");
+        json merged_recipe_options = model_entry.contains("recipe_options")
+            ? model_entry["recipe_options"] : json(nullptr);
+        merge_zeroentropy_logit_score_recipe_options(merged_recipe_options);
+        model_entry["recipe_options"] = std::move(merged_recipe_options);
     }
 
     // `recipe` already copied into `model_entry` by the USER_DEFINED_MODEL_PROPS

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -18,6 +18,9 @@ static const json DEFAULTS = {
     {"llamacpp_device", ""},
     {"llamacpp_backend", ""},  // Will be overridden dynamically
     {"llamacpp_args", ""},
+    {"llamacpp_reranking_adapter", ""},
+    {"llamacpp_reranking_true_token_id", -1},
+    {"llamacpp_reranking_logit_scale", 5.0},
     {"sd-cpp_backend", ""},   // "" means auto-detect (mapped from "auto" in config.json)
     {"sdcpp_args", ""},
     {"whispercpp_backend", ""},  // "" means auto-detect (mapped from "auto" in config.json)
@@ -59,7 +62,14 @@ static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
 
 static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     if (recipe == "llamacpp") {
-        return {"ctx_size", "llamacpp_device", "llamacpp_backend", "llamacpp_args", "merge_args"};
+        return {"ctx_size",
+                "llamacpp_device",
+                "llamacpp_backend",
+                "llamacpp_args",
+                "llamacpp_reranking_adapter",
+                "llamacpp_reranking_true_token_id",
+                "llamacpp_reranking_logit_scale",
+                "merge_args"};
     } else if (recipe == "whispercpp") {
         return {"whispercpp_backend", "whispercpp_args", "merge_args"};
     } else if (recipe == "flm") {

--- a/test/cpp/test_llamacpp_reranking_adapter.cpp
+++ b/test/cpp/test_llamacpp_reranking_adapter.cpp
@@ -1,0 +1,205 @@
+// Standalone test for Lemonade's llama.cpp reranking adapter.
+// Compile with:
+//   g++ -std=c++17 -I src/cpp/include \
+//       test/cpp/test_llamacpp_reranking_adapter.cpp \
+//       src/cpp/server/backends/llamacpp_reranking_adapter.cpp \
+//       src/cpp/server/recipe_options.cpp \
+//       -o /tmp/test_llamacpp_reranking_adapter
+
+#include "lemon/backends/llamacpp_reranking_adapter.h"
+#include "lemon/system_info.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace lemon {
+
+SystemInfo::SupportedBackendsResult SystemInfo::get_supported_backends(const std::string&) {
+    return {};
+}
+
+} // namespace lemon
+
+using lemon::RecipeOptions;
+using lemon::json;
+using lemon::ModelType;
+using lemon::backends::build_zeroentropy_logit_score_completion_request;
+using lemon::backends::format_zeroentropy_logit_score_prompt;
+using lemon::backends::rerank_with_zeroentropy_logit_score_adapter;
+using lemon::backends::should_launch_native_llamacpp_reranking;
+
+int main() {
+    int failures = 0;
+    auto expect_eq = [&failures](const std::string& actual,
+                                 const std::string& expected,
+                                 const char* name) {
+        const bool ok = actual == expected;
+        std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+        if (!ok) {
+            std::printf("  got:\n%s\n want:\n%s\n", actual.c_str(), expected.c_str());
+            ++failures;
+        }
+    };
+    auto expect_true = [&failures](bool condition, const char* name) {
+        std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+        if (!condition) ++failures;
+    };
+    auto expect_close = [&failures](double actual, double expected, const char* name) {
+        const bool ok = std::fabs(actual - expected) < 1e-9;
+        std::printf("[%s] %s  (got=%.12f, want=%.12f)\n",
+                    ok ? "PASS" : "FAIL", name, actual, expected);
+        if (!ok) ++failures;
+    };
+
+    expect_eq(
+        format_zeroentropy_logit_score_prompt("capital of France", "Paris is the capital of France."),
+        "<|im_start|>system\n"
+        "capital of France<|im_end|>\n"
+        "<|im_start|>user\n"
+        "Paris is the capital of France.<|im_end|>\n"
+        "<|im_start|>assistant\n",
+        "formats ZeroEntropy reranking prompt");
+
+    {
+        RecipeOptions options("llamacpp", {
+            {"llamacpp_reranking_adapter", "zeroentropy-logit-score"},
+            {"llamacpp_reranking_true_token_id", 9454},
+            {"llamacpp_reranking_logit_scale", 5.0}
+        });
+        json preserved = options.to_json();
+        expect_true(preserved.contains("llamacpp_reranking_adapter"),
+                    "preserves adapter option for llamacpp recipes");
+        expect_true(preserved.contains("llamacpp_reranking_true_token_id"),
+                    "preserves selected token id option for llamacpp recipes");
+        expect_true(preserved.contains("llamacpp_reranking_logit_scale"),
+                    "preserves logit scale option for llamacpp recipes");
+        expect_true(!should_launch_native_llamacpp_reranking(ModelType::RERANKING, options),
+                    "adapter-backed rerankers do not launch native llama.cpp reranking");
+    }
+
+    {
+        RecipeOptions options("llamacpp", {});
+        expect_true(should_launch_native_llamacpp_reranking(ModelType::RERANKING, options),
+                    "plain llama.cpp rerankers still launch native reranking");
+    }
+
+    {
+        json completion_request = build_zeroentropy_logit_score_completion_request(
+            "capital of France", "Paris is the capital of France.", 9454);
+        expect_true(completion_request["prompt"].is_string(), "completion request has prompt");
+        expect_true(completion_request["n_predict"] == 1, "completion request predicts one token");
+        expect_true(completion_request["temperature"] == 0, "completion request is deterministic");
+        expect_true(completion_request["token_logits"] == json::array({9454}),
+                    "completion request asks for selected token logit");
+    }
+
+    {
+        json request = {
+            {"model", "zerank"},
+            {"query", "capital of France"},
+            {"documents", json::array({
+                "Berlin is the capital of Germany.",
+                "Paris is the capital of France.",
+                "A baguette is bread."
+            })}
+        };
+        std::vector<double> logits = {2.0, 17.0, -1.0};
+        size_t calls = 0;
+        json response = rerank_with_zeroentropy_logit_score_adapter(
+            request, 9454, 5.0, [&logits, &calls](const json&) {
+                if (calls >= logits.size()) {
+                    return json{{"error", {{"message", "unexpected completion call count"}}}};
+                }
+                return json{{"token_logits", json::array({
+                    {{"id", 9454}, {"token", "Yes"}, {"logit", logits[calls++]}}
+                })}};
+            });
+        expect_true(!response.contains("error"), "mocked adapter reranking succeeds");
+        const bool has_valid_results =
+            response.contains("results") &&
+            response["results"].is_array() &&
+            response["results"].size() == 3;
+        expect_true(has_valid_results, "returns one result per document");
+        if (has_valid_results) {
+            expect_true(response["results"][0]["index"] == 1,
+                        "sorts Paris sanity document first by raw logit");
+            expect_true(response["results"][1]["index"] == 0,
+                        "sorts second document by raw logit");
+            expect_true(response["results"][2]["index"] == 2,
+                        "sorts last document by raw logit");
+            expect_close(response["results"][0]["relevance_score"].get<double>(),
+                         1.0 / (1.0 + std::exp(-(17.0 / 5.0))),
+                         "normalizes public score with sigmoid(logit / scale)");
+        }
+    }
+
+    {
+        json request = {
+            {"query", "capital of France"},
+            {"documents", json::array({"Paris is the capital of France."})}
+        };
+        bool completion_called = false;
+        json response = rerank_with_zeroentropy_logit_score_adapter(
+            request, -1, 5.0, [&completion_called](const json&) {
+                completion_called = true;
+                return json::object();
+            });
+        expect_true(response.contains("error"), "negative selected token id returns error");
+        expect_true(!completion_called, "negative selected token id does not call backend");
+    }
+
+    {
+        json request = {
+            {"query", "capital of France"},
+            {"documents", json::array({"Paris is the capital of France."})}
+        };
+        bool completion_called = false;
+        json response = rerank_with_zeroentropy_logit_score_adapter(
+            request, 9454, 0.0, [&completion_called](const json&) {
+                completion_called = true;
+                return json::object();
+            });
+        expect_true(response.contains("error"), "nonpositive logit scale returns error");
+        expect_true(!completion_called, "nonpositive logit scale does not call backend");
+    }
+
+    {
+        json request = {
+            {"query", "capital of France"},
+            {"documents", json::array({"Paris is the capital of France."})}
+        };
+        json response = rerank_with_zeroentropy_logit_score_adapter(
+            request, 9454, 5.0, [](const json&) {
+                return json{{"token_logits", json::array({{{"id", 1}, {"logit", 0.0}}})}};
+            });
+        expect_true(response.contains("error"), "missing selected token returns error");
+    }
+
+    {
+        json request = {
+            {"query", "capital of France"},
+            {"documents", json::array({"Paris is the capital of France."})}
+        };
+        json response = rerank_with_zeroentropy_logit_score_adapter(
+            request, 9454, 5.0, [](const json&) {
+                return json{{"token_logits", "not an array"}};
+            });
+        expect_true(response.contains("error"), "malformed token_logits returns error");
+    }
+
+    {
+        json request = {
+            {"query", "capital of France"},
+            {"documents", json::array({"Paris is the capital of France."})}
+        };
+        json response = rerank_with_zeroentropy_logit_score_adapter(
+            request, 9454, 5.0, [](const json&) {
+                return json{{"error", {{"message", "backend failed"}}}};
+            });
+        expect_true(response.contains("error"), "backend error returns Lemonade error");
+    }
+
+    return failures == 0 ? 0 : 1;
+}

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -670,6 +670,46 @@ class LLMTests(ServerTestBase):
             f"Expected food-related documents {expected_top_3} in top 3, got {actual_top_3}",
         )
 
+    @skip_if_unsupported("reranking")
+    def test_019_zeroentropy_zerank_adapter_reranking(self):
+        """Test zerank-2 reranking through Lemonade's selected-logit adapter."""
+        if os.environ.get("LEMONADE_TEST_ZERANK_ADAPTER") != "1":
+            self.skipTest(
+                "Set LEMONADE_TEST_ZERANK_ADAPTER=1 for live zerank-2 adapter validation"
+            )
+
+        model = os.environ.get("LEMONADE_TEST_ZERANK_MODEL", "zerank-2-GGUF")
+        documents = [
+            "Berlin is the capital of Germany.",
+            "Paris is the capital of France.",
+            "A baguette is bread.",
+        ]
+
+        response = requests.post(
+            f"{self.base_url}/reranking",
+            json={
+                "query": "capital of France",
+                "documents": documents,
+                "model": model,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        self.assertNotIn("error", result)
+        results = result.get("results", [])
+        self.assertEqual(len(results), len(documents))
+        self.assertEqual(
+            results[0]["index"],
+            1,
+            f"Expected Paris document to rank first, got {results}",
+        )
+        self.assertTrue(
+            all(0 < r.get("relevance_score", 0) <= 1 for r in results),
+            f"Expected normalized scores in (0, 1], got {results}",
+        )
+
     # =========================================================================
     # MULTI-MODEL TESTS
     # =========================================================================


### PR DESCRIPTION
## Summary

Adds a Lemonade-side reranking adapter for ZeroEntropy's `zerank-2` GGUF model now that the installed `llama.cpp` packages expose selected-token logits on `/completion`.

The adapter builds the ZeroEntropy prompt, requests a single-token completion with `token_logits` for the configured true-token id, ranks documents by the returned raw logit, and returns OpenAI-compatible reranking results with normalized relevance scores.

## Changes

- Add `zeroentropy-logit-score` llama.cpp reranking adapter support.
- Register built-in `zerank-2-GGUF` with `mradermacher/zerank-2-GGUF:Q8_0`.
- Auto-detect imported `zerank-2` llama.cpp models as reranking models and preserve the needed recipe options.
- Normalize stale saved `zerank-2` labels so existing user entries route as reranking rather than chat models.
- Add focused C++ adapter coverage and an opt-in live server test for the installed-package path.

## Verification

- `cmake --build --preset default --target lemond`
- `g++ -std=c++17 -I src/cpp/include test/cpp/test_llamacpp_reranking_adapter.cpp src/cpp/server/backends/llamacpp_reranking_adapter.cpp src/cpp/server/recipe_options.cpp -o /tmp/test_llamacpp_reranking_adapter && /tmp/test_llamacpp_reranking_adapter`
- `python -X pycache_prefix=/tmp/lemonade-pycache -m py_compile test/server_llm.py`
- `python -m json.tool src/cpp/resources/server_models.json`
- `git diff --check`
- Installed-package live smoke using `llama.cpp-vulkan-gfx1151 b9222-3`:
  - server: `build/lemond /tmp/lemonade-zerank-installed-vulkan --port 18082 --host 127.0.0.1`
  - request: `/api/v1/reranking` with query `capital of France`
  - result ranked the Paris document first: `index: 1`, score about `0.96765`
- Opt-in live test passed against the same server:
  - `LEMONADE_TEST_ZERANK_ADAPTER=1 LEMONADE_TEST_ZERANK_MODEL=zerank-2-GGUF`

## Notes

Depends on the merged/installed `llama.cpp` selected-logits package work:

- `llama.cpp-vulkan-gfx1151 b9222-3`
- `llama.cpp-hip-gfx1151 b9222-3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZeroEntropy logit-score reranking adapter for document relevance ranking and UI settings to configure adapter, token ID, and logit scale
  * Registered a zerank-2 reranking model variant with default recipe options and automatic detection in model discovery/registration
  * Reranking endpoint updated to route adapter-mode requests while preserving native reranking behavior

* **Tests**
  * Added unit and end-to-end tests covering adapter logic, scoring, sorting, and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->