### PR TITLE
Hide zerank adapter options from base llama.cpp model settings

### DIFF
--- a/src/app/src/renderer/ModelOptionsModal.tsx
+++ b/src/app/src/renderer/ModelOptionsModal.tsx
@@ -290,7 +290,7 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
   const handleReset = () => {
     if (!options?.recipe) return;
     setNumericDrafts({});
-    setOptions(createDefaultOptions(options.recipe));
+    setOptions(createDefaultOptions(options.recipe, modelInfo?.recipe_options as Record<string, unknown> | undefined));
   };
 
   const handleCopyModelName = async () => {
@@ -404,7 +404,7 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
   }
 
   const recipe = options.recipe;
-  const availableOptions = getOptionsForRecipe(recipe);
+  const availableOptions = getOptionsForRecipe(recipe, modelInfo?.recipe_options as Record<string, unknown> | undefined);
 
   // Check if recipe has multiple backends available
   const hasMultipleBackends = modelInfo?.recipe && (supportedRecipes[modelInfo.recipe]?.length ?? 0) > 1;

--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -36,9 +36,9 @@ export interface LlamaOptions {
   ctxSize: NumericOption;
   llamacppBackend: StringOption;
   llamacppArgs: StringOption;
-  llamacppRerankingAdapter: StringOption;
-  llamacppRerankingTrueTokenId: NumericOption;
-  llamacppRerankingLogitScale: NumericOption;
+  llamacppRerankingAdapter?: StringOption;
+  llamacppRerankingTrueTokenId?: NumericOption;
+  llamacppRerankingLogitScale?: NumericOption;
   mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
@@ -293,12 +293,24 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
 
 export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'ryzenai-llm' | 'sd-cpp' | 'vllm';
 
+export const LLAMACPP_RERANKING_ADAPTER_OPTIONS = [
+  'llamacppRerankingAdapter',
+  'llamacppRerankingTrueTokenId',
+  'llamacppRerankingLogitScale',
+];
+
+const hasLlamacppRerankingAdapterOptions = (recipeOptions?: Record<string, unknown>): boolean => {
+  return recipeOptions != null
+    && Object.prototype.hasOwnProperty.call(recipeOptions, 'llamacpp_reranking_adapter');
+};
+
 /**
  * Maps recipe names to the option keys they support.
- * This mirrors the C++ get_keys_for_recipe() function in recipe_options.cpp
+ * This mirrors the baseline C++ get_keys_for_recipe() surface; model-specific
+ * controls are added by getOptionsForRecipe().
  */
 export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
-  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'llamacppRerankingAdapter', 'llamacppRerankingTrueTokenId', 'llamacppRerankingLogitScale', 'mergeArgs', 'saveOptions'],
+  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'mergeArgs', 'saveOptions'],
   'whispercpp': ['whispercppBackend', 'whispercppArgs', 'mergeArgs', 'saveOptions'],
   'flm': ['ctxSize', 'mergeArgs', 'saveOptions'],
   'ryzenai-llm': ['ctxSize', 'saveOptions'],
@@ -309,11 +321,25 @@ export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
 /**
  * Gets the option keys for a given recipe
  */
-export function getOptionsForRecipe(recipe: string): string[] {
-  if (recipe in RECIPE_OPTIONS_MAP) {
-    return RECIPE_OPTIONS_MAP[recipe as RecipeName];
+export function getOptionsForRecipe(recipe: string, recipeOptions?: Record<string, unknown>): string[] {
+  if (!(recipe in RECIPE_OPTIONS_MAP)) {
+    return [];
   }
-  return [];
+
+  const optionKeys = RECIPE_OPTIONS_MAP[recipe as RecipeName];
+  if (recipe === 'llamacpp' && hasLlamacppRerankingAdapterOptions(recipeOptions)) {
+    const insertionIndex = optionKeys.indexOf('mergeArgs');
+    if (insertionIndex === -1) {
+      return [...optionKeys, ...LLAMACPP_RERANKING_ADAPTER_OPTIONS];
+    }
+    return [
+      ...optionKeys.slice(0, insertionIndex),
+      ...LLAMACPP_RERANKING_ADAPTER_OPTIONS,
+      ...optionKeys.slice(insertionIndex),
+    ];
+  }
+
+  return [...optionKeys];
 }
 
 /**
@@ -379,8 +405,8 @@ export function clampOptionValue(key: string, value: number): number {
 /**
  * Creates default options for a recipe
  */
-export function createDefaultOptions(recipe: string): RecipeOptions {
-  const optionKeys = getOptionsForRecipe(recipe);
+export function createDefaultOptions(recipe: string, recipeOptions?: Record<string, unknown>): RecipeOptions {
+  const optionKeys = getOptionsForRecipe(recipe, recipeOptions);
   const result: Record<string, unknown> = { recipe };
 
   for (const key of optionKeys) {
@@ -397,7 +423,7 @@ export function createDefaultOptions(recipe: string): RecipeOptions {
  * Converts API response options to RecipeOptions format
  */
 export function apiToRecipeOptions(recipe: string, apiOptions?: Record<string, unknown>): RecipeOptions {
-  const optionKeys = getOptionsForRecipe(recipe);
+  const optionKeys = getOptionsForRecipe(recipe, apiOptions);
   const result: Record<string, unknown> = { recipe };
 
   for (const key of optionKeys) {

--- a/test/app/app-regression/recipeOptionsConfig.test.cjs
+++ b/test/app/app-regression/recipeOptionsConfig.test.cjs
@@ -1,0 +1,112 @@
+const {
+  readSource,
+  normalizeWhitespace,
+  assertIncludes,
+  assertNotMatches,
+  assertMatches,
+} = require('./helpers/source.cjs');
+
+const RECIPE_OPTIONS_CONFIG = 'src/app/src/renderer/recipes/recipeOptionsConfig.ts';
+const MODEL_OPTIONS_MODAL = 'src/app/src/renderer/ModelOptionsModal.tsx';
+
+function extractArray(source, name) {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`${escapedName}[^\\[]*\\[([^\\]]+)\\]`);
+  const match = source.match(pattern);
+  if (!match) {
+    throw new Error(`Could not find ${name} array.`);
+  }
+
+  return Array.from(match[1].matchAll(/'([^']+)'/g), (item) => item[1]);
+}
+
+function visibleLlamacppOptions(source, recipeOptions) {
+  const baseOptions = extractArray(source, "'llamacpp':");
+  if (recipeOptions == null || !Object.prototype.hasOwnProperty.call(recipeOptions, 'llamacpp_reranking_adapter')) {
+    return baseOptions;
+  }
+
+  const adapterOptions = extractArray(source, 'LLAMACPP_RERANKING_ADAPTER_OPTIONS');
+  const insertionIndex = baseOptions.indexOf('mergeArgs');
+  if (insertionIndex === -1) {
+    return [...baseOptions, ...adapterOptions];
+  }
+
+  return [
+    ...baseOptions.slice(0, insertionIndex),
+    ...adapterOptions,
+    ...baseOptions.slice(insertionIndex),
+  ];
+}
+
+const tests = [
+  {
+    name: 'llama.cpp base launch options do not expose reranking adapter controls',
+    run() {
+      const source = normalizeWhitespace(readSource(RECIPE_OPTIONS_CONFIG));
+      const llamaMapMatch = source.match(/'llamacpp': \[([^\]]+)\]/);
+
+      assertMatches(
+        source,
+        /LLAMACPP_RERANKING_ADAPTER_OPTIONS/,
+        'Reranking adapter controls should live in a named conditional option group.',
+      );
+      assertMatches(
+        source,
+        /'llamacpp': \[[^\]]+\]/,
+        'The regression guard must fail if the llama.cpp option map cannot be found.',
+      );
+      assertNotMatches(
+        llamaMapMatch[1],
+        /llamacppReranking(Adapter|TrueTokenId|LogitScale)/,
+        'Plain llama.cpp models should not inherit reranking adapter controls from the base option map.',
+      );
+    },
+  },
+  {
+    name: 'model options modal asks for model-specific visible options',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_OPTIONS_MODAL));
+
+      assertIncludes(
+        source,
+        'getOptionsForRecipe(recipe, modelInfo?.recipe_options',
+        'ModelOptionsModal should pass model recipe options when deriving visible launch options.',
+      );
+      assertIncludes(
+        source,
+        'createDefaultOptions(options.recipe, modelInfo?.recipe_options',
+        'Resetting model options should preserve model-specific conditional controls.',
+      );
+    },
+  },
+  {
+    name: 'reranking adapter controls are visible only for adapter-backed llama.cpp models',
+    run() {
+      const source = normalizeWhitespace(readSource(RECIPE_OPTIONS_CONFIG));
+      const normalOptions = visibleLlamacppOptions(source, {});
+      const nullOptions = visibleLlamacppOptions(source, null);
+      const adapterOptions = visibleLlamacppOptions(source, {
+        llamacpp_reranking_adapter: 'zeroentropy-logit-score',
+      });
+
+      assertNotMatches(
+        normalOptions.join(','),
+        /llamacppReranking(Adapter|TrueTokenId|LogitScale)/,
+        'Normal llama.cpp model options should hide adapter controls.',
+      );
+      assertNotMatches(
+        nullOptions.join(','),
+        /llamacppReranking(Adapter|TrueTokenId|LogitScale)/,
+        'Null recipe options should be treated like absent recipe options.',
+      );
+      assertMatches(
+        adapterOptions.join(','),
+        /llamacppRerankingAdapter,llamacppRerankingTrueTokenId,llamacppRerankingLogitScale/,
+        'Adapter-backed llama.cpp model options should include the complete adapter control group.',
+      );
+    },
+  },
+];
+
+module.exports = { tests };


### PR DESCRIPTION
## Summary

- Fixes the #17 regression where ZeroEntropy reranking adapter controls appeared in every llama.cpp model's Model Options modal.
- Keeps the adapter fields available only for llama.cpp models whose model-specific recipe options include `llamacpp_reranking_adapter`, such as `zerank-2-GGUF` and imported models detected into the same adapter path.
- Adds a focused app regression guard so plain llama.cpp launch options cannot inherit those adapter controls from the base option map again.

## Root Cause

PR #17 added `llamacppRerankingAdapter`, `llamacppRerankingTrueTokenId`, and `llamacppRerankingLogitScale` directly to the global llama.cpp frontend option list. `ModelOptionsModal` rendered that recipe-level list for every llama.cpp model, so regular chat models showed reranking-only fields even when their server model details did not opt into the adapter.

## Changes

- Split the adapter controls into a named conditional option group in `recipeOptionsConfig.ts`.
- Make `getOptionsForRecipe()` accept model recipe options and append adapter controls only when the model declares the adapter option.
- Pass the selected model's recipe options through the modal option visibility and reset paths.
- Mark the adapter fields optional in the llama.cpp frontend option type because they are no longer part of the base llama.cpp launch surface.

## Verification

- `node test/app/run-app-regression-tests.cjs` passed.
- `npm ci --cache /tmp/lemonade-npm-cache` completed for `src/app`.
- `npm run build:renderer` passed in `src/app`.
- `git diff --check` passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model options now honor model-specific recipe options when displaying and resetting defaults.
  * Reranking controls for llama.cpp appear only when the model is configured for reranking, and defaults reflect that conditional visibility.

* **Tests**
  * Added regression tests to validate conditional option visibility and correct default generation tied to model recipe options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->