### PR TITLE
Fix CodeQL archive extraction command injection alerts

### DIFF
--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -38,15 +38,25 @@ namespace lemon::backends {
     static int run_archive_process(const std::string& executable,
                                    const std::vector<std::string>& args,
                                    std::string& output) {
+        constexpr size_t max_output_size = 8192;
+        const std::string truncated_suffix = "... (output truncated)\n";
+        bool output_truncated = false;
+
         output.clear();
         try {
             return lemon::utils::ProcessManager::run_process_with_output(
                 executable,
                 args,
                 [&](const std::string& line) {
-                    if (output.size() < 8192) {
-                        output += line;
-                        output += '\n';
+                    const std::string next_line = line + '\n';
+                    if (output.size() + next_line.size() <= max_output_size) {
+                        output += next_line;
+                    } else if (!output_truncated) {
+                        if (output.size() > max_output_size - truncated_suffix.size()) {
+                            output.resize(max_output_size - truncated_suffix.size());
+                        }
+                        output += truncated_suffix;
+                        output_truncated = true;
                     }
                     return true;
                 });
@@ -122,7 +132,7 @@ namespace lemon::backends {
                 LOG(ERROR, backend_name) << "Extraction failed. Ensure 'unzip' is installed. Code: " << result << std::endl;
             #endif
             if (!output.empty()) {
-                LOG(ERROR, backend_name) << output;
+                LOG(ERROR, backend_name) << output << std::endl;
             }
             return false;
         }
@@ -150,7 +160,7 @@ namespace lemon::backends {
         if (result != 0) {
             LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
             if (!output.empty()) {
-                LOG(ERROR, backend_name) << output;
+                LOG(ERROR, backend_name) << output << std::endl;
             }
             return false;
         }

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -16,6 +16,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -33,6 +34,27 @@
 using json = nlohmann::json;
 
 namespace lemon::backends {
+
+    static int run_archive_process(const std::string& executable,
+                                   const std::vector<std::string>& args,
+                                   std::string& output) {
+        output.clear();
+        try {
+            return lemon::utils::ProcessManager::run_process_with_output(
+                executable,
+                args,
+                [&](const std::string& line) {
+                    if (output.size() < 8192) {
+                        output += line;
+                        output += '\n';
+                    }
+                    return true;
+                });
+        } catch (const std::exception& e) {
+            output = e.what();
+            return -1;
+        }
+    }
 
     const BackendSpec* try_get_spec_for_recipe(const std::string& recipe) {
         if (recipe == "llamacpp") return &LlamaCppServer::SPEC;
@@ -60,19 +82,20 @@ namespace lemon::backends {
 
     static bool is_native_tar_available() {
         std::string tar_path = get_native_tar_path();
-        std::string command = tar_path + " --version >nul 2>&1";
         std::string unused;
-        return lemon::utils::ProcessManager::run_command(command, unused) == 0;
+        return run_archive_process(tar_path, {"--version"}, unused) == 0;
     }
 #endif
 
     bool BackendUtils::extract_zip(const std::string& zip_path, const std::string& dest_dir, const std::string& backend_name) {
-        std::string command;
+        std::string executable;
+        std::vector<std::string> args;
         fs::create_directories(dest_dir);
 #ifdef _WIN32
         if (is_native_tar_available()) {
             LOG(DEBUG, backend_name) << "Extracting ZIP with native tar to " << dest_dir << std::endl;
-            command = get_native_tar_path() + " -xf \"" + zip_path + "\" -C \"" + dest_dir + "\"";
+            executable = get_native_tar_path();
+            args = {"-xf", zip_path, "-C", dest_dir};
         } else {
             LOG(DEBUG, backend_name) << "Extracting ZIP via PowerShell to " << dest_dir << std::endl;
             std::string powershell_path = "powershell";
@@ -80,27 +103,35 @@ namespace lemon::backends {
             if (system_root) {
                 powershell_path = std::string(system_root) + "\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
             }
-            command = powershell_path + " -Command \"Expand-Archive -Path '" + zip_path +
-                    "' -DestinationPath '" + dest_dir + "' -Force\"";
+            executable = powershell_path;
+            args = {"-NoProfile", "-NonInteractive", "-Command",
+                    "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+                    zip_path, dest_dir};
         }
 #elif defined(__APPLE__) || defined(__linux__)
         LOG(DEBUG, backend_name) << "Extracting zip to " << dest_dir << std::endl;
-        command = "unzip -o -q \"" + zip_path + "\" -d \"" + dest_dir + "\"";
+        executable = "unzip";
+        args = {"-o", "-q", zip_path, "-d", dest_dir};
 #endif
-        int result = system(command.c_str());
+        std::string output;
+        int result = run_archive_process(executable, args, output);
         if (result != 0) {
             #ifdef _WIN32
                 LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
             #else
                 LOG(ERROR, backend_name) << "Extraction failed. Ensure 'unzip' is installed. Code: " << result << std::endl;
             #endif
+            if (!output.empty()) {
+                LOG(ERROR, backend_name) << output;
+            }
             return false;
         }
         return true;
     }
 
     bool BackendUtils::extract_tarball(const std::string& tarball_path, const std::string& dest_dir, const std::string& backend_name) {
-        std::string command;
+        std::string executable;
+        std::vector<std::string> args;
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting tarball to " << dest_dir << std::endl;
 #ifdef _WIN32
@@ -108,13 +139,19 @@ namespace lemon::backends {
             LOG(ERROR, backend_name) << "Error: 'tar' command not found. Windows 10 (17063+) required." << std::endl;
             return false;
         }
-        command = get_native_tar_path() + " -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        executable = get_native_tar_path();
+        args = {"-xzf", tarball_path, "-C", dest_dir, "--strip-components=1", "--no-same-owner"};
 #else
-        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        executable = "tar";
+        args = {"-xzf", tarball_path, "-C", dest_dir, "--strip-components=1", "--no-same-owner"};
 #endif
-        int result = system(command.c_str());
+        std::string output;
+        int result = run_archive_process(executable, args, output);
         if (result != 0) {
             LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            if (!output.empty()) {
+                LOG(ERROR, backend_name) << output;
+            }
             return false;
         }
         return true;

--- a/test/test_backend_archive_security.py
+++ b/test/test_backend_archive_security.py
@@ -1,0 +1,49 @@
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_UTILS = REPO_ROOT / "src/cpp/server/backends/backend_utils.cpp"
+
+
+def _function_body(source: str, name: str) -> str:
+    match = re.search(rf"bool BackendUtils::{name}\([^)]*\) \{{", source)
+    if not match:
+        raise AssertionError(f"{name} not found")
+
+    depth = 0
+    for index in range(match.end() - 1, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[match.end() : index]
+    raise AssertionError(f"{name} body not terminated")
+
+
+class BackendArchiveExtractionSecurityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = BACKEND_UTILS.read_text(encoding="utf-8")
+
+    def test_archive_extractors_execute_with_argument_vectors(self):
+        for function in ("extract_zip", "extract_tarball"):
+            with self.subTest(function=function):
+                body = _function_body(self.source, function)
+                self.assertIn("std::vector<std::string> args", body)
+                self.assertIn("run_archive_process(executable, args, output)", body)
+                self.assertNotIn("system(", body)
+
+    def test_powershell_zip_fallback_uses_literal_path_arguments(self):
+        body = _function_body(self.source, "extract_zip")
+        self.assertIn(
+            "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+            body,
+        )
+        self.assertNotIn("Expand-Archive -Path '\" + zip_path", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_backend_archive_security.py
+++ b/test/test_backend_archive_security.py
@@ -7,7 +7,7 @@ BACKEND_UTILS = REPO_ROOT / "src/cpp/server/backends/backend_utils.cpp"
 
 
 def _function_body(source: str, name: str) -> str:
-    match = re.search(rf"bool BackendUtils::{name}\([^)]*\) \{{", source)
+    match = re.search(rf"bool BackendUtils::{name}\b[^\{{]*\{{", source)
     if not match:
         raise AssertionError(f"{name} not found")
 


### PR DESCRIPTION
## Summary
- run backend archive extraction through ProcessManager argument vectors instead of shell-built command strings
- pass zip/tar paths as executable arguments on Linux/macOS/Windows, including the PowerShell fallback through `-LiteralPath $args[...]`
- add a focused regression test for the archive extraction command boundary

## Security
Addresses CodeQL `cpp/command-line-injection` alerts:
- https://github.com/nisavid/lemonade/security/code-scanning/1
- https://github.com/nisavid/lemonade/security/code-scanning/2

## Validation
- `python -X pycache_prefix=/tmp/lemonade-pycache -m unittest test.test_backend_archive_security`
- `python -m black --check test/test_backend_archive_security.py`
- `git diff --check`
- `cmake --preset default`
- `cmake --build --preset default --target lemond`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable ZIP and tarball extraction across platforms with improved error reporting and captured diagnostic output; Windows ZIP now falls back to PowerShell when needed and native tar is preferred/required appropriately.
* **Tests**
  * New automated tests validating secure and consistent archive extraction behavior and PowerShell fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->