### PR TITLE
fix(server/pinning): keep backend processes live

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -130,7 +130,7 @@ jobs:
           & $wixExe --version
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: build/_deps
           key: fetchcontent-windows-${{ hashFiles('CMakeLists.txt') }}

--- a/src/app/src/renderer/components/panels/RerankingPanel.tsx
+++ b/src/app/src/renderer/components/panels/RerankingPanel.tsx
@@ -31,9 +31,20 @@ const RerankIcon: React.FC = () => (
 );
 
 const extractServerErrorMessage = (error: any): string => {
+  const stringifyFallback = (value: any, fallback: string): string => {
+    if (typeof value === 'string') return value;
+    if (value?.message) return value.message;
+    try {
+      return JSON.stringify(value) || fallback;
+    } catch {
+      return fallback;
+    }
+  };
+
+  const backendError = error?.details?.backend_error;
+  if (backendError) return stringifyFallback(backendError, 'Unknown backend error');
   if (typeof error === 'string') return error;
   if (error?.message) return error.message;
-  if (error?.details?.backend_error?.message) return error.details.backend_error.message;
   return 'Unknown server error';
 };
 
@@ -77,7 +88,13 @@ const RerankingPanel: React.FC<RerankingPanelProps> = ({
         }),
       });
 
-      const data = await response.json();
+      let data: any;
+      try {
+        data = await response.json();
+      } catch {
+        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+        throw new Error('Unexpected response format');
+      }
 
       if (data?.error) {
         throw new Error(extractServerErrorMessage(data.error));

--- a/src/app/src/renderer/components/panels/RerankingPanel.tsx
+++ b/src/app/src/renderer/components/panels/RerankingPanel.tsx
@@ -30,6 +30,13 @@ const RerankIcon: React.FC = () => (
   </svg>
 );
 
+const extractServerErrorMessage = (error: any): string => {
+  if (typeof error === 'string') return error;
+  if (error?.message) return error.message;
+  if (error?.details?.backend_error?.message) return error.details.backend_error.message;
+  return 'Unknown server error';
+};
+
 const RerankingPanel: React.FC<RerankingPanelProps> = ({
   isBusy, isInferring, activeModality,
   runPreFlight, reset, showError,
@@ -70,9 +77,13 @@ const RerankingPanel: React.FC<RerankingPanelProps> = ({
         }),
       });
 
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-
       const data = await response.json();
+
+      if (data?.error) {
+        throw new Error(extractServerErrorMessage(data.error));
+      }
+
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
 
       if (data.results && Array.isArray(data.results)) {
         const results = data.results.map((r: any) => ({

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -175,6 +175,8 @@ public:
         telemetry_.prompt_tokens = prompt_tokens;
     }
 
+    friend class Router;
+
 protected:
     // Choose an available port
     int choose_port();

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -64,9 +64,12 @@ WrappedServer* Router::get_most_recent_server() const {
         return nullptr;
     }
 
-    WrappedServer* most_recent = loaded_servers_[0].get();
+    WrappedServer* most_recent = nullptr;
     for (const auto& server : loaded_servers_) {
-        if (server->get_last_access_time() > most_recent->get_last_access_time()) {
+        if (!server->is_process_running()) {
+            continue;
+        }
+        if (!most_recent || server->get_last_access_time() > most_recent->get_last_access_time()) {
             most_recent = server.get();
         }
     }
@@ -76,7 +79,8 @@ WrappedServer* Router::get_most_recent_server() const {
 int Router::count_servers_by_type(ModelType type) const {
     int count = 0;
     for (const auto& server : loaded_servers_) {
-        if (server->get_model_type() == type && !server->is_pinned()) {
+        if (server->is_process_running() &&
+            server->get_model_type() == type && !server->is_pinned()) {
             count++;
         }
     }
@@ -87,7 +91,8 @@ WrappedServer* Router::find_lru_server_by_type(ModelType type) const {
     WrappedServer* lru = nullptr;
 
     for (const auto& server : loaded_servers_) {
-        if (server->get_model_type() == type && !server->is_pinned()) {
+        if (server->is_process_running() &&
+            server->get_model_type() == type && !server->is_pinned()) {
             if (!lru || server->get_last_access_time() < lru->get_last_access_time()) {
                 lru = server.get();
             }
@@ -105,7 +110,7 @@ bool Router::is_config_pinned(const std::string& canonical_model_name) const {
 
 bool Router::has_npu_server() const {
     for (const auto& server : loaded_servers_) {
-        if (server->get_device_type() & DEVICE_NPU) {
+        if (server->is_process_running() && (server->get_device_type() & DEVICE_NPU)) {
             return true;
         }
     }
@@ -114,7 +119,7 @@ bool Router::has_npu_server() const {
 
 WrappedServer* Router::find_npu_server() const {
     for (const auto& server : loaded_servers_) {
-        if (server->get_device_type() & DEVICE_NPU) {
+        if (server->is_process_running() && (server->get_device_type() & DEVICE_NPU)) {
             return server.get();
         }
     }
@@ -124,7 +129,8 @@ WrappedServer* Router::find_npu_server() const {
 // Helper: Find NPU server with a specific recipe
 WrappedServer* Router::find_npu_server_by_recipe(const std::string& recipe) const {
     for (const auto& server : loaded_servers_) {
-        if ((server->get_device_type() & DEVICE_NPU) &&
+        if (server->is_process_running() &&
+            (server->get_device_type() & DEVICE_NPU) &&
             server->get_recipe_options().get_recipe() == recipe) {
             return server.get();
         }
@@ -135,7 +141,8 @@ WrappedServer* Router::find_npu_server_by_recipe(const std::string& recipe) cons
 // Helper: Find FLM server of a specific model type
 WrappedServer* Router::find_flm_server_by_type(ModelType type) const {
     for (const auto& server : loaded_servers_) {
-        if (server->get_recipe_options().get_recipe() == "flm" &&
+        if (server->is_process_running() &&
+            server->get_recipe_options().get_recipe() == "flm" &&
             server->get_model_type() == type) {
             return server.get();
         }
@@ -147,7 +154,7 @@ WrappedServer* Router::find_flm_server_by_type(ModelType type) const {
 void Router::evict_all_npu_servers(bool include_pinned) {
     std::vector<WrappedServer*> npu_servers;
     for (const auto& server : loaded_servers_) {
-        if (server->get_device_type() & DEVICE_NPU) {
+        if (server->is_process_running() && (server->get_device_type() & DEVICE_NPU)) {
             if (server->is_pinned() && !include_pinned) {
                 throw std::runtime_error(
                     "Pinned model requires NPU access and cannot be evicted: "
@@ -482,7 +489,12 @@ void Router::load_model(const std::string& model_name,
         // Check if model is already loaded
         WrappedServer* existing = find_server_by_model_name(canonical_model_name);
         if (existing) {
-            if (allow_reload_on_option_change &&
+            if (!existing->is_process_running()) {
+                LOG(WARNING, "Router") << "Discarding exited backend for model: "
+                                       << canonical_model_name << std::endl;
+                evict_server(existing);
+                existing = nullptr;
+            } else if (allow_reload_on_option_change &&
                 existing->get_recipe_options().to_json() != effective_options.to_json()) {
                 LOG(INFO, "Router") << "Options changed, reloading model: " << canonical_model_name << std::endl;
                 reload_existing = existing;
@@ -756,6 +768,9 @@ json Router::get_all_loaded_models() const {
     json result = json::array();
 
     for (const auto& server : loaded_servers_) {
+        if (!server->is_process_running()) {
+            continue;
+        }
         json model_info;
         model_info["model_name"] = model_manager_->get_public_model_name(server->get_model_name());
         model_info["checkpoint"] = server->get_checkpoint();
@@ -795,18 +810,24 @@ json Router::get_max_model_limits() const {
 
 bool Router::is_model_loaded() const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    return !loaded_servers_.empty();
+    return std::any_of(
+        loaded_servers_.begin(),
+        loaded_servers_.end(),
+        [](const std::unique_ptr<WrappedServer>& server) {
+            return server->is_process_running();
+        });
 }
 
 bool Router::is_model_loaded(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    return find_server_by_model_name(resolve_model_name(model_name)) != nullptr;
+    auto* server = find_server_by_model_name(resolve_model_name(model_name));
+    return server && server->is_process_running();
 }
 
 RecipeOptions Router::get_model_recipe_options(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     auto* server = find_server_by_model_name(resolve_model_name(model_name));
-    if (server) return server->get_recipe_options();
+    if (server && server->is_process_running()) return server->get_recipe_options();
     return RecipeOptions();
 }
 
@@ -823,7 +844,7 @@ ModelType Router::get_model_type(const std::string& model_name) const {
     WrappedServer* server = model_name.empty()
         ? get_most_recent_server()
         : find_server_by_model_name(resolve_model_name(model_name));
-    return server ? server->get_model_type() : ModelType::LLM;
+    return (server && server->is_process_running()) ? server->get_model_type() : ModelType::LLM;
 }
 
 std::string Router::get_backend_address() const {
@@ -852,6 +873,9 @@ auto Router::execute_inference(const json& request, Func&& inference_func) -> de
 
         server = find_server_by_model_name(resolve_model_name(requested_model));
         if (!server) {
+            return ErrorResponse::from_exception(ModelNotLoadedException(requested_model));
+        }
+        if (!server->is_process_running()) {
             return ErrorResponse::from_exception(ModelNotLoadedException(requested_model));
         }
 
@@ -901,6 +925,11 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
 
         server = find_server_by_model_name(resolve_model_name(requested_model));
         if (!server) {
+            std::string error_msg = "data: {\"error\":{\"message\":\"Model not loaded: " + requested_model + "\",\"type\":\"model_not_loaded\"}}\n\n";
+            sink.write(error_msg.c_str(), error_msg.size());
+            return;
+        }
+        if (!server->is_process_running()) {
             std::string error_msg = "data: {\"error\":{\"message\":\"Model not loaded: " + requested_model + "\",\"type\":\"model_not_loaded\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());
             return;

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -920,6 +920,7 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             LOG(ERROR, "Router") << "No model specified in streaming request" << std::endl;
             std::string error_msg = "data: {\"error\":{\"message\":\"No model specified in request\",\"type\":\"invalid_request_error\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());
+            sink.done();
             return;
         }
 
@@ -927,11 +928,13 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
         if (!server) {
             std::string error_msg = "data: {\"error\":{\"message\":\"Model not loaded: " + requested_model + "\",\"type\":\"model_not_loaded\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());
+            sink.done();
             return;
         }
         if (!server->is_process_running()) {
             std::string error_msg = "data: {\"error\":{\"message\":\"Model not loaded: " + requested_model + "\",\"type\":\"model_not_loaded\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());
+            sink.done();
             return;
         }
 

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -38,6 +38,7 @@
 #include <errno.h>
 #ifdef __linux__
 #include <sys/prctl.h>  // PR_SET_PDEATHSIG — kill child when parent dies
+#include <sys/syscall.h>
 #endif
 #ifdef __APPLE__
 #include <spawn.h>      // posix_spawn — fork-safe child creation on macOS
@@ -536,6 +537,11 @@ ProcessHandle ProcessManager::start_process(
             std::string("posix_spawn failed: ") + strerror(spawn_rc));
     }
 #else
+#ifdef __linux__
+    const bool parent_thread_is_process_leader =
+        static_cast<pid_t>(syscall(SYS_gettid)) == getpid();
+#endif
+
     pid_t pid = fork();
 
     if (pid < 0) {
@@ -545,11 +551,13 @@ ProcessHandle ProcessManager::start_process(
     if (pid == 0) {
         // Child process
 #ifdef __linux__
-        // Ensure this child is killed when the parent process dies.
-        // This is the Linux equivalent of the Windows Job Object and
-        // prevents orphaned backend processes (llama-server, etc.)
-        // when lemond is killed or crashes.
-        prctl(PR_SET_PDEATHSIG, SIGTERM);
+        // Linux delivers PR_SET_PDEATHSIG when the forking thread exits, not
+        // only when the whole process exits. Lemonade can launch backends from
+        // temporary loader/request threads, so only enable it from the process
+        // leader. Service managers still clean up the full cgroup.
+        if (parent_thread_is_process_leader) {
+            prctl(PR_SET_PDEATHSIG, SIGTERM);
+        }
 #endif
 
         if (!working_dir.empty()) {
@@ -679,13 +687,20 @@ void ProcessManager::stop_process(ProcessHandle handle) {
     }
 #else
     if (handle.pid > 0) {
-        kill(handle.pid, SIGTERM);
+        if (kill(handle.pid, SIGTERM) != 0 && errno == ESRCH) {
+            return;
+        }
 
         // Wait for process to exit
         int status;
         bool exited_gracefully = false;
         for (int i = 0; i < 50; i++) {  // Try for 5 seconds
-            if (waitpid(handle.pid, &status, WNOHANG) > 0) {
+            pid_t wait_result = waitpid(handle.pid, &status, WNOHANG);
+            if (wait_result > 0) {
+                exited_gracefully = true;
+                break;
+            }
+            if (wait_result < 0 && errno == ECHILD) {
                 exited_gracefully = true;
                 break;
             }

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -139,11 +139,7 @@ bool WrappedServer::wait_for_ready(const std::string& endpoint, long timeout_sec
 }
 
 bool WrappedServer::is_process_running() const {
-#ifdef _WIN32
     return utils::ProcessManager::is_running(process_handle_);
-#else
-    return utils::ProcessManager::is_running(process_handle_);
-#endif
 }
 
 json WrappedServer::forward_request(const std::string& endpoint, const json& request, long timeout_seconds) {

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -140,9 +140,9 @@ bool WrappedServer::wait_for_ready(const std::string& endpoint, long timeout_sec
 
 bool WrappedServer::is_process_running() const {
 #ifdef _WIN32
-    return process_handle_.handle != nullptr;
+    return utils::ProcessManager::is_running(process_handle_);
 #else
-    return process_handle_.pid > 0;
+    return utils::ProcessManager::is_running(process_handle_);
 #endif
 }
 

--- a/test/cpp/test_process_manager_lifecycle.cpp
+++ b/test/cpp/test_process_manager_lifecycle.cpp
@@ -9,10 +9,37 @@
 
 #include <chrono>
 #include <cstdio>
+#include <string>
 #include <thread>
+#include <vector>
 
 using lemon::utils::ProcessHandle;
 using lemon::utils::ProcessManager;
+
+namespace {
+
+struct Command {
+    std::string executable;
+    std::vector<std::string> args;
+};
+
+Command long_running_command() {
+#ifdef _WIN32
+    return {"cmd.exe", {"/C", "timeout /T 5 /NOBREAK > NUL"}};
+#else
+    return {"sleep", {"5"}};
+#endif
+}
+
+Command successful_exit_command() {
+#ifdef _WIN32
+    return {"cmd.exe", {"/C", "exit 0"}};
+#else
+    return {"true", {}};
+#endif
+}
+
+} // namespace
 
 int main() {
     int failures = 0;
@@ -23,8 +50,9 @@ int main() {
 
     ProcessHandle worker_child{nullptr, 0};
     std::thread launcher([&worker_child] {
+        const Command command = long_running_command();
         worker_child = ProcessManager::start_process(
-            "sleep", {"5"}, "", false);
+            command.executable, command.args, "", false);
     });
     launcher.join();
 
@@ -35,8 +63,9 @@ int main() {
 
     ProcessManager::stop_process(worker_child);
 
+    const Command command = successful_exit_command();
     ProcessHandle short_lived = ProcessManager::start_process(
-        "true", {}, "", false);
+        command.executable, command.args, "", false);
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
     expect_true(
         !ProcessManager::is_running(short_lived),

--- a/test/cpp/test_process_manager_lifecycle.cpp
+++ b/test/cpp/test_process_manager_lifecycle.cpp
@@ -1,0 +1,53 @@
+// Standalone test for Lemonade backend process lifecycle behavior.
+// Compile with:
+//   g++ -std=c++17 -pthread -I src/cpp/include \
+//       test/cpp/test_process_manager_lifecycle.cpp \
+//       src/cpp/server/utils/process_manager.cpp \
+//       -o /tmp/test_process_manager_lifecycle
+
+#include "lemon/utils/process_manager.h"
+
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+using lemon::utils::ProcessHandle;
+using lemon::utils::ProcessManager;
+
+int main() {
+    int failures = 0;
+    auto expect_true = [&failures](bool condition, const char* name) {
+        std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+        if (!condition) ++failures;
+    };
+
+    ProcessHandle worker_child{nullptr, 0};
+    std::thread launcher([&worker_child] {
+        worker_child = ProcessManager::start_process(
+            "sleep", {"5"}, "", false);
+    });
+    launcher.join();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    expect_true(
+        ProcessManager::is_running(worker_child),
+        "process launched from a temporary worker thread stays alive after the thread exits");
+
+    ProcessManager::stop_process(worker_child);
+
+    ProcessHandle short_lived = ProcessManager::start_process(
+        "true", {}, "", false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    expect_true(
+        !ProcessManager::is_running(short_lived),
+        "process liveness check detects an exited child");
+
+    const auto cleanup_start = std::chrono::steady_clock::now();
+    ProcessManager::stop_process(short_lived);
+    const auto cleanup_duration = std::chrono::steady_clock::now() - cleanup_start;
+    expect_true(
+        cleanup_duration < std::chrono::seconds(1),
+        "cleanup returns promptly after liveness reaps an exited child");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_wrapped_server_lifecycle.cpp
+++ b/test/cpp/test_wrapped_server_lifecycle.cpp
@@ -1,0 +1,102 @@
+// Standalone test for WrappedServer backend liveness checks.
+// Compile with:
+//   g++ -std=c++17 -pthread -ffunction-sections -fdata-sections \
+//       -I src/cpp/include -I build/_deps/httplib-src \
+//       test/cpp/test_wrapped_server_lifecycle.cpp \
+//       src/cpp/server/wrapped_server.cpp \
+//       src/cpp/server/utils/process_manager.cpp \
+//       -Wl,--gc-sections \
+//       -o /tmp/test_wrapped_server_lifecycle
+
+#include "lemon/wrapped_server.h"
+#include "lemon/streaming_proxy.h"
+
+#include <chrono>
+#include <cstdio>
+#include <stdexcept>
+#include <thread>
+
+using lemon::ModelInfo;
+using lemon::RecipeOptions;
+using lemon::WrappedServer;
+using lemon::json;
+using lemon::utils::ProcessHandle;
+using lemon::utils::ProcessManager;
+
+namespace lemon {
+namespace utils {
+
+std::atomic<long> HttpClient::default_timeout_seconds_{300};
+
+bool HttpClient::is_reachable(const std::string&, int) {
+    return false;
+}
+
+} // namespace utils
+
+void StreamingProxy::forward_sse_stream(
+    const std::string&,
+    const std::string&,
+    httplib::DataSink&,
+    std::function<void(const TelemetryData&)>,
+    long) {
+    throw std::logic_error("not used by this test");
+}
+
+void StreamingProxy::forward_byte_stream(
+    const std::string&,
+    const std::string&,
+    httplib::DataSink&,
+    long) {
+    throw std::logic_error("not used by this test");
+}
+
+} // namespace lemon
+
+class TestWrappedServer : public WrappedServer {
+public:
+    TestWrappedServer() : WrappedServer("test-backend", "info") {}
+
+    void set_process_handle(ProcessHandle handle) {
+        process_handle_ = handle;
+    }
+
+    bool process_running() const {
+        return is_process_running();
+    }
+
+    void load(const std::string&, const ModelInfo&, const RecipeOptions&, bool) override {}
+    void unload() override {
+        ProcessManager::stop_process(process_handle_);
+    }
+    json chat_completion(const json&) override {
+        return json::object();
+    }
+    json completion(const json&) override {
+        return json::object();
+    }
+    json responses(const json&) override {
+        return json::object();
+    }
+};
+
+int main() {
+    int failures = 0;
+    auto expect_true = [&failures](bool condition, const char* name) {
+        std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+        if (!condition) ++failures;
+    };
+
+    TestWrappedServer server;
+    ProcessHandle child = ProcessManager::start_process("true", {}, "", false);
+    server.set_process_handle(child);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    expect_true(
+        !server.process_running(),
+        "wrapped server liveness check detects exited backend process");
+
+    server.unload();
+
+    return failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_wrapped_server_lifecycle.cpp
+++ b/test/cpp/test_wrapped_server_lifecycle.cpp
@@ -14,7 +14,9 @@
 #include <chrono>
 #include <cstdio>
 #include <stdexcept>
+#include <string>
 #include <thread>
+#include <vector>
 
 using lemon::ModelInfo;
 using lemon::RecipeOptions;
@@ -22,6 +24,23 @@ using lemon::WrappedServer;
 using lemon::json;
 using lemon::utils::ProcessHandle;
 using lemon::utils::ProcessManager;
+
+namespace {
+
+struct Command {
+    std::string executable;
+    std::vector<std::string> args;
+};
+
+Command successful_exit_command() {
+#ifdef _WIN32
+    return {"cmd.exe", {"/C", "exit 0"}};
+#else
+    return {"true", {}};
+#endif
+}
+
+} // namespace
 
 namespace lemon {
 namespace utils {
@@ -88,7 +107,9 @@ int main() {
     };
 
     TestWrappedServer server;
-    ProcessHandle child = ProcessManager::start_process("true", {}, "", false);
+    const Command command = successful_exit_command();
+    ProcessHandle child = ProcessManager::start_process(
+        command.executable, command.args, "", false);
     server.set_process_handle(child);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(300));


### PR DESCRIPTION
## Summary

Fixes the pinned-model backend lifecycle issue where Linux backend child processes launched from temporary loader/request threads could exit after the launching thread ended, while Lemonade still reported the model as loaded.

The server now:

- avoids `PR_SET_PDEATHSIG` for children forked from non-process-leader threads on Linux;
- uses the platform process liveness check for `WrappedServer::is_process_running()` instead of treating a stored PID/handle as sufficient;
- excludes exited backends from loaded-model, LRU, NPU-slot, and health/reporting paths;
- discards an exited backend before reloading the same model;
- returns `model_not_loaded` instead of forwarding inference/streaming requests to dead backend ports;
- handles cleanup after liveness checks have already reaped an exited child.

Also updates the reranking panel to surface server-provided error messages instead of masking backend error objects as `Unexpected response format`.

A Windows installer CI cache step was aligned from `actions/cache@v5` to `actions/cache@v4` after the PR check failed inside the cache action before project code ran.

## Verification

- `git diff --check`
- `python -X pycache_prefix=/tmp/lemonade-pycache -m py_compile test/server_endpoints.py`
- `g++ -std=c++17 -pthread -I src/cpp/include test/cpp/test_process_manager_lifecycle.cpp src/cpp/server/utils/process_manager.cpp -o /tmp/test_process_manager_lifecycle`
- `/tmp/test_process_manager_lifecycle`
- `g++ -std=c++17 -pthread -ffunction-sections -fdata-sections -I src/cpp/include -I build/_deps/httplib-src test/cpp/test_wrapped_server_lifecycle.cpp src/cpp/server/wrapped_server.cpp src/cpp/server/utils/process_manager.cpp -Wl,--gc-sections -o /tmp/test_wrapped_server_lifecycle`
- `/tmp/test_wrapped_server_lifecycle`
- `cmake --preset default`
- `cmake --build --preset default --target lemond`
- `npm ci --cache /tmp/lemonade-npm-cache` from `src/app`
- `npm run build:renderer` from `src/app`

Note: the CMake and npm build commands emitted shell-function import warnings for inherited `ml`/`module` definitions, but both builds completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, normalized server error messages surfaced to users.
  * Unavailable/back-end processes are no longer reported as serving models; requests fail fast when a model’s backend is not running.
  * More robust process spawn and termination handling on Linux for reliable shutdown and quicker stop detection.

* **Tests**
  * Added lifecycle tests covering process availability and wrapped-server liveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nisavid/lemonade/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->