### PR TITLE
feat(residency/recovery): add crash-safe durable journal

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.py text eol=lf
+src/cpp/include/lemon/residency/journal.h text eol=lf
+src/cpp/server/residency/journal.cpp text eol=lf

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -140,6 +140,18 @@ jobs:
           ctest --test-dir build -C Release --output-on-failure -R "^mcp_client_config$"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Build durable residency journal test on Windows
+        shell: PowerShell
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run durable residency journal test on Windows
+        shell: PowerShell
+        run: |
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload Lemonade Server Installers
         id: upload-unsigned-msi
         uses: actions/upload-artifact@v7
@@ -974,6 +986,13 @@ jobs:
           echo "Archive contents:"
           tar tzf "$ARCHIVE"
           ls -lh "$ARCHIVE"
+
+      - name: Run durable residency journal test
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake --build --preset default --target test_durable_residency_journal
+          ctest --test-dir build --output-on-failure --no-tests=error -R '^ResidencyDurableJournal$'
 
       - name: Upload embeddable archive
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2382,6 +2382,66 @@ if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROTOTYPE_TASK018_TEST_SRC}")
     set_tests_properties(ResidencyPrototypeContractTask018 PROPERTIES TIMEOUT 45)
 endif()
 
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/residency/recovery/durable_journal_public_seam.cpp")
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    find_package(Threads REQUIRED)
+
+    if(WIN32)
+        set(_TASK020_PLATFORM_SOURCE
+            src/cpp/server/residency/platform/durable_file_adapter_windows.cpp
+        )
+    elseif(APPLE)
+        set(_TASK020_PLATFORM_SOURCE
+            src/cpp/server/residency/platform/durable_file_adapter_macos.cpp
+        )
+    else()
+        set(_TASK020_PLATFORM_SOURCE
+            src/cpp/server/residency/platform/durable_file_adapter_posix.cpp
+        )
+    endif()
+
+    add_executable(test_durable_residency_journal
+        test/residency/recovery/durable_journal_public_seam.cpp
+        test/residency/recovery/journal_persistence_test_support.cpp
+        src/cpp/server/residency/durable_journal.cpp
+        src/cpp/server/residency/durable_file_adapter_common.cpp
+        src/cpp/server/residency/journal.cpp
+        ${_TASK020_PLATFORM_SOURCE}
+    )
+    add_library(test_durable_residency_private_authority_gate OBJECT
+        test/residency/recovery/durable_journal_private_authority_gate.cpp
+    )
+    target_include_directories(test_durable_residency_private_authority_gate PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/residency
+    )
+    add_dependencies(test_durable_residency_journal
+        test_durable_residency_private_authority_gate
+    )
+    target_include_directories(test_durable_residency_journal PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/residency
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/residency/recovery
+    )
+    target_link_libraries(test_durable_residency_journal PRIVATE
+        lemonade-digest-crypto
+        nlohmann_json::nlohmann_json
+        Threads::Threads
+    )
+    target_compile_definitions(test_durable_residency_journal PRIVATE
+        LEMONADE_RESIDENCY_DURABLE_TESTING
+    )
+    add_cpp_ci_test(
+        ResidencyDurableJournal
+        CI ON
+        COMMAND ${Python3_EXECUTABLE} test/residency/recovery/test_durable_journal_public_seam.py --existing-executable $<TARGET_FILE:test_durable_residency_journal> --compiler ${CMAKE_CXX_COMPILER} --private-authority-gate $<TARGET_OBJECTS:test_durable_residency_private_authority_gate>
+        DEPENDS test_durable_residency_journal
+    )
+    set_tests_properties(ResidencyDurableJournal PROPERTIES
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
 # ProcessManager zombie detection and non-mutating reap contract.
 if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_PROCESS_MANAGER_TEST_SRC

--- a/plan/evidence/red-fixtures/TASK-020/result.json
+++ b/plan/evidence/red-fixtures/TASK-020/result.json
@@ -1,0 +1,45 @@
+{
+  "command": [
+    "python3",
+    "-B",
+    "test/residency/recovery/test_durable_journal_public_seam.py"
+  ],
+  "environment": {
+    "platform": "Linux x86_64",
+    "python_version": "3.14.6",
+    "toolchain": [
+      "c++ (GCC) 16.2.1 20260810",
+      "clang++ 22.1.8",
+      "python3"
+    ]
+  },
+  "fallback_state": "production_cutover_inactive",
+  "fixture_sha256": {
+    "test/residency/recovery/durable_journal_private_authority_gate.cpp": "9869521ed951ae3df9e9947d118665f65e3eda04edb854fd7711aa2160d31f63",
+    "test/residency/recovery/durable_journal_public_seam.cpp": "5ecadcea7ac2c0ed17a4ae95474f0b46f6848acf780c1b418ddaa02ebf1af30e",
+    "test/residency/recovery/journal_persistence_test_support.cpp": "27598da43517dbf829345a9d8cc2d1d61812a8669c21d25f3f4fd9217e827561",
+    "test/residency/recovery/journal_persistence_test_support.h": "24f2a89d3b670708157d69c1fca5565fd72dc3ebaa69c11cd59f072f58334e01",
+    "test/residency/recovery/test_durable_journal_public_seam.py": "8be11f9d6fa5fb7a22a2b50197a884855bad6d23739d3f44f2b23486730388a6"
+  },
+  "observed_result": {
+    "exit_code": 1,
+    "failure_signature": "TASK-020 durable residency persistence contract is unavailable",
+    "stderr": {
+      "byte_count": 63,
+      "hex": "5441534b2d3032302064757261626c65207265736964656e63792070657273697374656e636520636f6e747261637420697320756e617661696c61626c650a",
+      "sha256": "d2ca24f571d2a1612a465a936dcc18cba69ef749892879244128bdf929aaddf4"
+    },
+    "stdout": {
+      "byte_count": 0,
+      "hex": "",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "patch": {
+    "path": "plan/evidence/red-fixtures/TASK-020/test.patch",
+    "sha256": "0e1dc4d01f848c19c41aade640b14f9ea656d00f358b8d82a58f8099fda12213"
+  },
+  "schema": "portable_residency_red_fixture_result/v2",
+  "task_base_commit": "0c93411bc9b0463eee0f56d38cd97fffb0bae633",
+  "task_id": "TASK-020"
+}

--- a/plan/evidence/red-fixtures/TASK-020/test.patch
+++ b/plan/evidence/red-fixtures/TASK-020/test.patch
@@ -1,0 +1,18123 @@
+diff --git c/test/residency/recovery/durable_journal_private_authority_gate.cpp i/test/residency/recovery/durable_journal_private_authority_gate.cpp
+new file mode 100644
+index 0000000000000000000000000000000000000000..7c3db7d1352eef9d3cdc80e638cc2090151bf0c8
+--- /dev/null
++++ i/test/residency/recovery/durable_journal_private_authority_gate.cpp
+@@ -0,0 +1,122 @@
++#include "lemon/residency/durable_journal.h"
++#include "platform/durable_file_adapter.h"
++
++#include <memory>
++#include <string>
++#include <type_traits>
++#include <utility>
++
++namespace {
++
++using lemon::residency::AuthorityRootCandidate;
++using lemon::residency::DurableJournal;
++using lemon::residency::ExactSchemaExportCandidate;
++using lemon::residency::JournalHistory;
++using lemon::residency::ParsedJournalRecord;
++using lemon::residency::PublishedJournal;
++
++struct ForgedAdapter {};
++
++static_assert(std::is_move_constructible_v<PublishedJournal>);
++static_assert(!std::is_copy_constructible_v<PublishedJournal>);
++static_assert(!std::is_default_constructible_v<PublishedJournal>);
++static_assert(!std::is_constructible_v<PublishedJournal, std::string>);
++static_assert(!std::is_constructible_v<PublishedJournal,
++                                       ExactSchemaExportCandidate>);
++static_assert(!std::is_constructible_v<PublishedJournal,
++                                       const ParsedJournalRecord &>);
++static_assert(!std::is_constructible_v<PublishedJournal, JournalHistory &&>);
++static_assert(!std::is_constructible_v<PublishedJournal,
++                                       const AuthorityRootCandidate &>);
++static_assert(!std::is_constructible_v<PublishedJournal,
++                                       std::shared_ptr<ForgedAdapter>>);
++static_assert(!std::is_default_constructible_v<DurableJournal>);
++static_assert(!std::is_copy_constructible_v<DurableJournal>);
++
++} // namespace
++
++namespace lemon::residency {
++
++class PublishedJournalAccess {
++    template <typename T>
++    static auto can_private_construct(int)
++        -> decltype(T(std::unique_ptr<typename T::Impl>{}), std::true_type{});
++    template <typename>
++    static auto can_private_construct(...) -> std::false_type;
++
++public:
++    static constexpr bool can_forge =
++        decltype(can_private_construct<PublishedJournal>(0))::value;
++};
++
++class DurableJournalTestAccess {
++    template <typename T>
++    static auto can_private_construct(int)
++        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
++                      std::declval<JournalLimits>()),
++                    std::true_type{});
++    template <typename>
++    static auto can_private_construct(...) -> std::false_type;
++
++public:
++    static constexpr bool can_forge =
++        decltype(can_private_construct<DurableJournal>(0))::value;
++};
++
++static_assert(!PublishedJournalAccess::can_forge);
++static_assert(!DurableJournalTestAccess::can_forge);
++
++namespace detail {
++
++enum class DurablePreflightTestFault { MacroOffNameCollision };
++inline constexpr int make_platform_durable_file_adapter_for_test = 0;
++inline constexpr int make_durable_journal_for_test = 0;
++
++class DurableJournalAccess {
++    template <typename T>
++    static auto can_private_construct(int)
++        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
++                      std::declval<JournalLimits>()),
++                    std::true_type{});
++    template <typename>
++    static auto can_private_construct(...) -> std::false_type;
++
++public:
++    static constexpr bool can_forge =
++        decltype(can_private_construct<DurableJournal>(0))::value;
++};
++
++class DurableJournalTestAccess {
++    template <typename T>
++    static auto can_private_construct(int)
++        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
++                      std::declval<JournalLimits>()),
++                    std::true_type{});
++    template <typename>
++    static auto can_private_construct(...) -> std::false_type;
++
++public:
++    static constexpr bool can_forge =
++        decltype(can_private_construct<DurableJournal>(0))::value;
++};
++
++class DurableJournalTestFactory {
++    template <typename T>
++    static auto can_private_construct(int)
++        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
++                      std::declval<JournalLimits>()),
++                    std::true_type{});
++    template <typename>
++    static auto can_private_construct(...) -> std::false_type;
++
++public:
++    static constexpr bool can_forge =
++        decltype(can_private_construct<DurableJournal>(0))::value;
++};
++
++static_assert(!DurableJournalAccess::can_forge);
++static_assert(!DurableJournalTestAccess::can_forge);
++static_assert(!DurableJournalTestFactory::can_forge);
++
++} // namespace detail
++} // namespace lemon::residency
+diff --git c/test/residency/recovery/durable_journal_public_seam.cpp i/test/residency/recovery/durable_journal_public_seam.cpp
+new file mode 100644
+index 0000000000000000000000000000000000000000..bc4edfa83bdc558883c4c30f635b10cc1556672b
+--- /dev/null
++++ i/test/residency/recovery/durable_journal_public_seam.cpp
+@@ -0,0 +1,6252 @@
++#include "journal_persistence_test_support.h"
++
++#include "platform/durable_file_adapter.h"
++
++#include "lemon/residency/durable_journal.h"
++#include "lemon/residency/journal.h"
++
++#include <algorithm>
++#include <atomic>
++#include <chrono>
++#include <condition_variable>
++#include <cstdlib>
++#include <filesystem>
++#include <fstream>
++#include <initializer_list>
++#include <iostream>
++#include <limits>
++#include <map>
++#include <memory>
++#include <mutex>
++#include <optional>
++#include <set>
++#include <string>
++#include <string_view>
++#include <thread>
++#include <tuple>
++#include <type_traits>
++#include <utility>
++#include <vector>
++
++#ifdef _WIN32
++#ifndef NOMINMAX
++#define NOMINMAX
++#endif
++#include <windows.h>
++#endif
++
++namespace {
++
++using namespace lemon::residency;
++using namespace lemon::residency::testing;
++
++constexpr std::string_view genesis_wire =
++    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"dae75ca123b7b872994ff29f8661049c9c28a1798b76fcd0015271739c5adf63","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":null,"quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":null,"resident_id":"resident/alpha","resident_state":"prepared","schema":{"major":1,"minor":0},"sequence":1})";
++
++constexpr std::string_view successor_wire =
++    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"ec749a93f0e1a98911b9b91d1823f706d5ce16d1f477690b3c5e07b59fd98147","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":"dae75ca123b7b872994ff29f8661049c9c28a1798b76fcd0015271739c5adf63","quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":null,"resident_id":"resident/alpha","resident_state":"provisional","schema":{"major":1,"minor":0},"sequence":2})";
++
++constexpr std::string_view wrong_predecessor_wire =
++    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"dacce12645761d37967d12704a1eef45ea8634c12b6d77d01f4d1e69cd7606b0","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":"f51528eb4d96e562a5a09c5ac314af4bd5a0821106053f0775e76407eba98ff6","quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":null,"resident_id":"resident/alpha","resident_state":"provisional","schema":{"major":1,"minor":0},"sequence":2})";
++
++constexpr std::string_view illegal_transition_wire =
++    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"3db5747617ca25795e6a961271308b9897e0ccaf825adfb92682181589b064dc","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":"dae75ca123b7b872994ff29f8661049c9c28a1798b76fcd0015271739c5adf63","quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":"verified_intact","resident_id":"resident/alpha","resident_state":"active","schema":{"major":1,"minor":0},"sequence":2})";
++
++void require(bool condition, std::string_view message) {
++    if (!condition) {
++        std::cerr << "FAIL: " << message << '\n';
++        std::exit(1);
++    }
++}
++
++std::string frame(const ParsedJournalRecord &record) {
++    return std::string(record.canonical_bytes()) + '\n';
++}
++
++JournalLimits generous_limits() {
++    return JournalLimits{1024 * 1024, 128, 32, 1024 * 1024};
++}
++
++JournalRecordDraft draft_for(std::string journal_id, std::string resident_id,
++                             ResidentState state) {
++    JournalRecordDraft draft;
++    draft.journal_id = std::move(journal_id);
++    draft.resident_id = std::move(resident_id);
++    draft.daemon_epoch = "epoch/7";
++    draft.operation = OperationIdentity{"op/1", std::string("plan/1"),
++                                        OperationFamily::ResourceLifecycle,
++                                        OperationKind::Admission};
++    draft.claim_closure = {
++        ClaimFamilyClosure{ClaimFamily::ConsumableCapacity,
++                           ClaimCompleteness::Bounded,
++                           {ClaimAmount{"gpu/gtt", ClaimUnit::Bytes, 4096}}},
++        ClaimFamilyClosure{
++            ClaimFamily::SafetyFloor, ClaimCompleteness::KnownZero, {}},
++        ClaimFamilyClosure{
++            ClaimFamily::CardinalityPool,
++            ClaimCompleteness::Bounded,
++            {ClaimAmount{"model-type/llm", ClaimUnit::Count, 2}}},
++        ClaimFamilyClosure{ClaimFamily::CompatibilityExclusivity,
++                           ClaimCompleteness::NotApplicable,
++                           {}},
++    };
++    draft.resident_state = state;
++    switch (state) {
++    case ResidentState::Prepared:
++    case ResidentState::Provisional:
++        break;
++    case ResidentState::Active:
++    case ResidentState::Suspended:
++        draft.recovery_disposition = RecoveryDisposition::VerifiedIntact;
++        break;
++    case ResidentState::Quarantined:
++        draft.recovery_disposition = RecoveryDisposition::Quarantined;
++        draft.quarantine_origin = RecoveryOrigin{
++            RecoveryOriginKind::RuntimeRealization,
++            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"};
++        break;
++    case ResidentState::Released:
++        draft.recovery_disposition = RecoveryDisposition::VerifiedReleased;
++        break;
++    }
++    draft.action_lease_claim_ids = {"lease/a"};
++    draft.ownership_claim_ids = {"owner/a"};
++    draft.recovery_claim_ids = {"recovery/a"};
++    return draft;
++}
++
++class AllowingOriginVerifier final : public RecoveryOriginVerifier {
++public:
++    bool verify(const RecoveryOriginVerification &) const noexcept override {
++        return true;
++    }
++};
++
++class RejectIfCalledVerifier final : public RecoveryOriginVerifier {
++public:
++    bool verify(const RecoveryOriginVerification &) const noexcept override {
++        called.store(true);
++        return false;
++    }
++
++    mutable std::atomic<bool> called{false};
++};
++
++struct VerifierLifetimeState {
++    std::atomic<std::size_t> calls{0};
++    std::atomic<bool> alive{false};
++};
++
++class LifetimeAllowingVerifier final : public RecoveryOriginVerifier {
++public:
++    explicit LifetimeAllowingVerifier(
++        std::shared_ptr<VerifierLifetimeState> state)
++        : state_(std::move(state)) {
++        state_->alive.store(true);
++    }
++
++    ~LifetimeAllowingVerifier() override { state_->alive.store(false); }
++
++    bool verify(const RecoveryOriginVerification &) const noexcept override {
++        state_->calls.fetch_add(1);
++        return true;
++    }
++
++private:
++    std::shared_ptr<VerifierLifetimeState> state_;
++};
++
++struct Chain {
++    ParsedJournalRecord genesis;
++    ParsedJournalRecord successor;
++    ParsedJournalRecord fork;
++    ParsedJournalRecord third;
++    AuthorityRootCandidate genesis_root;
++    AuthorityRootCandidate successor_root;
++    AuthorityRootCandidate fork_root;
++    AuthorityRootCandidate third_root;
++};
++
++ParsedJournalRecord make_quarantine_tail(const Chain &chain);
++
++ParsedJournalRecord take_record(ParsedJournalRecordResult result,
++                                std::string_view label) {
++    require(result.accepted() && result.candidate.has_value(), label);
++    return std::move(*result.candidate);
++}
++
++JournalHistory take_history(JournalHistoryResult result,
++                            std::string_view label) {
++    require(result.accepted() && result.history.has_value(), label);
++    return std::move(*result.history);
++}
++
++AuthorityRootCandidate take_root(AuthorityRootCandidateResult result,
++                                 std::string_view label) {
++    require(result.accepted() && result.candidate.has_value(), label);
++    return std::move(*result.candidate);
++}
++
++Chain make_chain(std::string journal_id = "journal/main") {
++    auto genesis =
++        take_record(seal_genesis(draft_for(journal_id, "resident/alpha",
++                                           ResidentState::Prepared)),
++                    "genesis fixture was rejected");
++    auto genesis_history =
++        take_history(begin_history(genesis), "genesis history was rejected");
++    auto genesis_root =
++        take_root(seal_authority_root_candidate(genesis_history),
++                  "genesis root fixture was rejected");
++
++    auto successor = take_record(
++        seal_successor(genesis_history, draft_for(journal_id, "resident/alpha",
++                                                  ResidentState::Provisional)),
++        "successor fixture was rejected");
++    if (journal_id == "journal/main") {
++        require(genesis.canonical_bytes() == genesis_wire &&
++                    successor.canonical_bytes() == successor_wire,
++                "TASK-019 canonical fixtures drifted");
++    }
++    auto fork = take_record(
++        seal_successor(genesis_history, draft_for(journal_id, "resident/alpha",
++                                                  ResidentState::Released)),
++        "fork fixture was rejected");
++
++    auto successor_history =
++        take_history(advance_history(std::move(genesis_history), successor),
++                     "successor history fixture was rejected");
++    auto successor_root = take_root(
++        seal_authority_root_candidate(successor_history, &genesis_root),
++        "successor root fixture was rejected");
++
++    auto fork_history =
++        take_history(begin_history(genesis), "fork genesis was rejected");
++    fork_history = take_history(advance_history(std::move(fork_history), fork),
++                                "fork history fixture was rejected");
++    auto fork_root =
++        take_root(seal_authority_root_candidate(fork_history, &genesis_root),
++                  "fork root fixture was rejected");
++
++    auto third =
++        take_record(seal_successor(successor_history,
++                                   draft_for(journal_id, "resident/alpha",
++                                             ResidentState::Active)),
++                    "third fixture was rejected");
++    auto third_history =
++        take_history(advance_history(std::move(successor_history), third),
++                     "third history fixture was rejected");
++    auto third_root =
++        take_root(seal_authority_root_candidate(third_history, &successor_root),
++                  "third root fixture was rejected");
++
++    return Chain{std::move(genesis),      std::move(successor),
++                 std::move(fork),         std::move(third),
++                 std::move(genesis_root), std::move(successor_root),
++                 std::move(fork_root),    std::move(third_root)};
++}
++
++std::string replace_once(std::string value, std::string_view needle,
++                         std::string_view replacement) {
++    const auto offset = value.find(needle);
++    require(offset != std::string::npos,
++            "root-adversary fixture token was absent");
++    value.replace(offset, needle.size(), replacement);
++    return value;
++}
++
++template <typename Map>
++bool same_optional_value(const Map &left, const Map &right,
++                         std::string_view key) {
++    const auto left_value = left.find(std::string(key));
++    const auto right_value = right.find(std::string(key));
++    if ((left_value == left.end()) != (right_value == right.end())) {
++        return false;
++    }
++    return left_value == left.end() ||
++           left_value->second == right_value->second;
++}
++
++bool fixed_file_unchanged(const NamespaceSnapshot &before,
++                          const NamespaceSnapshot &after,
++                          std::string_view name) {
++    return same_optional_value(before.live_file_bytes, after.live_file_bytes,
++                               name) &&
++           same_optional_value(before.durable_file_bytes,
++                               after.durable_file_bytes, name) &&
++           same_optional_value(before.entry_kinds, after.entry_kinds, name) &&
++           before.relative_paths.count(std::string(name)) ==
++               after.relative_paths.count(std::string(name)) &&
++           before.durable_paths.count(std::string(name)) ==
++               after.durable_paths.count(std::string(name)) &&
++           before.durable_content_available.count(std::string(name)) ==
++               after.durable_content_available.count(std::string(name));
++}
++
++bool authority_files_unchanged(const NamespaceSnapshot &before,
++                               const NamespaceSnapshot &after) {
++    for (const auto name :
++         {"journal.jsonl", "authority-root.json", ".journal.jsonl.stage",
++          ".authority-root.json.stage"}) {
++        if (!fixed_file_unchanged(before, after, name)) {
++            return false;
++        }
++    }
++    return before.journal_bytes == after.journal_bytes &&
++           before.authority_root_bytes == after.authority_root_bytes;
++}
++
++bool stage_files_unchanged(const NamespaceSnapshot &before,
++                           const NamespaceSnapshot &after) {
++    for (const auto name :
++         {".journal.jsonl.stage", ".authority-root.json.stage"}) {
++        if (!fixed_file_unchanged(before, after, name)) {
++            return false;
++        }
++    }
++    return true;
++}
++
++bool is_stage_operation(FaultOperation operation) {
++    switch (operation) {
++    case FaultOperation::RootStageCreate:
++    case FaultOperation::RootStageWrite:
++    case FaultOperation::RootStageFlush:
++    case FaultOperation::RootStageClose:
++    case FaultOperation::RootReplace:
++    case FaultOperation::NamespaceDurability:
++    case FaultOperation::CompactionStageCreate:
++    case FaultOperation::CompactionWrite:
++    case FaultOperation::CompactionFlush:
++    case FaultOperation::CompactionClose:
++    case FaultOperation::CompactionReplace:
++    case FaultOperation::CompactionNamespaceDurability:
++        return true;
++    default:
++        return false;
++    }
++}
++
++bool has_stage_operation(const NamespaceSnapshot &snapshot) {
++    return std::any_of(snapshot.observations.begin(),
++                       snapshot.observations.end(),
++                       [](const OperationObservation &observation) {
++                           return is_stage_operation(observation.operation);
++                       });
++}
++
++ParsedJournalRecord make_second_resident(const Chain &chain,
++                                         std::string journal_id) {
++    auto history = take_history(begin_history(chain.genesis),
++                                "second-resident genesis failed");
++    return take_record(
++        seal_successor(history,
++                       draft_for(std::move(journal_id), "resident/beta",
++                                 ResidentState::Prepared)),
++        "second-resident fixture was rejected");
++}
++
++AuthorityRootCandidate root_after(const Chain &chain,
++                                  const ParsedJournalRecord &record) {
++    auto history =
++        take_history(begin_history(chain.genesis), "root-after genesis failed");
++    history = take_history(advance_history(std::move(history), record),
++                           "root-after successor failed");
++    return take_root(
++        seal_authority_root_candidate(history, &chain.genesis_root),
++        "root-after seal failed");
++}
++
++void require_result(DurableJournalResult &result, DurableJournalStatus expected,
++                    std::string_view label) {
++    require(result.status == expected, label);
++    require(result.published() == (expected == DurableJournalStatus::Published),
++            "result success predicate disagreed with status");
++    require(result.journal.has_value() ==
++                (expected == DurableJournalStatus::Published),
++            "authority handle availability disagreed with status");
++    if (result.journal.has_value()) {
++        require(result.journal->available(),
++                "returned authority handle was unavailable");
++    }
++}
++
++void require_storage_released_after_return(JournalTestStorage &storage,
++                                           std::string_view label) {
++    const auto snapshot = storage.snapshot();
++    const auto acquired = static_cast<std::size_t>(std::count_if(
++        snapshot.observations.begin(), snapshot.observations.end(),
++        [](const OperationObservation &observation) {
++            return observation.operation ==
++                       FaultOperation::AuthorityLockAcquire &&
++                   observation.lock_held;
++        }));
++    require(snapshot.open_handles.empty(), label);
++    if (acquired != 0) {
++        require(storage.attempt_count(FaultOperation::AuthorityLockClose) ==
++                    acquired,
++                "acquired authority lock was not closed exactly once");
++    }
++}
++
++void require_public_shape() {
++    static_assert(!std::is_default_constructible_v<TrustedReplayFloor>);
++    static_assert(!std::is_default_constructible_v<DurableJournal>);
++    static_assert(!std::is_copy_constructible_v<DurableJournal>);
++    static_assert(!std::is_copy_assignable_v<DurableJournal>);
++    static_assert(std::is_nothrow_move_constructible_v<DurableJournal>);
++    static_assert(std::is_nothrow_move_assignable_v<DurableJournal>);
++    static_assert(!std::is_default_constructible_v<PublishedJournal>);
++    static_assert(!std::is_copy_constructible_v<PublishedJournal>);
++    static_assert(!std::is_copy_assignable_v<PublishedJournal>);
++    static_assert(std::is_move_constructible_v<PublishedJournal>);
++    static_assert(std::is_move_assignable_v<PublishedJournal>);
++    static_assert(
++        !std::is_constructible_v<PublishedJournal, ParsedJournalRecord>);
++    static_assert(!std::is_constructible_v<PublishedJournal, JournalHistory>);
++    static_assert(
++        !std::is_constructible_v<PublishedJournal, AuthorityRootCandidate>);
++    static_assert(
++        !std::is_constructible_v<PublishedJournal, ExactSchemaExportCandidate>);
++    static_assert(
++        !std::is_convertible_v<ParsedJournalRecord, PublishedJournal>);
++    static_assert(!std::is_convertible_v<JournalHistory, PublishedJournal>);
++    static_assert(
++        !std::is_convertible_v<AuthorityRootCandidate, PublishedJournal>);
++    static_assert(
++        !std::is_convertible_v<ExactSchemaExportCandidate, PublishedJournal>);
++
++    const auto limits = generous_limits();
++    require(
++        limits.max_committed_bytes != 0 && limits.max_committed_records != 0 &&
++            limits.max_resident_heads != 0 && limits.max_crash_tail_bytes != 0,
++        "test limits were not explicit");
++
++    const std::set<DurableJournalStatus> statuses{
++        DurableJournalStatus::Published,
++        DurableJournalStatus::ConflictBeforeWrite,
++        DurableJournalStatus::UnsupportedStorage,
++        DurableJournalStatus::CorruptOrRollback,
++        DurableJournalStatus::LimitExceeded,
++        DurableJournalStatus::RecoveryRequired,
++    };
++    require(statuses.size() == 6, "stable durable-journal outcomes collapsed");
++    require(durable_journal_data_filename == "journal.jsonl" &&
++                durable_journal_root_filename == "authority-root.json" &&
++                durable_journal_lock_filename == "authority.lock",
++            "fixed public authority filenames drifted");
++    const std::set<ExactSchemaExportStatus> export_statuses{
++        ExactSchemaExportStatus::ExportedCandidate,
++        ExactSchemaExportStatus::QuiescenceRequired,
++        ExactSchemaExportStatus::ConflictBeforeRead,
++        ExactSchemaExportStatus::RecoveryRequired,
++        ExactSchemaExportStatus::UnsupportedStorage,
++        ExactSchemaExportStatus::CorruptOrRollback,
++        ExactSchemaExportStatus::SchemaMismatch,
++        ExactSchemaExportStatus::LimitExceeded,
++    };
++    require(export_statuses.size() == 8,
++            "stable exact-schema export outcomes collapsed");
++}
++
++void require_shared_io_helpers() {
++    const std::string bytes = "partial-write-contract";
++    const auto partial = probe_write_all(bytes, {FaultAction::ShortWrite});
++    require(partial.result == HelperResultKind::Succeeded &&
++                partial.bytes == bytes && partial.attempts > 1,
++            "write_all did not complete an exact partial write");
++
++    const auto interrupted = probe_write_all(
++        bytes, {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce,
++                FaultAction::ShortWrite});
++    require(interrupted.result == HelperResultKind::Succeeded &&
++                interrupted.bytes == bytes && interrupted.attempts > 3,
++            "write_all did not retry interrupted partial progress");
++    const auto interrupted_after_progress = probe_write_all(
++        bytes, {FaultAction::ShortWrite, FaultAction::InterruptedOnce,
++                FaultAction::ShortWrite});
++    require(interrupted_after_progress.result == HelperResultKind::Succeeded &&
++                interrupted_after_progress.bytes == bytes &&
++                interrupted_after_progress.attempts > 3,
++            "write_all reset or duplicated progress after interruption");
++
++    for (const auto action :
++         {FaultAction::ZeroProgress, FaultAction::OverreportedWrite,
++          FaultAction::Error}) {
++        const auto rejected = probe_write_all(bytes, {action});
++        require(rejected.result == HelperResultKind::FailedBeforeEffect &&
++                    rejected.attempts == 1,
++                "write_all did not fail closed on invalid progress");
++    }
++    const auto partial_prefix = bytes.substr(0, bytes.size() / 2);
++    for (const auto action : {FaultAction::Error, FaultAction::ZeroProgress,
++                              FaultAction::OverreportedWrite}) {
++        const auto rejected_after_progress =
++            probe_write_all(bytes, {FaultAction::ShortWrite, action});
++        require(rejected_after_progress.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    rejected_after_progress.bytes == partial_prefix &&
++                    rejected_after_progress.attempts == 2,
++                "write_all forgot partial progress before terminal failure");
++    }
++    const auto effect_may =
++        probe_write_all(bytes, {FaultAction::EffectThenError});
++    require(effect_may.result == HelperResultKind::EffectMayHaveOccurred &&
++                effect_may.bytes == bytes && effect_may.attempts == 1,
++            "write_all lost a possibly-effectful failure");
++
++    const auto flushed = probe_flush_retry(
++        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
++    require(flushed.result == HelperResultKind::Succeeded &&
++                flushed.attempts == 3,
++            "flush helper did not retry all interruptions");
++
++    const auto truncated = probe_truncate_retry(
++        bytes, 7, {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
++    require(truncated.result == HelperResultKind::Succeeded &&
++                truncated.bytes == bytes.substr(0, 7) &&
++                truncated.attempts == 3,
++            "truncate helper did not retry to the exact boundary");
++
++    for (const auto &[action, expected] :
++         {std::pair{FaultAction::Error, HelperResultKind::FailedBeforeEffect},
++          std::pair{FaultAction::EffectThenError,
++                    HelperResultKind::EffectMayHaveOccurred}}) {
++        const auto terminal_flush = probe_flush_retry({action});
++        require(terminal_flush.result == expected &&
++                    terminal_flush.attempts == 1,
++                "flush helper retried a non-interrupted failure");
++        const auto terminal_truncate = probe_truncate_retry(bytes, 7, {action});
++        const auto expected_bytes =
++            action == FaultAction::EffectThenError ? bytes.substr(0, 7) : bytes;
++        require(terminal_truncate.result == expected &&
++                    terminal_truncate.bytes == expected_bytes &&
++                    terminal_truncate.attempts == 1,
++                "truncate helper retried or lost a terminal outcome");
++    }
++
++    for (const auto &[action, expected] :
++         {std::pair{FaultAction::InterruptedOnce,
++                    HelperResultKind::Interrupted},
++          std::pair{FaultAction::EffectThenError,
++                    HelperResultKind::EffectMayHaveOccurred},
++          std::pair{FaultAction::Error,
++                    HelperResultKind::FailedBeforeEffect}}) {
++        const auto closed = probe_close_once({action});
++        require(closed.result == expected && closed.attempts == 1,
++                "close_once retried or collapsed a failed close");
++    }
++
++    const auto write_success = probe_write_flush_close(bytes, {}, {}, {});
++    require(write_success.result == HelperResultKind::Succeeded &&
++                write_success.bytes == bytes &&
++                write_success.write_attempts == 1 &&
++                write_success.flush_attempts == 1 &&
++                write_success.truncate_attempts == 0 &&
++                write_success.close_attempts == 1,
++            "write-flush-close changed the all-success path");
++
++    const auto write_retried = probe_write_flush_close(
++        bytes,
++        {FaultAction::InterruptedOnce, FaultAction::ShortWrite,
++         FaultAction::InterruptedOnce},
++        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce}, {});
++    require(write_retried.result == HelperResultKind::Succeeded &&
++                write_retried.bytes == bytes &&
++                write_retried.write_attempts > 3 &&
++                write_retried.flush_attempts == 3 &&
++                write_retried.close_attempts == 1,
++            "write-flush-close did not reuse retrying primitives exactly");
++
++    const auto possibly_written =
++        probe_write_flush_close(bytes, {FaultAction::EffectThenError}, {}, {});
++    require(possibly_written.result ==
++                    HelperResultKind::EffectMayHaveOccurred &&
++                possibly_written.bytes == bytes &&
++                possibly_written.write_attempts == 1 &&
++                possibly_written.close_attempts == 1,
++            "write-flush-close erased a possibly-effectful write");
++
++    for (const auto flush_action :
++         {FaultAction::Error, FaultAction::EffectThenError}) {
++        const auto failed_flush =
++            probe_write_flush_close(bytes, {}, {flush_action}, {});
++        require(failed_flush.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    failed_flush.bytes == bytes &&
++                    failed_flush.write_attempts == 1 &&
++                    failed_flush.flush_attempts == 1 &&
++                    failed_flush.close_attempts == 1,
++                "write-flush-close forgot a confirmed write before flush "
++                "failure");
++    }
++    for (const auto close_action :
++         {FaultAction::Error, FaultAction::InterruptedOnce,
++          FaultAction::EffectThenError}) {
++        const auto failed_close =
++            probe_write_flush_close(bytes, {}, {}, {close_action});
++        require(failed_close.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    failed_close.bytes == bytes &&
++                    failed_close.write_attempts == 1 &&
++                    failed_close.flush_attempts == 1 &&
++                    failed_close.close_attempts == 1,
++                "write-flush-close retried close or forgot prior progress");
++    }
++    for (const auto close_action : {FaultAction::Error}) {
++        const auto failed_before = probe_write_flush_close(
++            bytes, {FaultAction::Error}, {}, {close_action});
++        require(failed_before.result == HelperResultKind::FailedBeforeEffect &&
++                    failed_before.bytes.empty() &&
++                    failed_before.write_attempts == 1 &&
++                    failed_before.close_attempts == 1,
++                "write-flush-close collapsed two pre-effect failures");
++    }
++    const auto close_effect_after_write_failure = probe_write_flush_close(
++        bytes, {FaultAction::Error}, {}, {FaultAction::EffectThenError});
++    require(close_effect_after_write_failure.result ==
++                    HelperResultKind::FailedBeforeEffect &&
++                close_effect_after_write_failure.bytes.empty() &&
++                close_effect_after_write_failure.close_attempts == 1,
++            "write-flush-close changed a pre-effect write failure during "
++            "checked close");
++
++    const auto truncate_success =
++        probe_truncate_flush_close(bytes, 7, {}, {}, {});
++    require(truncate_success.result == HelperResultKind::Succeeded &&
++                truncate_success.bytes == bytes.substr(0, 7) &&
++                truncate_success.write_attempts == 0 &&
++                truncate_success.truncate_attempts == 1 &&
++                truncate_success.flush_attempts == 1 &&
++                truncate_success.close_attempts == 1,
++            "truncate-flush-close changed the all-success path");
++
++    const auto truncate_retried = probe_truncate_flush_close(
++        bytes, 7, {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce},
++        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce}, {});
++    require(truncate_retried.result == HelperResultKind::Succeeded &&
++                truncate_retried.bytes == bytes.substr(0, 7) &&
++                truncate_retried.truncate_attempts == 3 &&
++                truncate_retried.flush_attempts == 3 &&
++                truncate_retried.close_attempts == 1,
++            "truncate-flush-close did not reuse retrying primitives exactly");
++
++    const auto possibly_truncated = probe_truncate_flush_close(
++        bytes, 7, {FaultAction::EffectThenError}, {}, {});
++    require(possibly_truncated.result ==
++                    HelperResultKind::EffectMayHaveOccurred &&
++                possibly_truncated.bytes == bytes.substr(0, 7) &&
++                possibly_truncated.truncate_attempts == 1 &&
++                possibly_truncated.close_attempts == 1,
++            "truncate-flush-close erased a possibly-effectful truncate");
++
++    for (const auto flush_action :
++         {FaultAction::Error, FaultAction::EffectThenError}) {
++        const auto failed_flush =
++            probe_truncate_flush_close(bytes, 7, {}, {flush_action}, {});
++        require(failed_flush.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    failed_flush.bytes == bytes.substr(0, 7) &&
++                    failed_flush.truncate_attempts == 1 &&
++                    failed_flush.flush_attempts == 1 &&
++                    failed_flush.close_attempts == 1,
++                "truncate-flush-close forgot a confirmed truncate before "
++                "flush failure");
++    }
++    for (const auto close_action :
++         {FaultAction::Error, FaultAction::InterruptedOnce,
++          FaultAction::EffectThenError}) {
++        const auto failed_close =
++            probe_truncate_flush_close(bytes, 7, {}, {}, {close_action});
++        require(failed_close.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    failed_close.bytes == bytes.substr(0, 7) &&
++                    failed_close.truncate_attempts == 1 &&
++                    failed_close.flush_attempts == 1 &&
++                    failed_close.close_attempts == 1,
++                "truncate-flush-close retried close or forgot prior effect");
++    }
++    for (const auto close_action : {FaultAction::Error}) {
++        const auto failed_before = probe_truncate_flush_close(
++            bytes, 7, {FaultAction::Error}, {}, {close_action});
++        require(failed_before.result == HelperResultKind::FailedBeforeEffect &&
++                    failed_before.bytes == bytes &&
++                    failed_before.truncate_attempts == 1 &&
++                    failed_before.close_attempts == 1,
++                "truncate-flush-close collapsed two pre-effect failures");
++    }
++    const auto close_effect_after_truncate_failure = probe_truncate_flush_close(
++        bytes, 7, {FaultAction::Error}, {}, {FaultAction::EffectThenError});
++    require(close_effect_after_truncate_failure.result ==
++                    HelperResultKind::FailedBeforeEffect &&
++                close_effect_after_truncate_failure.bytes == bytes &&
++                close_effect_after_truncate_failure.close_attempts == 1,
++            "truncate-flush-close changed a pre-effect truncate failure "
++            "during checked close");
++
++    const auto requests_stay_within_remaining_sentinel =
++        [](const ReadHelperProbeResult &probe, std::size_t max_bytes) {
++            if (probe.requested_bytes.size() != probe.returned_bytes.size()) {
++                return false;
++            }
++            auto retained = std::size_t{0};
++            for (std::size_t index = 0; index < probe.requested_bytes.size();
++                 ++index) {
++                if (retained > max_bytes + 1 ||
++                    probe.requested_bytes[index] > max_bytes + 1 - retained ||
++                    probe.returned_bytes[index] >
++                        probe.requested_bytes[index]) {
++                    return false;
++                }
++                retained += probe.returned_bytes[index];
++            }
++            return retained <= max_bytes + 1;
++        };
++
++    const auto empty_read = probe_read_bounded_close({}, 7, {}, {});
++    require(empty_read.result == HelperResultKind::Succeeded &&
++                empty_read.bytes.empty() && !empty_read.truncated &&
++                empty_read.read_attempts == 1 &&
++                empty_read.close_attempts == 1 &&
++                requests_stay_within_remaining_sentinel(empty_read, 7),
++            "bounded read did not preserve explicit empty EOF");
++
++    const std::string exact_cap_bytes = "1234567";
++    const auto exact_cap = probe_read_bounded_close(exact_cap_bytes, 7, {}, {});
++    require(exact_cap.result == HelperResultKind::Succeeded &&
++                exact_cap.bytes == exact_cap_bytes && !exact_cap.truncated &&
++                exact_cap.read_attempts >= 2 &&
++                !exact_cap.returned_bytes.empty() &&
++                exact_cap.returned_bytes.back() == 0 &&
++                exact_cap.close_attempts == 1 &&
++                requests_stay_within_remaining_sentinel(exact_cap, 7),
++            "bounded read did not confirm exact-cap EOF with a zero read");
++
++    constexpr auto bounded_read_chunk_bytes = std::size_t{64 * 1024};
++    const std::string large_exact_cap_bytes(
++        bounded_read_chunk_bytes * 2 + 17, 'q');
++    const auto large_exact_cap = probe_read_bounded_close(
++        large_exact_cap_bytes, large_exact_cap_bytes.size(), {}, {});
++    require(large_exact_cap.result == HelperResultKind::Succeeded &&
++                large_exact_cap.bytes == large_exact_cap_bytes &&
++                !large_exact_cap.truncated &&
++                large_exact_cap.read_attempts >= 4 &&
++                std::all_of(large_exact_cap.requested_bytes.begin(),
++                            large_exact_cap.requested_bytes.end(),
++                            [&](std::size_t requested) {
++                                return requested <= bounded_read_chunk_bytes;
++                            }) &&
++                large_exact_cap.close_attempts == 1 &&
++                requests_stay_within_remaining_sentinel(
++                    large_exact_cap, large_exact_cap_bytes.size()),
++            "bounded read requested an eager max-sized native allocation");
++
++    for (const auto &over_cap_bytes :
++         {std::string("12345678"), std::string(64, 'z')}) {
++        const auto over_cap =
++            probe_read_bounded_close(over_cap_bytes, 7, {}, {});
++        require(over_cap.result == HelperResultKind::Succeeded &&
++                    over_cap.bytes == over_cap_bytes.substr(0, 7) &&
++                    over_cap.truncated && over_cap.close_attempts == 1 &&
++                    requests_stay_within_remaining_sentinel(over_cap, 7),
++                "bounded read did not cap and classify extra input");
++    }
++
++    const std::string chunked_bytes = "abcdef";
++    const auto chunked = probe_read_bounded_close(chunked_bytes, 10,
++                                                  {FaultAction::ShortWrite,
++                                                   FaultAction::InterruptedOnce,
++                                                   FaultAction::ShortWrite},
++                                                  {});
++    require(chunked.result == HelperResultKind::Succeeded &&
++                chunked.bytes == chunked_bytes && !chunked.truncated &&
++                chunked.read_attempts >= 4 && chunked.close_attempts == 1 &&
++                !chunked.returned_bytes.empty() &&
++                chunked.returned_bytes.back() == 0 &&
++                requests_stay_within_remaining_sentinel(chunked, 10),
++            "bounded read duplicated, skipped, or reset bytes across an "
++            "interruption or skipped zero-count EOF confirmation");
++
++    for (const auto action :
++         {FaultAction::Error, FaultAction::EffectThenError}) {
++        const auto failed_after_progress = probe_read_bounded_close(
++            chunked_bytes, 10, {FaultAction::ShortWrite, action}, {});
++        const auto expected_partial =
++            action == FaultAction::EffectThenError ? chunked_bytes : "abc";
++        require(failed_after_progress.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    failed_after_progress.bytes == expected_partial &&
++                    !failed_after_progress.truncated &&
++                    failed_after_progress.read_attempts == 2 &&
++                    failed_after_progress.close_attempts == 1 &&
++                    requests_stay_within_remaining_sentinel(
++                        failed_after_progress, 10),
++                "bounded read forgot partial progress before terminal read "
++                "failure");
++    }
++
++    const auto zero_progress = probe_read_bounded_close(
++        chunked_bytes, 10, {FaultAction::ZeroProgress}, {});
++    require(zero_progress.result == HelperResultKind::FailedBeforeEffect &&
++                zero_progress.bytes.empty() &&
++                zero_progress.read_attempts == 1 &&
++                zero_progress.close_attempts == 1,
++            "bounded read accepted successful non-EOF zero progress");
++
++    const auto overreported = probe_read_bounded_close(
++        chunked_bytes, 10, {FaultAction::OverreportedWrite}, {});
++    require(overreported.result == HelperResultKind::FailedBeforeEffect &&
++                overreported.bytes.empty() &&
++                overreported.returned_bytes.size() == 1 &&
++                overreported.requested_bytes.size() == 1 &&
++                overreported.returned_bytes.front() >
++                    overreported.requested_bytes.front() &&
++                overreported.close_attempts == 1,
++            "bounded read accepted a chunk larger than its request");
++
++    for (const auto close_action :
++         {FaultAction::Error, FaultAction::InterruptedOnce,
++          FaultAction::EffectThenError}) {
++        const auto close_after_success =
++            probe_read_bounded_close(chunked_bytes, 10, {}, {close_action});
++        require(close_after_success.result ==
++                        HelperResultKind::EffectMayHaveOccurred &&
++                    close_after_success.bytes == chunked_bytes &&
++                    close_after_success.close_attempts == 1,
++                "bounded read retried close or forgot observed bytes");
++    }
++
++    const auto read_and_close_failed = probe_read_bounded_close(
++        chunked_bytes, 10, {FaultAction::Error}, {FaultAction::Error});
++    require(read_and_close_failed.result ==
++                    HelperResultKind::FailedBeforeEffect &&
++                read_and_close_failed.bytes.empty() &&
++                read_and_close_failed.read_attempts == 1 &&
++                read_and_close_failed.close_attempts == 1,
++            "bounded read collapsed two pre-effect failures");
++    const auto effectful_close_after_read_failure =
++        probe_read_bounded_close(chunked_bytes, 10, {FaultAction::Error},
++                                 {FaultAction::EffectThenError});
++    require(effectful_close_after_read_failure.result ==
++                    HelperResultKind::EffectMayHaveOccurred &&
++                effectful_close_after_read_failure.bytes.empty() &&
++                effectful_close_after_read_failure.close_attempts == 1,
++            "possibly-effectful read close did not dominate a read failure");
++}
++
++PublishedJournal create(JournalTestStorage &storage, const Chain &chain,
++                        JournalLimits limits = generous_limits()) {
++    auto journal = storage.make_journal(limits);
++    auto result =
++        journal.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(result, DurableJournalStatus::Published,
++                   "fresh create was not published");
++    require(result.journal->root_bytes() ==
++                chain.genesis_root.canonical_bytes(),
++            "fresh create returned the wrong root");
++    require(result.journal->journal_id() == chain.genesis.journal_id(),
++            "fresh create returned the wrong journal identity");
++    require(result.journal->tip_sequence() == 1,
++            "fresh create returned the wrong sequence");
++    require_storage_released_after_return(
++        storage, "fresh create returned with a live authority handle");
++    return std::move(*result.journal);
++}
++
++PublishedJournal recover(JournalTestStorage &storage, std::string_view floor,
++                         JournalLimits limits = generous_limits(),
++                         const RecoveryOriginVerifier *verifier = nullptr) {
++    auto journal = storage.make_journal(limits);
++    auto result = journal.recover_existing(
++        TrustedReplayFloor::exact_root(std::string(floor)), verifier);
++    require_result(result, DurableJournalStatus::Published,
++                   "valid recovery was rejected");
++    require_storage_released_after_return(
++        storage, "recovery returned with a live authority handle");
++    return std::move(*result.journal);
++}
++
++void require_exact_initial_publication() {
++    const auto chain = make_chain();
++    auto storage = JournalTestStorage::fresh();
++    auto authority = create(storage, chain);
++    const auto snapshot = storage.snapshot();
++    require(snapshot.journal_bytes == frame(chain.genesis),
++            "fresh journal frame bytes drifted");
++    require(snapshot.authority_root_bytes ==
++                chain.genesis_root.canonical_bytes(),
++            "fresh authority-root bytes drifted");
++    require(!snapshot.authority_root_bytes.empty() &&
++                snapshot.authority_root_bytes.back() != '\n',
++            "authority root gained a trailing line terminator");
++    require(snapshot.all_authority_io_under_lock,
++            "authority publication performed I/O outside the full lock");
++    require(snapshot.lock_file_present && snapshot.lock_file_stable,
++            "authority lock was removed, staged, or replaced");
++    require(snapshot.open_handles.empty() && authority.available(),
++            "fresh publication leaked a handle or consumed authority");
++
++    auto initialized_storage = JournalTestStorage::fresh();
++    const auto initialized_before = initialized_storage.snapshot();
++    auto wrong_floor = initialized_storage.make_journal(generous_limits());
++    auto wrong =
++        wrong_floor.create_new(TrustedReplayFloor::exact_root(std::string(
++                                   chain.genesis_root.canonical_bytes())),
++                               chain.genesis);
++    require_result(wrong, DurableJournalStatus::CorruptOrRollback,
++                   "initialized floor authorized create_new");
++    require(initialized_storage.snapshot() == initialized_before,
++            "initialized-floor create_new changed fresh storage");
++
++    storage.reset_observations();
++    const auto duplicate_before = storage.snapshot();
++    auto second = storage.make_journal(generous_limits());
++    auto duplicate =
++        second.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(duplicate, DurableJournalStatus::ConflictBeforeWrite,
++                   "nonfresh namespace did not conflict before write");
++    require(
++        same_persistent_state(storage.snapshot(), duplicate_before) &&
++            storage.attempt_count(FaultOperation::FixedNamespaceInspect) == 1 &&
++            storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++            storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
++            storage.attempt_count(FaultOperation::InitialJournalCreate) == 0 &&
++            storage.attempt_count(FaultOperation::JournalWrite) == 0 &&
++            storage.attempt_count(FaultOperation::RootStageCreate) == 0 &&
++            storage.attempt_count(FaultOperation::RootReplace) == 0 &&
++            !storage.snapshot().authority_mutation_attempted &&
++            storage.snapshot().all_authority_io_under_lock &&
++            storage.snapshot().open_handles.empty() &&
++            storage.attempt_count(FaultOperation::AuthorityLockClose) == 1,
++        "nonfresh create changed storage");
++}
++
++void require_durable_journal_moves() {
++    const auto chain = make_chain();
++    auto constructed_storage = JournalTestStorage::fresh();
++    auto constructed_source =
++        constructed_storage.make_journal(generous_limits());
++    DurableJournal constructed(std::move(constructed_source));
++    auto constructed_result = constructed.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(constructed_result, DurableJournalStatus::Published,
++                   "move-constructed DurableJournal was not operational");
++
++    auto assigned_storage = JournalTestStorage::fresh();
++    auto assigned_source = assigned_storage.make_journal(generous_limits());
++    auto displaced_storage = JournalTestStorage::fresh();
++    auto assigned = displaced_storage.make_journal(generous_limits());
++    assigned = std::move(assigned_source);
++    auto assigned_result =
++        assigned.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(assigned_result, DurableJournalStatus::Published,
++                   "move-assigned DurableJournal was not operational");
++}
++
++void require_explicit_floor_states() {
++    const auto chain = make_chain();
++    for (const auto &floor_bytes : {std::string{}, std::string("{")}) {
++        auto fresh = JournalTestStorage::fresh();
++        const auto fresh_before = fresh.snapshot();
++        auto fresh_journal = fresh.make_journal(generous_limits());
++        auto create_result = fresh_journal.create_new(
++            TrustedReplayFloor::exact_root(floor_bytes), chain.genesis);
++        require_result(create_result, DurableJournalStatus::CorruptOrRollback,
++                       "invalid exact floor authorized fresh create");
++        require(same_persistent_state(fresh.snapshot(), fresh_before) &&
++                    !fresh.snapshot().authority_mutation_attempted,
++                "invalid exact floor mutated fresh storage");
++        require_storage_released_after_return(
++            fresh, "invalid create floor retained an authority handle");
++
++        auto existing = JournalTestStorage::seeded(
++            frame(chain.genesis),
++            std::string(chain.genesis_root.canonical_bytes()));
++        const auto existing_before = existing.snapshot();
++        auto existing_journal = existing.make_journal(generous_limits());
++        auto recover_result = existing_journal.recover_existing(
++            TrustedReplayFloor::exact_root(floor_bytes));
++        require_result(recover_result, DurableJournalStatus::CorruptOrRollback,
++                       "invalid exact floor authorized recovery");
++        require(same_persistent_state(existing.snapshot(), existing_before) &&
++                    !existing.snapshot().authority_mutation_attempted,
++                "invalid exact floor mutated existing storage");
++        require_storage_released_after_return(
++            existing, "invalid recovery floor retained an authority handle");
++    }
++}
++
++void require_fresh_namespace_asymmetry() {
++    const auto chain = make_chain();
++    const std::vector<std::pair<FixedAuthorityChild, std::string>> blockers{
++        {FixedAuthorityChild::Root,
++         std::string(chain.genesis_root.canonical_bytes())},
++        {FixedAuthorityChild::Journal, frame(chain.genesis)},
++        {FixedAuthorityChild::RootStage, "root-stage"},
++        {FixedAuthorityChild::JournalStage, "journal-stage"},
++        {FixedAuthorityChild::Root, ""},
++        {FixedAuthorityChild::Journal, ""},
++    };
++    for (const auto &[child, bytes] : blockers) {
++        auto storage = JournalTestStorage::fresh();
++        storage.overwrite_fixed_child_bytes(child, bytes);
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "incomplete authority namespace was overwritten");
++        const auto after = storage.snapshot();
++        require(authority_files_unchanged(before, after) &&
++                    !after.authority_mutation_attempted &&
++                    after.all_authority_io_under_lock &&
++                    after.open_handles.empty() &&
++                    storage.attempt_count(
++                        FaultOperation::FixedNamespaceInspect) == 1 &&
++                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++                    storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                    storage.attempt_count(
++                        FaultOperation::InitialJournalCreate) == 0 &&
++                    storage.attempt_count(FaultOperation::RootStageCreate) == 0,
++                "blocked create changed incomplete authority storage");
++        require_storage_released_after_return(
++            storage, "incomplete create retained an authority handle");
++    }
++
++    for (const auto &[stage, bytes] :
++         {std::pair{FixedAuthorityChild::RootStage,
++                    std::string("root-stage-with-complete-authority")},
++          std::pair{FixedAuthorityChild::JournalStage,
++                    std::string("journal-stage-with-complete-authority")}}) {
++        auto storage = JournalTestStorage::seeded(
++            frame(chain.genesis),
++            std::string(chain.genesis_root.canonical_bytes()));
++        storage.overwrite_fixed_child_bytes(stage, bytes);
++        storage.reset_observations();
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "stage residue did not override complete-create "
++                       "conflict classification");
++        const auto after = storage.snapshot();
++        require(same_persistent_state(after, before) &&
++                    authority_files_unchanged(before, after) &&
++                    !after.authority_mutation_attempted &&
++                    after.all_authority_io_under_lock &&
++                    after.open_handles.empty() &&
++                    storage.attempt_count(
++                        FaultOperation::FixedNamespaceInspect) == 1 &&
++                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++                    storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                    storage.attempt_count(
++                        FaultOperation::InitialJournalCreate) == 0 &&
++                    storage.attempt_count(FaultOperation::RootStageCreate) == 0,
++                "complete authority with a stage was changed or treated as "
++                "a duplicate");
++        require_storage_released_after_return(
++            storage, "complete-with-stage create retained a handle");
++    }
++
++    auto lock_only = JournalTestStorage::fresh();
++    lock_only.overwrite_fixed_child_bytes(FixedAuthorityChild::Lock, {});
++    static_cast<void>(create(lock_only, chain));
++
++    auto sentinel = JournalTestStorage::fresh();
++    sentinel.seed_untrusted_file("sentinel.bin", "outside-authority");
++    static_cast<void>(create(sentinel, chain));
++    require(sentinel.snapshot().live_file_bytes.at("sentinel.bin") ==
++                    "outside-authority" &&
++                sentinel.snapshot().durable_file_bytes.at("sentinel.bin") ==
++                    "outside-authority",
++            "fresh create changed unrelated sentinel bytes");
++}
++
++void require_unique_authority_moves() {
++    const auto chain = make_chain();
++    auto constructed_storage = JournalTestStorage::fresh();
++    auto constructed_source = create(constructed_storage, chain);
++    PublishedJournal constructed(std::move(constructed_source));
++    require(!constructed_source.available() && constructed.available(),
++            "move construction duplicated or lost authority");
++    constructed_storage.reset_observations();
++    const auto constructed_before = constructed_storage.snapshot();
++    auto moved_from_construction_journal =
++        constructed_storage.make_journal(generous_limits());
++    auto moved_from_construction =
++        moved_from_construction_journal.append_and_publish(
++            std::move(constructed_source), chain.successor);
++    require_result(moved_from_construction,
++                   DurableJournalStatus::CorruptOrRollback,
++                   "move-constructed source retained write authority");
++    require(!constructed_source.available() && constructed.available() &&
++                constructed_storage.snapshot() == constructed_before,
++            "move-constructed source reached authority storage");
++    auto constructed_journal =
++        constructed_storage.make_journal(generous_limits());
++    auto constructed_published = constructed_journal.append_and_publish(
++        std::move(constructed), chain.successor);
++    require_result(constructed_published, DurableJournalStatus::Published,
++                   "move-constructed destination could not publish");
++    require(!constructed.available() &&
++                constructed_published.journal->available(),
++            "move-constructed destination duplicated authority");
++
++    auto compact_storage = JournalTestStorage::fresh();
++    auto compact_source = create(compact_storage, chain);
++    PublishedJournal compact_destination(std::move(compact_source));
++    compact_storage.reset_observations();
++    const auto compact_before = compact_storage.snapshot();
++    auto moved_from_compaction_journal =
++        compact_storage.make_journal(generous_limits());
++    auto moved_from_compaction = moved_from_compaction_journal.compact_physical(
++        std::move(compact_source));
++    require_result(moved_from_compaction,
++                   DurableJournalStatus::CorruptOrRollback,
++                   "move-constructed source retained compaction authority");
++    require(!compact_source.available() && compact_destination.available() &&
++                compact_storage.snapshot() == compact_before,
++            "moved-from compaction reached authority storage");
++    auto compact_destination_journal =
++        compact_storage.make_journal(generous_limits());
++    auto compact_destination_published =
++        compact_destination_journal.append_and_publish(
++            std::move(compact_destination), chain.successor);
++    require_result(compact_destination_published,
++                   DurableJournalStatus::Published,
++                   "compaction move destination could not publish");
++
++    auto assigned_storage = JournalTestStorage::fresh();
++    auto assigned_source = create(assigned_storage, chain);
++    auto displaced_storage = JournalTestStorage::seeded(
++        frame(chain.genesis),
++        std::string(chain.genesis_root.canonical_bytes()));
++    auto assigned =
++        recover(displaced_storage, chain.genesis_root.canonical_bytes());
++    assigned = std::move(assigned_source);
++    require(!assigned_source.available() && assigned.available(),
++            "move assignment duplicated or lost authority");
++    assigned_storage.reset_observations();
++    const auto assigned_before = assigned_storage.snapshot();
++    auto moved_from_assignment_journal =
++        assigned_storage.make_journal(generous_limits());
++    auto moved_from_assignment =
++        moved_from_assignment_journal.append_and_publish(
++            std::move(assigned_source), chain.successor);
++    require_result(moved_from_assignment,
++                   DurableJournalStatus::CorruptOrRollback,
++                   "move-assigned source retained write authority");
++    require(!assigned_source.available() && assigned.available() &&
++                assigned_storage.snapshot() == assigned_before,
++            "move-assigned source reached authority storage");
++
++    auto journal = assigned_storage.make_journal(generous_limits());
++    auto published =
++        journal.append_and_publish(std::move(assigned), chain.successor);
++    require_result(published, DurableJournalStatus::Published,
++                   "move-assigned destination could not publish");
++    require(!assigned.available() && published.journal->available(),
++            "move-assigned destination duplicated authority");
++
++    auto export_storage = JournalTestStorage::fresh();
++    auto export_source = create(export_storage, chain);
++    auto export_displaced_storage = JournalTestStorage::seeded(
++        frame(chain.genesis),
++        std::string(chain.genesis_root.canonical_bytes()));
++    auto export_destination =
++        recover(export_displaced_storage, chain.genesis_root.canonical_bytes());
++    export_destination = std::move(export_source);
++    export_storage.reset_observations();
++    const auto export_before = export_storage.snapshot();
++    auto moved_from_export_journal =
++        export_storage.make_journal(generous_limits());
++    auto moved_from_export =
++        moved_from_export_journal.export_exact_schema_candidate(
++            export_source, supported_journal_schema,
++            JournalQuiescence::Confirmed);
++    require(moved_from_export.status ==
++                    ExactSchemaExportStatus::CorruptOrRollback &&
++                !moved_from_export.exported() &&
++                !moved_from_export.candidate.has_value() &&
++                !export_source.available() && export_destination.available() &&
++                export_storage.snapshot() == export_before,
++            "moved-from export reached authority storage");
++    auto export_destination_journal =
++        export_storage.make_journal(generous_limits());
++    auto export_destination_published =
++        export_destination_journal.append_and_publish(
++            std::move(export_destination), chain.successor);
++    require_result(export_destination_published,
++                   DurableJournalStatus::Published,
++                   "export move destination could not publish");
++}
++
++void require_fixed_paths() {
++    const std::vector<std::string> journal_ids{
++        "../escape",
++        "/absolute",
++        "C:\\root\\journal",
++        "\\\\?\\C:\\device",
++        "CON",
++        "con",
++        "A",
++        "a",
++        "%2e%2e%2fescape",
++        "..\\escape",
++        "aux.txt",
++        "PRN",
++        "COM1",
++        "LPT1",
++        "authority-root.json",
++        "authority.lock",
++        "JOURNAL.JSONL",
++        "\\\\server\\share",
++    };
++    std::optional<std::set<std::string>> expected_paths;
++    for (const auto &journal_id : journal_ids) {
++        const auto chain = make_chain(journal_id);
++        auto storage = JournalTestStorage::fresh();
++        static_cast<void>(create(storage, chain));
++        storage.restart();
++        const auto restarted = storage.snapshot();
++        const auto paths = restarted.relative_paths;
++        require(paths.count("journal.jsonl") == 1 &&
++                    paths.count("authority-root.json") == 1 &&
++                    paths.count("authority.lock") == 1,
++                "fixed authority filenames were absent");
++        require(std::all_of(paths.begin(), paths.end(),
++                            [](const std::string &path) {
++                                return path.find('/') == std::string::npos &&
++                                       path.find('\\') == std::string::npos &&
++                                       path != "." && path != "..";
++                            }),
++                "journal identity influenced a storage path");
++        require(restarted.lock_file_present && restarted.lock_file_stable,
++                "authority lock did not survive unlock and restart unchanged");
++        if (!expected_paths.has_value()) {
++            expected_paths = paths;
++        } else {
++            require(paths == *expected_paths,
++                    "case, encoding, or platform identity changed fixed paths");
++        }
++    }
++}
++
++void require_identifier_boundaries_precede_persistence() {
++    std::vector<std::string> invalid_ids;
++    invalid_ids.emplace_back("journal/\xc3\xa9");
++    invalid_ids.emplace_back("journal/e\xcc\x81");
++    auto embedded_nul = std::string("journal/a");
++    embedded_nul.push_back('\0');
++    embedded_nul.push_back('b');
++    invalid_ids.push_back(std::move(embedded_nul));
++
++    auto untouched = JournalTestStorage::fresh();
++    const auto before = untouched.snapshot();
++    for (auto &journal_id : invalid_ids) {
++        auto rejected = seal_genesis(draft_for(
++            std::move(journal_id), "resident/alpha", ResidentState::Prepared));
++        require(!rejected.accepted() && !rejected.candidate.has_value() &&
++                    rejected.status == JournalStatus::InvalidIdentifier,
++                "non-codec identifier crossed the TASK-019 boundary");
++    }
++    require(untouched.snapshot() == before,
++            "identifier rejection reached persistence");
++}
++
++void require_replay_and_floors() {
++    const auto chain = make_chain();
++    const auto one_frame = frame(chain.genesis);
++    const auto two_frames = one_frame + frame(chain.successor);
++    const auto three_frames = two_frames + frame(chain.third);
++
++    auto exact = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    auto exact_authority =
++        recover(exact, chain.successor_root.canonical_bytes());
++    require(exact_authority.root_bytes() ==
++                chain.successor_root.canonical_bytes(),
++            "exact floor recovered a different root");
++    require(exact.snapshot().root_read_before_journal_read &&
++                exact.snapshot().all_authority_io_under_lock,
++            "recovery did not read root first under the full lock");
++
++    auto descendant = JournalTestStorage::seeded(
++        three_frames, std::string(chain.third_root.canonical_bytes()));
++    auto descendant_authority =
++        recover(descendant, chain.genesis_root.canonical_bytes());
++    require(descendant_authority.root_bytes() ==
++                chain.third_root.canonical_bytes(),
++            "proven descendant floor did not recover the stored root");
++
++    auto regressed = JournalTestStorage::seeded(
++        one_frame, std::string(chain.genesis_root.canonical_bytes()));
++    auto regressed_journal = regressed.make_journal(generous_limits());
++    auto regressed_result =
++        regressed_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.successor_root.canonical_bytes())));
++    require_result(regressed_result, DurableJournalStatus::CorruptOrRollback,
++                   "regressed root passed a newer independent floor");
++    require_storage_released_after_return(
++        regressed, "regressed recovery retained an authority handle");
++
++    auto consistency_only = JournalTestStorage::seeded(
++        one_frame, std::string(chain.genesis_root.canonical_bytes()));
++    auto consistency_authority =
++        recover(consistency_only, chain.genesis_root.canonical_bytes());
++    require(consistency_authority.root_bytes() ==
++                chain.genesis_root.canonical_bytes(),
++            "coherently rolled-back storage and floor lost consistency-only "
++            "recovery");
++
++    auto divergent = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    auto divergent_journal = divergent.make_journal(generous_limits());
++    auto divergent_result =
++        divergent_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.fork_root.canonical_bytes())));
++    require_result(divergent_result, DurableJournalStatus::CorruptOrRollback,
++                   "same-generation fork passed the independent floor");
++    require_storage_released_after_return(
++        divergent, "divergent recovery retained an authority handle");
++
++    auto absent_floor = exact.make_journal(generous_limits());
++    auto absent_result =
++        absent_floor.recover_existing(TrustedReplayFloor::uninitialized());
++    require_result(absent_result, DurableJournalStatus::CorruptOrRollback,
++                   "uninitialized floor authorized existing storage");
++    require_storage_released_after_return(
++        exact, "uninitialized-floor recovery retained an authority handle");
++
++    auto local_rollback = JournalTestStorage::seeded(
++        one_frame, std::string(chain.genesis_root.canonical_bytes()));
++    local_rollback.seed_untrusted_file(
++        "local-floor.json", std::string(chain.genesis_root.canonical_bytes()));
++    auto local_journal = local_rollback.make_journal(generous_limits());
++    auto local_result =
++        local_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.successor_root.canonical_bytes())));
++    require_result(local_result, DurableJournalStatus::CorruptOrRollback,
++                   "local rollback sidecar replaced the independent floor");
++    require_storage_released_after_return(
++        local_rollback, "rollback rejection retained an authority handle");
++
++    auto root_ahead = JournalTestStorage::seeded(
++        one_frame, std::string(chain.successor_root.canonical_bytes()));
++    auto root_ahead_journal = root_ahead.make_journal(generous_limits());
++    auto root_ahead_result =
++        root_ahead_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++    require_result(root_ahead_result, DurableJournalStatus::CorruptOrRollback,
++                   "root ahead of durable journal was authorized");
++    require_storage_released_after_return(
++        root_ahead, "root-ahead rejection retained an authority handle");
++
++    auto missing_root = JournalTestStorage::seeded(one_frame, std::nullopt);
++    auto missing_root_journal = missing_root.make_journal(generous_limits());
++    auto missing_root_result =
++        missing_root_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++    require_result(missing_root_result, DurableJournalStatus::CorruptOrRollback,
++                   "journal bytes without a root implied genesis");
++    require_storage_released_after_return(
++        missing_root, "missing-root rejection retained an authority handle");
++
++    auto committed_truncation = JournalTestStorage::seeded(
++        two_frames.substr(0, two_frames.size() - 1),
++        std::string(chain.successor_root.canonical_bytes()));
++    auto truncation_journal =
++        committed_truncation.make_journal(generous_limits());
++    auto truncation_result =
++        truncation_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++    require_result(truncation_result, DurableJournalStatus::CorruptOrRollback,
++                   "missing committed LF terminator was authorized");
++    require_storage_released_after_return(
++        committed_truncation,
++        "committed-truncation rejection retained an authority handle");
++}
++
++void require_surviving_stage_recovery() {
++    const auto chain = make_chain();
++    const auto old_bytes = frame(chain.genesis);
++    const auto successor_bytes = old_bytes + frame(chain.successor);
++    const auto seed_stages = [](JournalTestStorage &storage) {
++        storage.overwrite_fixed_child_bytes(FixedAuthorityChild::RootStage,
++                                            "surviving-root-stage");
++        storage.overwrite_fixed_child_bytes(FixedAuthorityChild::JournalStage,
++                                            "surviving-journal-stage");
++    };
++
++    for (const auto &[journal_bytes, root_bytes, expected_journal,
++                      expected_root] :
++         {std::tuple{
++              old_bytes, std::string(chain.genesis_root.canonical_bytes()),
++              old_bytes, std::string(chain.genesis_root.canonical_bytes())},
++          std::tuple{successor_bytes,
++                     std::string(chain.genesis_root.canonical_bytes()),
++                     old_bytes,
++                     std::string(chain.genesis_root.canonical_bytes())},
++          std::tuple{successor_bytes,
++                     std::string(chain.successor_root.canonical_bytes()),
++                     successor_bytes,
++                     std::string(chain.successor_root.canonical_bytes())}}) {
++        auto storage = JournalTestStorage::seeded(journal_bytes, root_bytes);
++        seed_stages(storage);
++        const auto before = storage.snapshot();
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        const auto after = storage.snapshot();
++        require(authority.root_bytes() == expected_root &&
++                    after.journal_bytes == expected_journal &&
++                    stage_files_unchanged(before, after) &&
++                    !has_stage_operation(after) && after.journal_durable &&
++                    after.authority_root_durable &&
++                    after.all_authority_io_under_lock,
++                "safe surviving stages influenced or changed recovery");
++    }
++
++    auto append_storage = JournalTestStorage::seeded(
++        old_bytes, std::string(chain.genesis_root.canonical_bytes()));
++    seed_stages(append_storage);
++    const auto append_before = append_storage.snapshot();
++    auto append_authority =
++        recover(append_storage, chain.genesis_root.canonical_bytes());
++    auto append_journal = append_storage.make_journal(generous_limits());
++    auto appended = append_journal.append_and_publish(
++        std::move(append_authority), chain.successor);
++    require_result(appended, DurableJournalStatus::Published,
++                   "root publication could not replace a safe root stage");
++    const auto append_after = append_storage.snapshot();
++    require(
++        append_after.relative_paths.count(".authority-root.json.stage") == 0 &&
++            append_after.durable_paths.count(".authority-root.json.stage") ==
++                0 &&
++            fixed_file_unchanged(append_before, append_after,
++                                 ".journal.jsonl.stage") &&
++            append_after.journal_bytes == successor_bytes &&
++            append_after.authority_root_bytes ==
++                chain.successor_root.canonical_bytes() &&
++            append_after.all_authority_io_under_lock,
++        "root publication broadly cleaned or trusted surviving stages");
++
++    auto compact_storage = JournalTestStorage::seeded(
++        successor_bytes, std::string(chain.successor_root.canonical_bytes()));
++    seed_stages(compact_storage);
++    const auto compact_before = compact_storage.snapshot();
++    auto compact_authority =
++        recover(compact_storage, chain.genesis_root.canonical_bytes());
++    auto compact_journal = compact_storage.make_journal(generous_limits());
++    auto compacted =
++        compact_journal.compact_physical(std::move(compact_authority));
++    require_result(compacted, DurableJournalStatus::Published,
++                   "compaction could not replace a safe journal stage");
++    const auto compact_after = compact_storage.snapshot();
++    require(compact_after.relative_paths.count(".journal.jsonl.stage") == 0 &&
++                compact_after.durable_paths.count(".journal.jsonl.stage") ==
++                    0 &&
++                fixed_file_unchanged(compact_before, compact_after,
++                                     ".authority-root.json.stage") &&
++                compact_after.journal_bytes == successor_bytes &&
++                compact_after.authority_root_bytes ==
++                    chain.successor_root.canonical_bytes() &&
++                compact_after.all_authority_io_under_lock,
++            "compaction broadly cleaned or trusted surviving stages");
++
++    auto root_ahead = JournalTestStorage::seeded(
++        old_bytes, std::string(chain.successor_root.canonical_bytes()));
++    seed_stages(root_ahead);
++    const auto before = root_ahead.snapshot();
++    auto journal = root_ahead.make_journal(generous_limits());
++    auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++        std::string(chain.genesis_root.canonical_bytes())));
++    require_result(result, DurableJournalStatus::CorruptOrRollback,
++                   "root-ahead crash state was authorized by stages");
++    require(same_persistent_state(root_ahead.snapshot(), before) &&
++                !root_ahead.snapshot().authority_mutation_attempted,
++            "root-ahead rejection changed crash-state evidence");
++    require_storage_released_after_return(
++        root_ahead, "staged root-ahead rejection retained a handle");
++}
++
++void require_root_parser_is_task019() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    const auto exact_root = std::string(chain.genesis_root.canonical_bytes());
++    std::vector<std::string> adversaries{
++        exact_root + "\n",
++        exact_root + " ",
++        std::string("\xef\xbb\xbf") + exact_root,
++        "{",
++        std::string(max_journal_input_bytes + 1, 'x'),
++        replace_once(exact_root, "{", "{\"unknown\":0,"),
++        replace_once(exact_root, "{", "{\"schema\":{\"major\":1,\"minor\":0},"),
++        replace_once(exact_root, "\"major\":1", "\"major\":2"),
++        replace_once(exact_root, "\"generation\":1", "\"generation\":2"),
++        replace_once(exact_root, "\"tip_sequence\":1", "\"tip_sequence\":2"),
++        replace_once(exact_root, "\"journal_id\":\"journal/main\"",
++                     "\"journal_id\":\"journal/other\""),
++        replace_once(
++            exact_root, chain.genesis_root.checksum_sha256(),
++            "0000000000000000000000000000000000000000000000000000000000000000"),
++    };
++    for (const auto &root : adversaries) {
++        auto storage = JournalTestStorage::seeded(committed, root);
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.recover_existing(
++            TrustedReplayFloor::exact_root(exact_root));
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "alternate authority-root encoding was accepted");
++        require(same_persistent_state(storage.snapshot(), before) &&
++                    !storage.snapshot().authority_mutation_attempted,
++                "invalid authority root triggered repair or mutation");
++        require_storage_released_after_return(
++            storage, "invalid root rejection retained an authority handle");
++    }
++}
++
++void require_committed_origin_verification() {
++    const auto chain = make_chain();
++    AllowingOriginVerifier allowing;
++    const auto quarantine = make_quarantine_tail(chain);
++    auto history =
++        take_history(begin_history(chain.genesis), "origin genesis failed");
++    history =
++        take_history(advance_history(std::move(history), quarantine, &allowing),
++                     "origin quarantine history failed");
++    const auto root =
++        take_root(seal_authority_root_candidate(history, &chain.genesis_root),
++                  "origin quarantine root failed");
++    const auto bytes = frame(chain.genesis) + frame(quarantine);
++
++    RejectIfCalledVerifier rejecting;
++    for (const RecoveryOriginVerifier *verifier :
++         {static_cast<const RecoveryOriginVerifier *>(nullptr),
++          static_cast<const RecoveryOriginVerifier *>(&rejecting)}) {
++        auto storage = JournalTestStorage::seeded(
++            bytes, std::string(root.canonical_bytes()));
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result =
++            journal.recover_existing(TrustedReplayFloor::exact_root(std::string(
++                                         chain.genesis_root.canonical_bytes())),
++                                     verifier);
++        require_result(
++            result, DurableJournalStatus::CorruptOrRollback,
++            "unavailable origin verification authorized committed history");
++        require(same_persistent_state(storage.snapshot(), before) &&
++                    !storage.snapshot().authority_mutation_attempted,
++                "origin-verification failure changed committed storage");
++        require_storage_released_after_return(
++            storage,
++            "origin-verification rejection retained an authority handle");
++    }
++    require(rejecting.called.load(),
++            "rejecting verifier was not called for committed authority");
++
++    auto accepted =
++        JournalTestStorage::seeded(bytes, std::string(root.canonical_bytes()));
++    auto authority = recover(accepted, chain.genesis_root.canonical_bytes(),
++                             generous_limits(), &allowing);
++    require(authority.root_bytes() == root.canonical_bytes(),
++            "available origin verifier did not authorize committed history");
++}
++
++ParsedJournalRecord make_quarantine_tail(const Chain &chain) {
++    AllowingOriginVerifier verifier;
++    auto history = take_history(begin_history(chain.genesis),
++                                "quarantine-tail genesis failed");
++    return take_record(
++        seal_successor(history,
++                       draft_for(std::string(chain.genesis.journal_id()),
++                                 "resident/alpha", ResidentState::Quarantined),
++                       &verifier),
++        "quarantine tail fixture was rejected");
++}
++
++struct QuarantinedGenesis {
++    ParsedJournalRecord record;
++    AuthorityRootCandidate root;
++};
++
++QuarantinedGenesis make_quarantined_genesis() {
++    AllowingOriginVerifier verifier;
++    auto record = take_record(
++        seal_genesis(draft_for("journal/quarantine", "resident/quarantine",
++                               ResidentState::Quarantined),
++                     &verifier),
++        "quarantined genesis fixture was rejected");
++    auto history = take_history(begin_history(record, &verifier),
++                                "quarantined genesis history was rejected");
++    auto root = take_root(seal_authority_root_candidate(history),
++                          "quarantined genesis root was rejected");
++    return {std::move(record), std::move(root)};
++}
++
++void require_origin_verifier_publication_and_lifetime() {
++    const auto chain = make_chain();
++    const auto quarantined_genesis = make_quarantined_genesis();
++
++    RejectIfCalledVerifier create_rejecting;
++    for (const RecoveryOriginVerifier *verifier :
++         {static_cast<const RecoveryOriginVerifier *>(nullptr),
++          static_cast<const RecoveryOriginVerifier *>(&create_rejecting)}) {
++        auto storage = JournalTestStorage::fresh();
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         quarantined_genesis.record, verifier);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "unverified quarantined genesis was published");
++        require(same_persistent_state(storage.snapshot(), before) &&
++                    !storage.snapshot().authority_mutation_attempted,
++                "rejected quarantined genesis changed authority storage");
++        require_storage_released_after_return(
++            storage, "quarantined create rejection retained a handle");
++    }
++    require(create_rejecting.called.load(),
++            "create_new did not invoke the rejecting origin verifier");
++
++    AllowingOriginVerifier allowing;
++    auto created_storage = JournalTestStorage::fresh();
++    auto create_journal = created_storage.make_journal(generous_limits());
++    auto created =
++        create_journal.create_new(TrustedReplayFloor::uninitialized(),
++                                  quarantined_genesis.record, &allowing);
++    require_result(created, DurableJournalStatus::Published,
++                   "verified quarantined genesis was not published");
++    created_storage.restart();
++    auto missing_recovery =
++        created_storage.make_journal(generous_limits())
++            .recover_existing(TrustedReplayFloor::exact_root(
++                std::string(quarantined_genesis.root.canonical_bytes())));
++    require_result(missing_recovery, DurableJournalStatus::CorruptOrRollback,
++                   "quarantined genesis recovery skipped reverification");
++    require_storage_released_after_return(
++        created_storage,
++        "quarantined recovery rejection retained an authority handle");
++    static_cast<void>(recover(created_storage,
++                              quarantined_genesis.root.canonical_bytes(),
++                              generous_limits(), &allowing));
++
++    const auto prove_existing_quarantine_does_not_borrow =
++        [](JournalTestStorage &storage,
++           std::optional<PublishedJournal> authority,
++           const std::shared_ptr<VerifierLifetimeState> &state,
++           std::size_t validated_calls, std::string_view label) {
++            require(authority.has_value() && authority->available() &&
++                        !state->alive.load() && validated_calls != 0,
++                    label);
++            auto compact_journal = storage.make_journal(generous_limits());
++            auto compacted =
++                compact_journal.compact_physical(std::move(*authority));
++            require_result(compacted, DurableJournalStatus::Published, label);
++            auto export_journal = storage.make_journal(generous_limits());
++            auto exported = export_journal.export_exact_schema_candidate(
++                *compacted.journal, supported_journal_schema,
++                JournalQuiescence::Confirmed);
++            require(exported.exported() && exported.candidate.has_value() &&
++                        state->calls.load() == validated_calls,
++                    label);
++        };
++
++    auto create_lifetime_storage = JournalTestStorage::fresh();
++    auto create_lifetime_state = std::make_shared<VerifierLifetimeState>();
++    std::optional<PublishedJournal> create_lifetime_authority;
++    std::size_t create_lifetime_calls = 0;
++    {
++        LifetimeAllowingVerifier verifier(create_lifetime_state);
++        auto journal = create_lifetime_storage.make_journal(generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         quarantined_genesis.record, &verifier);
++        require_result(result, DurableJournalStatus::Published,
++                       "scoped verifier create was rejected");
++        create_lifetime_authority.emplace(std::move(*result.journal));
++        create_lifetime_calls = create_lifetime_state->calls.load();
++    }
++    prove_existing_quarantine_does_not_borrow(
++        create_lifetime_storage, std::move(create_lifetime_authority),
++        create_lifetime_state, create_lifetime_calls,
++        "create token retained a borrowed origin verifier");
++
++    auto recover_lifetime_storage = JournalTestStorage::seeded(
++        frame(quarantined_genesis.record),
++        std::string(quarantined_genesis.root.canonical_bytes()));
++    auto recover_lifetime_state = std::make_shared<VerifierLifetimeState>();
++    std::optional<PublishedJournal> recover_lifetime_authority;
++    std::size_t recover_lifetime_calls = 0;
++    {
++        LifetimeAllowingVerifier verifier(recover_lifetime_state);
++        auto journal = recover_lifetime_storage.make_journal(generous_limits());
++        auto result = journal.recover_existing(
++            TrustedReplayFloor::exact_root(
++                std::string(quarantined_genesis.root.canonical_bytes())),
++            &verifier);
++        require_result(result, DurableJournalStatus::Published,
++                       "scoped verifier recovery was rejected");
++        recover_lifetime_authority.emplace(std::move(*result.journal));
++        recover_lifetime_calls = recover_lifetime_state->calls.load();
++    }
++    prove_existing_quarantine_does_not_borrow(
++        recover_lifetime_storage, std::move(recover_lifetime_authority),
++        recover_lifetime_state, recover_lifetime_calls,
++        "recovery token retained a borrowed origin verifier");
++
++    const auto quarantine = make_quarantine_tail(chain);
++    RejectIfCalledVerifier append_rejecting;
++    for (const RecoveryOriginVerifier *verifier :
++         {static_cast<const RecoveryOriginVerifier *>(nullptr),
++          static_cast<const RecoveryOriginVerifier *>(&append_rejecting)}) {
++        auto storage = JournalTestStorage::seeded(
++            frame(chain.genesis),
++            std::string(chain.genesis_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.append_and_publish(std::move(authority),
++                                                 quarantine, verifier);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "unverified quarantined append was published");
++        require(!authority.available() &&
++                    same_persistent_state(storage.snapshot(), before) &&
++                    !storage.snapshot().authority_mutation_attempted,
++                "rejected quarantined append changed authority storage");
++        require_storage_released_after_return(
++            storage, "quarantined append rejection retained a handle");
++    }
++    require(append_rejecting.called.load(),
++            "append did not invoke the rejecting origin verifier");
++
++    auto lifetime_storage = JournalTestStorage::seeded(
++        frame(chain.genesis),
++        std::string(chain.genesis_root.canonical_bytes()));
++    auto lifetime_authority =
++        recover(lifetime_storage, chain.genesis_root.canonical_bytes());
++    auto lifetime_state = std::make_shared<VerifierLifetimeState>();
++    std::optional<PublishedJournal> verified_authority;
++    std::size_t verified_calls = 0;
++    {
++        LifetimeAllowingVerifier lifetime_verifier(lifetime_state);
++        auto journal = lifetime_storage.make_journal(generous_limits());
++        auto result = journal.append_and_publish(
++            std::move(lifetime_authority), quarantine, &lifetime_verifier);
++        require_result(result, DurableJournalStatus::Published,
++                       "verified quarantined append was rejected");
++        verified_authority.emplace(std::move(*result.journal));
++        verified_calls = lifetime_state->calls.load();
++    }
++    require(!lifetime_state->alive.load() && verified_calls != 0,
++            "verifier lifetime fixture did not expire after validation");
++
++    auto compact_journal = lifetime_storage.make_journal(generous_limits());
++    auto compacted =
++        compact_journal.compact_physical(std::move(*verified_authority));
++    require_result(compacted, DurableJournalStatus::Published,
++                   "compaction retained a borrowed verifier dependency");
++    auto export_journal = lifetime_storage.make_journal(generous_limits());
++    auto exported = export_journal.export_exact_schema_candidate(
++        *compacted.journal, supported_journal_schema,
++        JournalQuiescence::Confirmed);
++    require(exported.exported() && exported.candidate.has_value() &&
++                lifetime_state->calls.load() == verified_calls,
++            "compaction or export called a destroyed verifier");
++
++    lifetime_storage.restart();
++    auto recovery_without_verifier =
++        lifetime_storage.make_journal(generous_limits())
++            .recover_existing(TrustedReplayFloor::exact_root(
++                std::string(chain.genesis_root.canonical_bytes())));
++    require_result(recovery_without_verifier,
++                   DurableJournalStatus::CorruptOrRollback,
++                   "quarantined append recovery skipped reverification");
++    require_storage_released_after_return(
++        lifetime_storage,
++        "unverified quarantine recovery retained an authority handle");
++    static_cast<void>(recover(lifetime_storage,
++                              chain.genesis_root.canonical_bytes(),
++                              generous_limits(), &allowing));
++}
++
++void require_tail_classification_and_repair() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    const auto quarantine = make_quarantine_tail(chain);
++    const std::vector<std::string> tolerated_tails{
++        frame(chain.successor),
++        frame(chain.fork),
++        frame(chain.successor) + frame(chain.third),
++        frame(quarantine),
++        frame(chain.successor).substr(0, frame(chain.successor).size() / 2),
++        std::string("garbage\0tail", 12),
++        std::string(max_journal_input_bytes + 1, 'x'),
++        "\r\n\n",
++    };
++
++    for (const auto &tail : tolerated_tails) {
++        auto limits = generous_limits();
++        limits.max_crash_tail_bytes = tail.size();
++        auto storage = JournalTestStorage::seeded(
++            committed + tail,
++            std::string(chain.genesis_root.canonical_bytes()));
++        const auto before = storage.snapshot();
++        RejectIfCalledVerifier verifier;
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes(),
++                                 limits, &verifier);
++        require(authority.root_bytes() == chain.genesis_root.canonical_bytes(),
++                "tail recovery synthesized a root");
++        require(!verifier.called.load(),
++                "replay parsed past the stored authority root");
++        const auto after = storage.snapshot();
++        require(after.journal_bytes == committed &&
++                    after.authority_root_bytes ==
++                        chain.genesis_root.canonical_bytes() &&
++                    after.stage_files_absent &&
++                    after.durable_stage_files_absent &&
++                    !has_stage_operation(after) &&
++                    after.all_authority_io_under_lock,
++                "tail was not durably repaired before authority returned");
++        require(
++            after.journal_durable && after.journal_closed,
++            "tail repair returned before file durability and checked close");
++        require(before.journal_bytes != after.journal_bytes,
++                "tail-repair fixture did not mutate storage");
++    }
++
++    const auto second_resident =
++        make_second_resident(chain, std::string(chain.genesis.journal_id()));
++    for (auto limits : {[] {
++                            auto selected = generous_limits();
++                            selected.max_committed_records = 1;
++                            return selected;
++                        }(),
++                        [] {
++                            auto selected = generous_limits();
++                            selected.max_resident_heads = 1;
++                            return selected;
++                        }()}) {
++        const auto &tail_record = limits.max_committed_records == 1
++                                      ? chain.successor
++                                      : second_resident;
++        const auto tail = frame(tail_record);
++        limits.max_crash_tail_bytes = tail.size();
++        auto storage = JournalTestStorage::seeded(
++            committed + tail,
++            std::string(chain.genesis_root.canonical_bytes()));
++        RejectIfCalledVerifier verifier;
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes(),
++                                 limits, &verifier);
++        require(
++            authority.root_bytes() == chain.genesis_root.canonical_bytes() &&
++                storage.snapshot().journal_bytes == committed &&
++                storage.snapshot().journal_durable &&
++                storage.snapshot().journal_closed && !verifier.called.load(),
++            "valid crash tail was counted against the authorized prefix");
++    }
++
++    const std::vector<std::string> malformed_committed{
++        std::string("\xef\xbb\xbf") + std::string(genesis_wire) + '\n',
++        std::string(genesis_wire) + "\r\n",
++        std::string("\n") + std::string(genesis_wire) + '\n',
++        std::string(genesis_wire),
++    };
++    for (const auto &journal_bytes : malformed_committed) {
++        auto storage = JournalTestStorage::seeded(
++            journal_bytes, std::string(chain.genesis_root.canonical_bytes()));
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "invalid committed LF framing was authorized");
++        require(same_persistent_state(storage.snapshot(), before),
++                "invalid committed LF framing triggered repair or mutation");
++        require(!storage.snapshot().authority_mutation_attempted,
++                "invalid committed LF framing attempted authority mutation");
++        require_storage_released_after_return(
++            storage,
++            "invalid committed LF framing retained an authority handle");
++    }
++}
++
++DurableJournalStatus recovery_status(JournalTestStorage &storage,
++                                     std::string_view floor,
++                                     JournalLimits limits) {
++    auto journal = storage.make_journal(limits);
++    auto result = journal.recover_existing(
++        TrustedReplayFloor::exact_root(std::string(floor)));
++    require(!result.journal.has_value() ||
++                result.status == DurableJournalStatus::Published,
++            "failed recovery carried authority");
++    require_storage_released_after_return(
++        storage, "recovery result retained an authority handle");
++    return result.status;
++}
++
++void require_explicit_limits() {
++    const auto chain = make_chain();
++    const auto one_frame = frame(chain.genesis);
++    const auto two_frames = one_frame + frame(chain.successor);
++
++    for (std::size_t field = 0; field < 4; ++field) {
++        auto limits = generous_limits();
++        if (field == 0) {
++            limits.max_committed_bytes = 0;
++        } else if (field == 1) {
++            limits.max_committed_records = 0;
++        } else if (field == 2) {
++            limits.max_resident_heads = 0;
++        } else {
++            limits.max_crash_tail_bytes = 0;
++        }
++        auto storage = JournalTestStorage::fresh();
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(limits);
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::LimitExceeded,
++                       "zero journal limit did not fail closed");
++        require(storage.snapshot() == before, "zero limit mutated storage");
++
++        auto existing = JournalTestStorage::seeded(
++            one_frame, std::string(chain.genesis_root.canonical_bytes()));
++        const auto existing_before = existing.snapshot();
++        require(recovery_status(existing, chain.genesis_root.canonical_bytes(),
++                                limits) == DurableJournalStatus::LimitExceeded,
++                "zero journal limit was accepted during recovery");
++        require(existing.snapshot() == existing_before,
++                "zero recovery limit changed committed storage");
++    }
++
++    auto byte_exact_limits = generous_limits();
++    byte_exact_limits.max_committed_bytes = two_frames.size();
++    auto byte_exact = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    require(recovery_status(byte_exact, chain.genesis_root.canonical_bytes(),
++                            byte_exact_limits) ==
++                DurableJournalStatus::Published,
++            "inclusive committed-byte limit was rejected");
++    auto byte_over = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    byte_exact_limits.max_committed_bytes = two_frames.size() - 1;
++    const auto byte_over_before = byte_over.snapshot();
++    require(recovery_status(byte_over, chain.genesis_root.canonical_bytes(),
++                            byte_exact_limits) ==
++                DurableJournalStatus::LimitExceeded,
++            "committed-byte limit +1 was accepted");
++    require(same_persistent_state(byte_over.snapshot(), byte_over_before) &&
++                !byte_over.snapshot().authority_mutation_attempted,
++            "committed-byte limit failure changed storage");
++
++    auto record_limits = generous_limits();
++    record_limits.max_committed_records = 2;
++    auto record_exact = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    require(recovery_status(record_exact, chain.genesis_root.canonical_bytes(),
++                            record_limits) == DurableJournalStatus::Published,
++            "inclusive committed-record limit was rejected");
++    auto record_over = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    record_limits.max_committed_records = 1;
++    const auto record_over_before = record_over.snapshot();
++    require(recovery_status(record_over, chain.genesis_root.canonical_bytes(),
++                            record_limits) ==
++                DurableJournalStatus::LimitExceeded,
++            "committed-record limit +1 was accepted");
++    require(same_persistent_state(record_over.snapshot(), record_over_before) &&
++                !record_over.snapshot().authority_mutation_attempted,
++            "committed-record limit failure changed storage");
++
++    const auto beta = make_second_resident(chain, "journal/main");
++    const auto beta_root = root_after(chain, beta);
++    const auto beta_bytes = one_frame + frame(beta);
++    auto head_limits = generous_limits();
++    head_limits.max_resident_heads = 1;
++    auto same_resident = JournalTestStorage::seeded(
++        two_frames, std::string(chain.successor_root.canonical_bytes()));
++    require(recovery_status(same_resident, chain.genesis_root.canonical_bytes(),
++                            head_limits) == DurableJournalStatus::Published,
++            "record count was mistaken for resident-head count");
++    head_limits.max_resident_heads = 2;
++    auto head_exact = JournalTestStorage::seeded(
++        beta_bytes, std::string(beta_root.canonical_bytes()));
++    require(recovery_status(head_exact, chain.genesis_root.canonical_bytes(),
++                            head_limits) == DurableJournalStatus::Published,
++            "inclusive resident-head limit was rejected");
++    auto head_over = JournalTestStorage::seeded(
++        beta_bytes, std::string(beta_root.canonical_bytes()));
++    head_limits.max_resident_heads = 1;
++    const auto head_over_before = head_over.snapshot();
++    require(recovery_status(head_over, chain.genesis_root.canonical_bytes(),
++                            head_limits) == DurableJournalStatus::LimitExceeded,
++            "resident-head limit +1 was accepted");
++    require(same_persistent_state(head_over.snapshot(), head_over_before) &&
++                !head_over.snapshot().authority_mutation_attempted,
++            "resident-head limit failure changed storage");
++
++    const auto tail = frame(chain.successor);
++    auto tail_limits = generous_limits();
++    tail_limits.max_crash_tail_bytes = tail.size();
++    auto tail_exact = JournalTestStorage::seeded(
++        one_frame + tail, std::string(chain.genesis_root.canonical_bytes()));
++    require(recovery_status(tail_exact, chain.genesis_root.canonical_bytes(),
++                            tail_limits) == DurableJournalStatus::Published,
++            "inclusive crash-tail limit was rejected");
++    auto tail_over = JournalTestStorage::seeded(
++        one_frame + tail, std::string(chain.genesis_root.canonical_bytes()));
++    tail_limits.max_crash_tail_bytes = tail.size() - 1;
++    const auto tail_over_before = tail_over.snapshot();
++    require(recovery_status(tail_over, chain.genesis_root.canonical_bytes(),
++                            tail_limits) == DurableJournalStatus::LimitExceeded,
++            "crash-tail limit +1 was accepted");
++    require(same_persistent_state(tail_over.snapshot(), tail_over_before) &&
++                !tail_over.snapshot().authority_mutation_attempted,
++            "crash-tail limit failure changed storage");
++
++    for (const auto limits :
++         {JournalLimits{std::numeric_limits<std::size_t>::max(), 128, 32, 1},
++          JournalLimits{1, 128, 32, std::numeric_limits<std::size_t>::max()},
++          JournalLimits{std::numeric_limits<std::size_t>::max() - 1, 128, 32,
++                        1},
++          JournalLimits{1, 128, 32,
++                        std::numeric_limits<std::size_t>::max() - 1},
++          JournalLimits{std::numeric_limits<std::size_t>::max(), 128, 32,
++                        std::numeric_limits<std::size_t>::max()}}) {
++        auto overflow = JournalTestStorage::seeded(
++            one_frame, std::string(chain.genesis_root.canonical_bytes()));
++        overflow.reset_observations();
++        const auto before = overflow.snapshot();
++        require(recovery_status(overflow, chain.genesis_root.canonical_bytes(),
++                                limits) == DurableJournalStatus::LimitExceeded,
++                "overflowing bounded-read arithmetic did not fail closed");
++        require(same_persistent_state(overflow.snapshot(), before) &&
++                    overflow.attempt_count(FaultOperation::RootOpen) == 0 &&
++                    overflow.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                    !overflow.snapshot().authority_mutation_attempted,
++                "overflowing bounds reached storage I/O or mutation");
++    }
++
++    auto nonzero_small = generous_limits();
++    nonzero_small.max_committed_bytes = one_frame.size() - 1;
++    auto small_create = JournalTestStorage::fresh();
++    const auto small_before = small_create.snapshot();
++    auto small_journal = small_create.make_journal(nonzero_small);
++    auto small_result = small_journal.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(small_result, DurableJournalStatus::LimitExceeded,
++                   "nonzero undersized create limit reached publication");
++    require(small_create.snapshot() == small_before,
++            "undersized create limit performed storage I/O");
++
++    const auto require_append_limit = [&](JournalLimits limits,
++                                          const ParsedJournalRecord &candidate,
++                                          std::string_view label) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame, std::string(chain.genesis_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(limits);
++        auto result =
++            journal.append_and_publish(std::move(authority), candidate);
++        require_result(result, DurableJournalStatus::LimitExceeded, label);
++        require(!authority.available() && storage.snapshot() == before &&
++                    !storage.snapshot().authority_mutation_attempted &&
++                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++                    storage.attempt_count(FaultOperation::JournalOpen) == 0,
++                "append limit failure was not write-free");
++    };
++    auto append_bytes = generous_limits();
++    append_bytes.max_committed_bytes = one_frame.size();
++    require_append_limit(append_bytes, chain.successor,
++                         "append exceeded committed-byte limit");
++    auto append_records = generous_limits();
++    append_records.max_committed_records = 1;
++    require_append_limit(append_records, chain.successor,
++                         "append exceeded committed-record limit");
++    auto append_heads = generous_limits();
++    append_heads.max_resident_heads = 1;
++    require_append_limit(append_heads, beta,
++                         "append exceeded resident-head limit");
++
++    const std::vector<std::tuple<std::string, std::string, JournalLimits>>
++        token_limit_cases{
++            {two_frames, std::string(chain.successor_root.canonical_bytes()),
++             JournalLimits{two_frames.size() - 1, 128, 32,
++                           generous_limits().max_crash_tail_bytes}},
++            {two_frames, std::string(chain.successor_root.canonical_bytes()),
++             JournalLimits{generous_limits().max_committed_bytes, 1, 32,
++                           generous_limits().max_crash_tail_bytes}},
++            {beta_bytes, std::string(beta_root.canonical_bytes()),
++             JournalLimits{generous_limits().max_committed_bytes, 128, 1,
++                           generous_limits().max_crash_tail_bytes}},
++        };
++    for (const auto &[bytes, root, limits] : token_limit_cases) {
++        auto compact_storage = JournalTestStorage::seeded(bytes, root);
++        auto compact_authority =
++            recover(compact_storage, chain.genesis_root.canonical_bytes());
++        compact_storage.reset_observations();
++        const auto compact_before = compact_storage.snapshot();
++        auto compact_journal = compact_storage.make_journal(limits);
++        auto compact_result =
++            compact_journal.compact_physical(std::move(compact_authority));
++        require_result(compact_result, DurableJournalStatus::LimitExceeded,
++                       "token limit did not refuse compaction");
++        require(!compact_authority.available() &&
++                    compact_storage.snapshot() == compact_before,
++                "compaction limit reached storage I/O or mutation");
++
++        auto export_storage = JournalTestStorage::seeded(bytes, root);
++        auto export_authority =
++            recover(export_storage, chain.genesis_root.canonical_bytes());
++        export_storage.reset_observations();
++        const auto export_before = export_storage.snapshot();
++        auto export_journal = export_storage.make_journal(limits);
++        auto export_result = export_journal.export_exact_schema_candidate(
++            export_authority, supported_journal_schema,
++            JournalQuiescence::Confirmed);
++        require(export_result.status ==
++                        ExactSchemaExportStatus::LimitExceeded &&
++                    !export_result.exported() &&
++                    !export_result.candidate.has_value() &&
++                    export_authority.available(),
++                "token limit returned an export candidate");
++        require(export_storage.snapshot() == export_before,
++                "export limit reached storage I/O or mutation");
++    }
++}
++
++const std::vector<FaultOperation> pre_authority_operations{
++    FaultOperation::AuthorityLockOpen,
++    FaultOperation::AuthorityLockAcquire,
++    FaultOperation::AuthorityIdentityRead,
++    FaultOperation::PreflightProbe,
++    FaultOperation::PreflightFlushCreate,
++    FaultOperation::PreflightFlushWrite,
++    FaultOperation::PreflightFlushFileFlush,
++    FaultOperation::PreflightFlushClose,
++    FaultOperation::PreflightTruncate,
++    FaultOperation::PreflightTruncateFlush,
++    FaultOperation::PreflightTruncateClose,
++    FaultOperation::PreflightReplaceStageCreate,
++    FaultOperation::PreflightReplaceStageWrite,
++    FaultOperation::PreflightReplaceStageFlush,
++    FaultOperation::PreflightReplaceStageClose,
++    FaultOperation::PreflightReplace,
++    FaultOperation::PreflightNamespaceDurability,
++    FaultOperation::PreflightCleanup,
++    FaultOperation::FixedNamespaceInspect,
++};
++
++const std::vector<FaultOperation> publication_operations = [] {
++    auto operations = pre_authority_operations;
++    operations.insert(operations.end(), {
++                                            FaultOperation::RootOpen,
++                                            FaultOperation::RootRead,
++                                            FaultOperation::RootClose,
++                                            FaultOperation::JournalOpen,
++                                            FaultOperation::JournalRead,
++                                            FaultOperation::JournalReadClose,
++                                            FaultOperation::JournalAppendOpen,
++                                            FaultOperation::JournalWrite,
++                                            FaultOperation::JournalFlush,
++                                            FaultOperation::JournalClose,
++                                            FaultOperation::RootStageCreate,
++                                            FaultOperation::RootStageWrite,
++                                            FaultOperation::RootStageFlush,
++                                            FaultOperation::RootStageClose,
++                                            FaultOperation::RootReplace,
++                                            FaultOperation::NamespaceDurability,
++                                            FaultOperation::AuthorityUnlock,
++                                            FaultOperation::AuthorityLockClose,
++                                        });
++    return operations;
++}();
++
++const std::vector<FaultOperation> creation_operations = [] {
++    auto operations = pre_authority_operations;
++    operations.insert(operations.end(),
++                      {
++                          FaultOperation::RootOpen,
++                          FaultOperation::InitialJournalCreate,
++                          FaultOperation::JournalWrite,
++                          FaultOperation::JournalFlush,
++                          FaultOperation::JournalClose,
++                          FaultOperation::RootStageCreate,
++                          FaultOperation::RootStageWrite,
++                          FaultOperation::RootStageFlush,
++                          FaultOperation::RootStageClose,
++                          FaultOperation::RootReplace,
++                          FaultOperation::NamespaceDurability,
++                          FaultOperation::AuthorityUnlock,
++                          FaultOperation::AuthorityLockClose,
++                      });
++    return operations;
++}();
++
++bool preflight_may_have_effect(FaultOperation operation,
++                               FaultPosition position, FaultAction action) {
++    const auto found = std::find(pre_authority_operations.begin(),
++                                 pre_authority_operations.end(), operation);
++    const auto first = std::find(pre_authority_operations.begin(),
++                                 pre_authority_operations.end(),
++                                 FaultOperation::PreflightProbe);
++    return found >= first && found != pre_authority_operations.end() &&
++           (position == FaultPosition::After ||
++            action == FaultAction::EffectThenError);
++}
++
++void require_operations_in_order(
++    const NamespaceSnapshot &snapshot,
++    std::initializer_list<FaultOperation> operations,
++    std::string_view failure_message) {
++    std::size_t cursor = 0;
++    for (const auto operation : operations) {
++        const auto found = std::find_if(
++            snapshot.observations.begin() + static_cast<std::ptrdiff_t>(cursor),
++            snapshot.observations.end(),
++            [&](const OperationObservation &observation) {
++                return observation.operation == operation &&
++                       observation.lock_held;
++            });
++        require(found != snapshot.observations.end(), failure_message);
++        cursor = static_cast<std::size_t>(
++                     std::distance(snapshot.observations.begin(), found)) +
++                 1;
++    }
++}
++
++void require_durability_ordering() {
++    const auto chain = make_chain();
++
++    auto create_storage = JournalTestStorage::fresh();
++    static_cast<void>(create(create_storage, chain));
++    const auto create_snapshot = create_storage.snapshot();
++    require_operations_in_order(
++        create_snapshot,
++        {FaultOperation::InitialJournalCreate, FaultOperation::JournalWrite,
++         FaultOperation::JournalFlush, FaultOperation::JournalClose,
++         FaultOperation::RootStageCreate, FaultOperation::RootStageWrite,
++         FaultOperation::RootStageFlush, FaultOperation::RootStageClose,
++         FaultOperation::RootReplace, FaultOperation::NamespaceDurability},
++        "create did not durably publish journal before root");
++
++    auto append_storage = JournalTestStorage::seeded(
++        frame(chain.genesis),
++        std::string(chain.genesis_root.canonical_bytes()));
++    auto append_authority =
++        recover(append_storage, chain.genesis_root.canonical_bytes());
++    append_storage.reset_observations();
++    auto append_journal = append_storage.make_journal(generous_limits());
++    auto append_result = append_journal.append_and_publish(
++        std::move(append_authority), chain.successor);
++    require_result(append_result, DurableJournalStatus::Published,
++                   "ordering append was rejected");
++    const auto append_snapshot = append_storage.snapshot();
++    require_operations_in_order(
++        append_snapshot,
++        {FaultOperation::RootOpen, FaultOperation::RootRead,
++         FaultOperation::RootClose, FaultOperation::JournalOpen,
++         FaultOperation::JournalRead, FaultOperation::JournalReadClose,
++         FaultOperation::JournalAppendOpen, FaultOperation::JournalWrite,
++         FaultOperation::JournalFlush, FaultOperation::JournalClose,
++         FaultOperation::RootStageCreate, FaultOperation::RootStageWrite,
++         FaultOperation::RootStageFlush, FaultOperation::RootStageClose,
++         FaultOperation::RootReplace, FaultOperation::NamespaceDurability},
++        "append did not durably publish journal before root");
++
++    auto tail_storage = JournalTestStorage::seeded(
++        frame(chain.genesis) + frame(chain.successor).substr(0, 7),
++        std::string(chain.genesis_root.canonical_bytes()));
++    tail_storage.reset_observations();
++    auto tail_journal = tail_storage.make_journal(generous_limits());
++    auto tail_result =
++        tail_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++    require_result(tail_result, DurableJournalStatus::Published,
++                   "ordering tail repair was rejected");
++    const auto tail_snapshot = tail_storage.snapshot();
++    require_operations_in_order(
++        tail_snapshot,
++        {FaultOperation::RootOpen, FaultOperation::RootRead,
++         FaultOperation::RootClose, FaultOperation::JournalOpen,
++         FaultOperation::JournalRead, FaultOperation::JournalReadClose,
++         FaultOperation::TailRepairOpen, FaultOperation::TailRepairTruncate,
++         FaultOperation::TailRepairFlush, FaultOperation::TailRepairClose},
++        "tail repair did not truncate, flush, and close in place");
++    require(!has_stage_operation(tail_snapshot) &&
++                tail_snapshot.stage_files_absent &&
++                tail_snapshot.durable_stage_files_absent &&
++                tail_snapshot.all_authority_io_under_lock,
++            "tail repair used replacement or namespace durability");
++
++    const auto committed = frame(chain.genesis) + frame(chain.successor);
++    auto compact_storage = JournalTestStorage::seeded(
++        committed, std::string(chain.successor_root.canonical_bytes()));
++    auto compact_authority =
++        recover(compact_storage, chain.successor_root.canonical_bytes());
++    compact_storage.reset_observations();
++    auto compact_journal = compact_storage.make_journal(generous_limits());
++    auto compact_result =
++        compact_journal.compact_physical(std::move(compact_authority));
++    require_result(compact_result, DurableJournalStatus::Published,
++                   "ordering compaction was rejected");
++    const auto compact_snapshot = compact_storage.snapshot();
++    require_operations_in_order(
++        compact_snapshot,
++        {FaultOperation::CompactionStageCreate, FaultOperation::CompactionWrite,
++         FaultOperation::CompactionFlush, FaultOperation::CompactionClose,
++         FaultOperation::CompactionReplace,
++         FaultOperation::CompactionNamespaceDurability},
++        "compaction did not flush and close its stage before replacement");
++}
++
++void require_stage_replacement_swap_is_fail_closed() {
++    const auto chain = make_chain();
++    const auto genesis_root =
++        std::string(chain.genesis_root.canonical_bytes());
++    const auto successor_root =
++        std::string(chain.successor_root.canonical_bytes());
++
++    for (const bool corrupt_content : {false, true}) {
++        auto storage =
++            JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
++        auto authority = recover(storage, genesis_root);
++        storage.reset_observations();
++        storage.pause_after(FaultOperation::RootStageClose);
++        std::optional<DurableJournalResult> result;
++        std::thread publisher([&] {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(journal.append_and_publish(std::move(authority),
++                                                       chain.successor));
++        });
++        require(storage.wait_until_paused(5000),
++                "root replacement did not pause after stage close");
++        const auto swapped_root =
++            corrupt_content ? std::string("swapped-root-stage")
++                            : successor_root;
++        storage.replace_fixed_child_file(FixedAuthorityChild::RootStage,
++                                         swapped_root);
++        storage.release_pause();
++        publisher.join();
++        require(result.has_value(),
++                "root replacement did not return after stage swap");
++        require_result(*result, DurableJournalStatus::RecoveryRequired,
++                       "root stage swap returned publication authority");
++        require(!authority.available() && !result->journal.has_value() &&
++                    storage.snapshot().journal_bytes ==
++                        frame(chain.genesis) + frame(chain.successor) &&
++                    storage.snapshot().authority_root_bytes == swapped_root &&
++                    storage.snapshot().all_authority_io_under_lock,
++                "root stage swap escaped fail-closed publication");
++        require_storage_released_after_return(
++            storage, "root stage swap retained an authority handle");
++
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.recover_existing(
++            TrustedReplayFloor::exact_root(genesis_root));
++        if (corrupt_content) {
++            require_result(recovered, DurableJournalStatus::CorruptOrRollback,
++                           "corrupt swapped root remained authoritative");
++            require_storage_released_after_return(
++                storage, "corrupt swapped-root recovery retained a handle");
++        } else {
++            require_result(recovered, DurableJournalStatus::Published,
++                           "identity-only root swap was not recoverable");
++            auto continuation = storage.make_journal(generous_limits());
++            auto continued = continuation.append_and_publish(
++                std::move(*recovered.journal), chain.third);
++            require_result(continued, DurableJournalStatus::Published,
++                           "identity-only root swap could not continue");
++        }
++    }
++
++    for (const bool corrupt_content : {false, true}) {
++        auto storage =
++            JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
++        auto authority = recover(storage, genesis_root);
++        storage.reset_observations();
++        storage.pause_after(FaultOperation::CompactionClose);
++        std::optional<DurableJournalResult> result;
++        std::thread compactor([&] {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(
++                journal.compact_physical(std::move(authority)));
++        });
++        require(storage.wait_until_paused(5000),
++                "journal replacement did not pause after stage close");
++        const auto swapped_journal =
++            corrupt_content ? std::string("swapped-journal-stage")
++                            : frame(chain.genesis);
++        storage.replace_fixed_child_file(FixedAuthorityChild::JournalStage,
++                                         swapped_journal);
++        storage.release_pause();
++        compactor.join();
++        require(result.has_value(),
++                "journal replacement did not return after stage swap");
++        require_result(*result, DurableJournalStatus::RecoveryRequired,
++                       "journal stage swap returned publication authority");
++        require(!authority.available() && !result->journal.has_value() &&
++                    storage.snapshot().journal_bytes == swapped_journal &&
++                    storage.snapshot().authority_root_bytes == genesis_root &&
++                    storage.snapshot().all_authority_io_under_lock,
++                "journal stage swap escaped fail-closed publication");
++        require_storage_released_after_return(
++            storage, "journal stage swap retained an authority handle");
++
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.recover_existing(
++            TrustedReplayFloor::exact_root(genesis_root));
++        if (corrupt_content) {
++            require_result(recovered, DurableJournalStatus::CorruptOrRollback,
++                           "corrupt swapped journal remained authoritative");
++            require_storage_released_after_return(
++                storage,
++                "corrupt swapped-journal recovery retained a handle");
++        } else {
++            require_result(recovered, DurableJournalStatus::Published,
++                           "identity-only journal swap was not recoverable");
++            auto continuation = storage.make_journal(generous_limits());
++            auto continued = continuation.append_and_publish(
++                std::move(*recovered.journal), chain.successor);
++            require_result(continued, DurableJournalStatus::Published,
++                           "identity-only journal swap could not continue");
++        }
++    }
++}
++
++void require_paused_read_replacement_is_fail_closed() {
++    const auto chain = make_chain();
++    const auto genesis_root =
++        std::string(chain.genesis_root.canonical_bytes());
++    auto storage =
++        JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
++    storage.pause_after(FaultOperation::JournalRead);
++    std::optional<DurableJournalResult> result;
++    bool threw = false;
++    std::thread recoverer([&] {
++        try {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(journal.recover_existing(
++                TrustedReplayFloor::exact_root(genesis_root)));
++        } catch (...) {
++            threw = true;
++        }
++    });
++    require(storage.wait_until_paused(5000),
++            "recovery did not pause during its journal read");
++    storage.replace_fixed_child_file(FixedAuthorityChild::Journal, "x");
++    storage.release_pause();
++    recoverer.join();
++    require(!threw, "paused journal read used stale mutable storage");
++    require(result.has_value(), "paused journal read did not return");
++    require_result(*result, DurableJournalStatus::RecoveryRequired,
++                   "journal replacement during a read did not fail closed");
++    require_storage_released_after_return(
++        storage, "paused journal read retained an authority handle");
++}
++
++void require_paused_read_holds_authority_lock() {
++    const auto chain = make_chain();
++    const auto genesis_root =
++        std::string(chain.genesis_root.canonical_bytes());
++    auto storage =
++        JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
++    storage.pause_after(FaultOperation::JournalRead);
++    std::optional<DurableJournalResult> holder_result;
++    std::optional<DurableJournalResult> waiter_result;
++    std::thread holder([&] {
++        auto journal = storage.make_journal(generous_limits());
++        holder_result.emplace(journal.recover_existing(
++            TrustedReplayFloor::exact_root(genesis_root)));
++    });
++    require(storage.wait_until_paused(5000),
++            "lock holder did not pause during its journal read");
++    std::thread waiter([&] {
++        auto journal = storage.make_journal(generous_limits());
++        waiter_result.emplace(journal.recover_existing(
++            TrustedReplayFloor::exact_root(genesis_root)));
++    });
++    const auto waiter_blocked = storage.wait_until_lock_waiter(5000);
++    storage.release_pause();
++    holder.join();
++    waiter.join();
++    require(waiter_blocked,
++            "journal read did not retain the stable authority lock");
++    require(holder_result.has_value() && waiter_result.has_value(),
++            "serialized journal readers did not return");
++    require_result(*holder_result, DurableJournalStatus::Published,
++                   "paused journal reader lost publication authority");
++    require_result(*waiter_result, DurableJournalStatus::Published,
++                   "waiting journal reader lost publication authority");
++    require_storage_released_after_return(
++        storage, "serialized journal readers retained an authority handle");
++}
++
++void require_paused_write_observes_completed_effect() {
++    const auto chain = make_chain();
++    const auto genesis_journal = frame(chain.genesis);
++    const auto successor_frame = frame(chain.successor);
++    const auto genesis_root =
++        std::string(chain.genesis_root.canonical_bytes());
++    auto storage = JournalTestStorage::seeded(genesis_journal, genesis_root);
++    auto authority = recover(storage, genesis_root);
++    storage.reset_observations();
++    storage.pause_after(FaultOperation::JournalWrite);
++    std::optional<DurableJournalResult> result;
++    std::thread publisher([&] {
++        auto journal = storage.make_journal(generous_limits());
++        result.emplace(
++            journal.append_and_publish(std::move(authority), chain.successor));
++    });
++    const auto paused = storage.wait_until_paused(5000);
++    if (!paused) {
++        storage.release_pause();
++        publisher.join();
++        require(false, "journal write did not pause after observation");
++    }
++    const auto observed = storage.snapshot();
++    const auto write = std::find_if(
++        observed.observations.begin(), observed.observations.end(),
++        [](const OperationObservation &observation) {
++            return observation.operation == FaultOperation::JournalWrite;
++        });
++    require(write != observed.observations.end() && write->lock_held &&
++                write->mutation_attempted &&
++                write->requested_bytes == successor_frame.size() &&
++                write->transferred_bytes == successor_frame.size() &&
++                observed.journal_bytes == genesis_journal + successor_frame &&
++                observed.authority_root_bytes == genesis_root,
++            "journal write pause preceded its successful observation");
++    storage.release_pause();
++    publisher.join();
++    require(result.has_value(), "paused journal write did not return");
++    require_result(*result, DurableJournalStatus::Published,
++                   "paused journal write did not finish publication");
++    require_storage_released_after_return(
++        storage, "paused journal write retained an authority handle");
++}
++
++void require_fake_adapter_destructor_closes_open_lock() {
++    auto storage = JournalTestStorage::fresh();
++    require(storage.destroy_adapter_with_open_lock(false) &&
++                storage.snapshot().open_handles.empty(),
++            "fake adapter destructor leaked an open lock handle");
++
++    require(storage.destroy_adapter_with_open_lock(true) &&
++                storage.snapshot().open_handles.size() == 1,
++            "simulated crash incorrectly closed the fake lock handle");
++    storage.restart();
++    require(storage.snapshot().open_handles.empty(),
++            "restart retained a simulated-crash lock handle");
++}
++
++void require_final_under_lock_revalidation() {
++    const auto chain = make_chain();
++    const auto genesis_journal = frame(chain.genesis);
++    const auto successor_journal = genesis_journal + frame(chain.successor);
++    const auto genesis_root =
++        std::string(chain.genesis_root.canonical_bytes());
++    const auto successor_root =
++        std::string(chain.successor_root.canonical_bytes());
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
++        std::optional<DurableJournalResult> result;
++        std::thread creator([&] {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(journal.create_new(
++                TrustedReplayFloor::uninitialized(), chain.genesis));
++        });
++        require(storage.wait_until_paused(5000),
++                "create did not pause for final authority validation");
++        storage.replace_fixed_child_file(FixedAuthorityChild::Journal,
++                                         "post-create-journal-swap");
++        storage.release_pause();
++        creator.join();
++        require(result.has_value(), "paused create did not return");
++        require_result(*result, DurableJournalStatus::RecoveryRequired,
++                       "create minted authority after a final journal swap");
++        require(!result->journal.has_value() &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityIdentityRead) == 2,
++                "create skipped its final composite authority validation");
++        require_storage_released_after_return(
++            storage, "final create validation retained an authority handle");
++        storage.replace_fixed_child_file(FixedAuthorityChild::Journal,
++                                         genesis_journal);
++        static_cast<void>(recover(storage, genesis_root));
++    }
++
++    {
++        auto storage = JournalTestStorage::seeded(
++            genesis_journal, genesis_root, PlatformContract::Linux);
++        storage.reset_observations();
++        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
++        std::optional<DurableJournalResult> result;
++        std::thread recoverer([&] {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(journal.recover_existing(
++                TrustedReplayFloor::exact_root(genesis_root)));
++        });
++        require(storage.wait_until_paused(5000),
++                "recovery did not pause for final authority validation");
++        const auto old_lock_identity = storage.lock_identity();
++        require(old_lock_identity != 0 && storage.try_unlink_lock_file() &&
++                    storage.try_recreate_lock_file() &&
++                    storage.lock_identity() != old_lock_identity,
++                "recovery final validation fixture did not replace the lock");
++        storage.release_pause();
++        recoverer.join();
++        require(result.has_value(), "paused recovery did not return");
++        require_result(*result, DurableJournalStatus::RecoveryRequired,
++                       "recovery minted authority after final lock replacement");
++        require(!result->journal.has_value() &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityIdentityRead) == 2,
++                "recovery skipped its final composite authority validation");
++        require_storage_released_after_return(
++            storage,
++            "final recovery validation retained an authority handle");
++        static_cast<void>(recover(storage, genesis_root));
++    }
++
++    {
++        auto storage =
++            JournalTestStorage::seeded(genesis_journal, genesis_root);
++        auto authority = recover(storage, genesis_root);
++        storage.reset_observations();
++        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
++        std::optional<DurableJournalResult> result;
++        std::thread publisher([&] {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(journal.append_and_publish(std::move(authority),
++                                                       chain.successor));
++        });
++        require(storage.wait_until_paused(5000),
++                "append did not pause for final authority validation");
++        storage.replace_fixed_child_file(FixedAuthorityChild::Root,
++                                         "post-append-root-swap");
++        storage.release_pause();
++        publisher.join();
++        require(result.has_value(), "paused append did not return");
++        require_result(*result, DurableJournalStatus::RecoveryRequired,
++                       "append minted authority after a final root swap");
++        require(!authority.available() && !result->journal.has_value() &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityIdentityRead) == 2,
++                "append skipped its final composite authority validation");
++        require_storage_released_after_return(
++            storage, "final append validation retained an authority handle");
++        storage.replace_fixed_child_file(FixedAuthorityChild::Root,
++                                         successor_root);
++        static_cast<void>(recover(storage, successor_root));
++    }
++
++    {
++        auto storage =
++            JournalTestStorage::seeded(successor_journal, successor_root);
++        auto authority = recover(storage, successor_root);
++        storage.reset_observations();
++        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
++        std::optional<DurableJournalResult> result;
++        std::thread compactor([&] {
++            auto journal = storage.make_journal(generous_limits());
++            result.emplace(journal.compact_physical(std::move(authority)));
++        });
++        require(storage.wait_until_paused(5000),
++                "compaction did not pause for final authority validation");
++        storage.replace_fixed_child_file(FixedAuthorityChild::JournalStage,
++                                         successor_journal);
++        storage.release_pause();
++        compactor.join();
++        require(result.has_value(), "paused compaction did not return");
++        require_result(
++            *result, DurableJournalStatus::RecoveryRequired,
++            "compaction minted authority after final stage replacement");
++        require(!authority.available() && !result->journal.has_value() &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityIdentityRead) == 2,
++                "compaction skipped its final composite authority validation");
++        require_storage_released_after_return(
++            storage,
++            "final compaction validation retained an authority handle");
++        auto recovered = recover(storage, successor_root);
++        auto cleanup = storage.make_journal(generous_limits());
++        auto cleaned = cleanup.compact_physical(std::move(recovered));
++        require_result(cleaned, DurableJournalStatus::Published,
++                       "stage-drift recovery could not continue");
++        require(storage.snapshot().stage_files_absent,
++                "stage-drift continuation did not consume its stage");
++    }
++}
++
++void require_preflight_and_bounded_read_trace() {
++    const auto chain = make_chain();
++    const auto limits = generous_limits();
++    auto storage = JournalTestStorage::seeded(
++        frame(chain.genesis),
++        std::string(chain.genesis_root.canonical_bytes()));
++    storage.reset_observations();
++    auto journal = storage.make_journal(limits);
++    auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++        std::string(chain.genesis_root.canonical_bytes())));
++    require_result(result, DurableJournalStatus::Published,
++                   "trace recovery was rejected");
++    const auto snapshot = storage.snapshot();
++
++    const std::vector<FaultOperation> ordered_preflight{
++        FaultOperation::PreflightProbe,
++        FaultOperation::PreflightFlushCreate,
++        FaultOperation::PreflightFlushWrite,
++        FaultOperation::PreflightFlushFileFlush,
++        FaultOperation::PreflightFlushClose,
++        FaultOperation::PreflightTruncate,
++        FaultOperation::PreflightTruncateFlush,
++        FaultOperation::PreflightTruncateClose,
++        FaultOperation::PreflightReplaceStageCreate,
++        FaultOperation::PreflightReplaceStageWrite,
++        FaultOperation::PreflightReplaceStageFlush,
++        FaultOperation::PreflightReplaceStageClose,
++        FaultOperation::PreflightReplace,
++        FaultOperation::PreflightNamespaceDurability,
++        FaultOperation::PreflightCleanup,
++    };
++    std::size_t cursor = 0;
++    for (const auto operation : ordered_preflight) {
++        const auto found = std::find_if(
++            snapshot.observations.begin() + static_cast<std::ptrdiff_t>(cursor),
++            snapshot.observations.end(),
++            [&](const OperationObservation &observation) {
++                return observation.operation == operation &&
++                       observation.lock_held;
++            });
++        require(found != snapshot.observations.end(),
++                "preflight primitive was absent or out of order");
++        cursor = static_cast<std::size_t>(
++                     std::distance(snapshot.observations.begin(), found)) +
++                 1;
++    }
++    const auto first_authority_open = std::find_if(
++        snapshot.observations.begin(), snapshot.observations.end(),
++        [](const OperationObservation &observation) {
++            return observation.operation == FaultOperation::RootOpen ||
++                   observation.operation == FaultOperation::JournalOpen;
++        });
++    const auto fixed_namespace_inspection =
++        std::find_if(snapshot.observations.begin(), snapshot.observations.end(),
++                     [](const OperationObservation &observation) {
++                         return observation.operation ==
++                                FaultOperation::FixedNamespaceInspect;
++                     });
++    require(first_authority_open != snapshot.observations.end() &&
++                fixed_namespace_inspection != snapshot.observations.end() &&
++                fixed_namespace_inspection->lock_held &&
++                cursor <= static_cast<std::size_t>(
++                              std::distance(snapshot.observations.begin(),
++                                            fixed_namespace_inspection)) &&
++                fixed_namespace_inspection < first_authority_open,
++            "fixed namespace was not inspected after preflight and before "
++            "authority I/O");
++
++    const auto identity =
++        std::find_if(snapshot.observations.begin(), snapshot.observations.end(),
++                     [](const OperationObservation &observation) {
++                         return observation.operation ==
++                                FaultOperation::AuthorityIdentityRead;
++                     });
++    const auto first_preflight = std::find_if(
++        snapshot.observations.begin(), snapshot.observations.end(),
++        [](const OperationObservation &observation) {
++            return observation.operation == FaultOperation::PreflightProbe;
++        });
++    require(identity != snapshot.observations.end() && identity->lock_held &&
++                first_preflight != snapshot.observations.end() &&
++                identity < first_preflight,
++            "authority identity was not validated under lock before "
++            "preflight");
++
++    const auto root_read = std::find_if(
++        snapshot.observations.begin(), snapshot.observations.end(),
++        [](const OperationObservation &observation) {
++            return observation.operation == FaultOperation::RootRead;
++        });
++    const auto journal_read = std::find_if(
++        snapshot.observations.begin(), snapshot.observations.end(),
++        [](const OperationObservation &observation) {
++            return observation.operation == FaultOperation::JournalRead;
++        });
++    require(root_read != snapshot.observations.end() &&
++                journal_read != snapshot.observations.end() &&
++                root_read < journal_read &&
++                root_read->requested_bytes <= max_journal_input_bytes + 1 &&
++                root_read->requested_bytes >=
++                    chain.genesis_root.canonical_bytes().size() &&
++                journal_read->requested_bytes <=
++                    limits.max_committed_bytes + limits.max_crash_tail_bytes +
++                        1 &&
++                journal_read->requested_bytes >= frame(chain.genesis).size(),
++            "recovery did not use bounded root-first reads");
++    require(
++        storage.attempt_count(FaultOperation::RootClose) == 2 &&
++            storage.attempt_count(FaultOperation::JournalReadClose) == 2 &&
++            storage.attempt_count(FaultOperation::PreflightFlushClose) == 1 &&
++            storage.attempt_count(FaultOperation::PreflightTruncateClose) ==
++                1 &&
++            storage.attempt_count(FaultOperation::PreflightReplaceStageClose) ==
++                1 &&
++            storage.attempt_count(FaultOperation::AuthorityLockClose) == 1 &&
++            snapshot.open_handles.empty() &&
++            !snapshot.authority_mutation_attempted,
++        "bounded recovery did not checked-close each read handle once");
++}
++
++bool creation_may_have_mutated(FaultOperation operation, FaultPosition position,
++                               FaultAction action) {
++    if (preflight_may_have_effect(operation, position, action)) {
++        return true;
++    }
++    if (operation == FaultOperation::InitialJournalCreate) {
++        return position == FaultPosition::After ||
++               action == FaultAction::EffectThenError;
++    }
++    const auto found = std::find(creation_operations.begin(),
++                                 creation_operations.end(), operation);
++    const auto create =
++        std::find(creation_operations.begin(), creation_operations.end(),
++                  FaultOperation::InitialJournalCreate);
++    return found > create;
++}
++
++void require_create_faults() {
++    const auto chain = make_chain();
++    bool observed_journal_close_residue = false;
++    bool observed_root_stage_close_residue = false;
++    for (const auto operation : creation_operations) {
++        for (const auto position :
++             {FaultPosition::Before, FaultPosition::After}) {
++            for (const auto action : {FaultAction::Error, FaultAction::Crash,
++                                      FaultAction::EffectThenError}) {
++                auto storage = JournalTestStorage::fresh();
++                const auto initial = storage.snapshot();
++                storage.arm_fault(operation, position, action);
++                auto journal = storage.make_journal(generous_limits());
++                auto result = journal.create_new(
++                    TrustedReplayFloor::uninitialized(), chain.genesis);
++                const auto expected =
++                    creation_may_have_mutated(operation, position, action)
++                        ? DurableJournalStatus::RecoveryRequired
++                        : DurableJournalStatus::UnsupportedStorage;
++                const auto operation_position =
++                    std::find(creation_operations.begin(),
++                              creation_operations.end(), operation);
++                const auto create_position =
++                    std::find(creation_operations.begin(),
++                              creation_operations.end(),
++                              FaultOperation::InitialJournalCreate);
++                const bool retained_process_fence =
++                    preflight_may_have_effect(operation, position, action) ||
++                    operation_position > create_position ||
++                    (operation_position == create_position &&
++                     (position == FaultPosition::After ||
++                      action == FaultAction::EffectThenError));
++                require_result(
++                    result, expected,
++                    "create fault returned the wrong stable outcome");
++                const auto after_failure = storage.snapshot();
++                if (action != FaultAction::Crash) {
++                    const bool boundary_effect_happened =
++                        position == FaultPosition::After ||
++                        action == FaultAction::EffectThenError;
++                    const auto expected_preflight_close =
++                        [&](FaultOperation open_operation) {
++                            const auto fault =
++                                std::find(creation_operations.begin(),
++                                          creation_operations.end(), operation);
++                            const auto open = std::find(
++                                creation_operations.begin(),
++                                creation_operations.end(), open_operation);
++                            return static_cast<std::size_t>(
++                                fault > open ||
++                                (fault == open && boundary_effect_happened));
++                        };
++                    const auto expected_lock_close = static_cast<std::size_t>(
++                        operation != FaultOperation::AuthorityLockOpen ||
++                        boundary_effect_happened);
++                    require(
++                        after_failure.open_handles.empty() &&
++                            storage.attempt_count(
++                                FaultOperation::AuthorityLockClose) ==
++                                expected_lock_close &&
++                            storage.attempt_count(
++                                FaultOperation::PreflightFlushClose) ==
++                                expected_preflight_close(
++                                    FaultOperation::PreflightFlushCreate) &&
++                            storage.attempt_count(
++                                FaultOperation::PreflightTruncateClose) ==
++                                expected_preflight_close(
++                                    FaultOperation::PreflightTruncate) &&
++                            storage.attempt_count(
++                                FaultOperation::PreflightReplaceStageClose) ==
++                                expected_preflight_close(
++                                    FaultOperation::
++                                        PreflightReplaceStageCreate) &&
++                            storage.attempt_count(
++                                FaultOperation::JournalClose) ==
++                                expected_preflight_close(
++                                    FaultOperation::InitialJournalCreate) &&
++                            storage.attempt_count(
++                                FaultOperation::RootStageClose) ==
++                                expected_preflight_close(
++                                    FaultOperation::RootStageCreate),
++                        "create fault leaked or retried a handle before "
++                        "restart");
++                }
++                if (expected == DurableJournalStatus::UnsupportedStorage) {
++                    require(authority_files_unchanged(initial, after_failure) &&
++                                !after_failure.authority_mutation_attempted,
++                            "pre-authority failure changed authority files");
++                }
++                const auto established_lock_identity = storage.lock_identity();
++                storage.restart();
++                const auto snapshot = storage.snapshot();
++                require(snapshot.authority_root_bytes.empty() ||
++                            snapshot.authority_root_bytes ==
++                                chain.genesis_root.canonical_bytes(),
++                        "failed create exposed a synthesized root");
++                require(snapshot.all_authority_io_under_lock,
++                        "failed create performed authority I/O outside the "
++                        "full lock");
++                if (snapshot.authority_root_bytes ==
++                    chain.genesis_root.canonical_bytes()) {
++                    storage.reset_observations();
++                    auto recovered =
++                        recover(storage, chain.genesis_root.canonical_bytes());
++                    require(recovered.root_bytes() ==
++                                    chain.genesis_root.canonical_bytes() &&
++                                storage.snapshot().journal_bytes ==
++                                    frame(chain.genesis) &&
++                                storage.snapshot().journal_durable &&
++                                storage.snapshot().journal_closed &&
++                                storage.snapshot().stage_files_absent &&
++                                storage.snapshot().durable_stage_files_absent,
++                            "visible genesis root was not exactly recoverable");
++                } else {
++                    const auto has_residue =
++                        snapshot.relative_paths.count("journal.jsonl") != 0 ||
++                        snapshot.relative_paths.count(".journal.jsonl.stage") !=
++                            0 ||
++                        snapshot.relative_paths.count(
++                            ".authority-root.json.stage") != 0 ||
++                        snapshot.durable_file_bytes.count("journal.jsonl") !=
++                            0 ||
++                        snapshot.durable_file_bytes.count(
++                            ".journal.jsonl.stage") != 0 ||
++                        snapshot.durable_file_bytes.count(
++                            ".authority-root.json.stage") != 0;
++                    storage.reset_observations();
++                    const auto fenced_before = storage.snapshot();
++                    auto retry = storage.make_journal(generous_limits());
++                    auto retry_result = retry.create_new(
++                        TrustedReplayFloor::uninitialized(), chain.genesis);
++                    if (has_residue) {
++                        observed_journal_close_residue |=
++                            operation == FaultOperation::JournalClose &&
++                            position == FaultPosition::After &&
++                            action == FaultAction::Crash;
++                        observed_root_stage_close_residue |=
++                            operation == FaultOperation::RootStageClose &&
++                            position == FaultPosition::After &&
++                            action == FaultAction::Crash;
++                        require_result(
++                            retry_result,
++                            retained_process_fence
++                                ? DurableJournalStatus::RecoveryRequired
++                                : DurableJournalStatus::CorruptOrRollback,
++                            "rootless authority residue was not rejected");
++                        const auto after_create_rejection = storage.snapshot();
++                        require(
++                            same_persistent_state(after_create_rejection,
++                                                  fenced_before) &&
++                                !after_create_rejection
++                                     .authority_mutation_attempted,
++                            "rootless create rejection changed crash evidence");
++                        require_storage_released_after_return(
++                            storage,
++                            "rootless create rejection retained a handle");
++                        storage.reset_observations();
++                        const auto before_recovery_rejection =
++                            storage.snapshot();
++                        auto recovery = storage.make_journal(generous_limits());
++                        auto recovery_result = recovery.recover_existing(
++                            TrustedReplayFloor::uninitialized());
++                        require_result(
++                            recovery_result,
++                            DurableJournalStatus::CorruptOrRollback,
++                            "rootless authority residue minted recovery");
++                        const auto after_recovery_rejection =
++                            storage.snapshot();
++                        require(
++                            same_persistent_state(after_recovery_rejection,
++                                                  before_recovery_rejection) &&
++                                !after_recovery_rejection
++                                     .authority_mutation_attempted &&
++                                after_recovery_rejection.authority_root_bytes
++                                    .empty(),
++                            "rootless recovery rejection changed crash "
++                            "evidence");
++                        require_storage_released_after_return(
++                            storage,
++                            "rootless recovery rejection retained a handle");
++                    } else {
++                        require_result(
++                            retry_result, DurableJournalStatus::Published,
++                            "provably empty namespace could not retry create");
++                        const auto retried = storage.snapshot();
++                        require((established_lock_identity == 0 ||
++                                 storage.lock_identity() ==
++                                     established_lock_identity) &&
++                                    retried.relative_paths.count(
++                                        ".durability-probe") == 0 &&
++                                    retried.relative_paths.count(
++                                        ".durability-probe.stage") == 0 &&
++                                    retried.open_handles.empty(),
++                                "create retry changed stable lock or retained "
++                                "preflight residue");
++                    }
++                }
++            }
++        }
++    }
++    require(observed_journal_close_residue && observed_root_stage_close_residue,
++            "create fault matrix did not exercise rootless durable residue");
++}
++
++bool publication_may_have_mutated(FaultOperation operation,
++                                  FaultPosition position, FaultAction action) {
++    if (operation == FaultOperation::JournalWrite) {
++        return position == FaultPosition::After ||
++               action == FaultAction::EffectThenError;
++    }
++    const auto found = std::find(publication_operations.begin(),
++                                 publication_operations.end(), operation);
++    const auto write =
++        std::find(publication_operations.begin(), publication_operations.end(),
++                  FaultOperation::JournalWrite);
++    return found > write;
++}
++
++void require_append_and_fault_recovery() {
++    const auto chain = make_chain();
++    auto baseline = JournalTestStorage::fresh();
++    static_cast<void>(create(baseline, chain));
++
++    auto success = baseline.clone();
++    auto success_authority =
++        recover(success, chain.genesis_root.canonical_bytes());
++    auto success_journal = success.make_journal(generous_limits());
++    auto published = success_journal.append_and_publish(
++        std::move(success_authority), chain.successor);
++    require_result(published, DurableJournalStatus::Published,
++                   "valid append was not published");
++    require(published.journal->root_bytes() ==
++                chain.successor_root.canonical_bytes(),
++            "append published the wrong root");
++    require(success.snapshot().journal_bytes ==
++                    frame(chain.genesis) + frame(chain.successor) &&
++                success.snapshot().authority_root_bytes ==
++                    chain.successor_root.canonical_bytes() &&
++                success.snapshot().open_handles.empty(),
++            "append publication bytes drifted");
++    require(success.snapshot().all_authority_io_under_lock,
++            "append publication performed authority I/O outside the full lock");
++
++    for (const auto operation : publication_operations) {
++        for (const auto position :
++             {FaultPosition::Before, FaultPosition::After}) {
++            for (const auto action : {FaultAction::Error, FaultAction::Crash,
++                                      FaultAction::EffectThenError}) {
++                auto storage = baseline.clone();
++                auto authority =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                auto peer =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                storage.reset_observations();
++                storage.arm_fault(operation, position, action);
++                auto journal = storage.make_journal(generous_limits());
++                auto result = journal.append_and_publish(std::move(authority),
++                                                         chain.successor);
++                const bool authority_may_have_mutated =
++                    publication_may_have_mutated(operation, position, action);
++                const auto expected =
++                    (authority_may_have_mutated || preflight_may_have_effect(
++                                                       operation, position,
++                                                       action))
++                        ? DurableJournalStatus::RecoveryRequired
++                        : DurableJournalStatus::UnsupportedStorage;
++                require_result(
++                    result, expected,
++                    "publication fault returned the wrong stable outcome");
++                require(
++                    !authority.available(),
++                    "publication fault left the consumed handle write-capable");
++                if (action != FaultAction::Crash) {
++                    require_storage_released_after_return(
++                        storage,
++                        "publication fault retained an authority handle");
++                }
++                if (authority_may_have_mutated ||
++                    preflight_may_have_effect(operation, position, action)) {
++                    const auto before_fence = storage.snapshot();
++                    storage.reset_observations();
++                    auto fence = storage.make_journal(generous_limits());
++                    auto fenced = fence.append_and_publish(std::move(peer),
++                                                           chain.successor);
++                    require_result(
++                        fenced, DurableJournalStatus::RecoveryRequired,
++                        "possibly-effectful publication did not fence a "
++                        "pre-fault authority token");
++                    const auto after_fence = storage.snapshot();
++                    require(
++                        !peer.available() &&
++                            same_persistent_state(after_fence, before_fence) &&
++                            !after_fence.authority_mutation_attempted,
++                        "publication fence attempt changed authority");
++                    if (action != FaultAction::Crash) {
++                        require_storage_released_after_return(
++                            storage,
++                            "publication fence retained an authority handle");
++                    }
++                }
++                storage.restart();
++                const auto restart_snapshot = storage.snapshot();
++                storage.reset_observations();
++                auto recovered =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                const bool prior = recovered.root_bytes() ==
++                                   chain.genesis_root.canonical_bytes();
++                const bool successor = recovered.root_bytes() ==
++                                       chain.successor_root.canonical_bytes();
++                require(prior || successor,
++                        "publication crash recovered a synthesized root");
++                const auto recovered_snapshot = storage.snapshot();
++                require(
++                    recovered_snapshot.journal_bytes ==
++                            (prior ? frame(chain.genesis)
++                                   : frame(chain.genesis) +
++                                         frame(chain.successor)) &&
++                        recovered_snapshot.authority_root_bytes ==
++                            (prior ? chain.genesis_root.canonical_bytes()
++                                   : chain.successor_root.canonical_bytes()) &&
++                        stage_files_unchanged(restart_snapshot,
++                                              recovered_snapshot) &&
++                        recovered_snapshot.journal_durable,
++                    "recovery returned before exact fault-state repair was "
++                    "durable");
++                auto continuation = storage.make_journal(generous_limits());
++                auto continued = continuation.append_and_publish(
++                    std::move(recovered),
++                    prior ? chain.successor : chain.third);
++                require_result(
++                    continued, DurableJournalStatus::Published,
++                    "recovered authority could not continue appending");
++            }
++        }
++    }
++}
++
++void require_stale_cas_is_write_free() {
++    const auto chain = make_chain();
++    auto storage = JournalTestStorage::fresh();
++    static_cast<void>(create(storage, chain));
++    auto stale = recover(storage, chain.genesis_root.canonical_bytes());
++    auto stale_compaction =
++        recover(storage, chain.genesis_root.canonical_bytes());
++    auto winner = recover(storage, chain.genesis_root.canonical_bytes());
++    auto winning_journal = storage.make_journal(generous_limits());
++    auto published =
++        winning_journal.append_and_publish(std::move(winner), chain.successor);
++    require_result(published, DurableJournalStatus::Published,
++                   "CAS winner did not publish");
++
++    storage.reset_observations();
++    const auto before = storage.snapshot();
++    auto losing_journal = storage.make_journal(generous_limits());
++    auto conflict =
++        losing_journal.append_and_publish(std::move(stale), chain.successor);
++    require_result(conflict, DurableJournalStatus::ConflictBeforeWrite,
++                   "stale expected root did not conflict before write");
++    const auto after = storage.snapshot();
++    require(!stale.available() &&
++                after.authority_root_bytes == before.authority_root_bytes &&
++                after.journal_bytes == before.journal_bytes &&
++                !after.authority_mutation_attempted,
++            "CAS loser attempted an authority mutation");
++    require(after.root_read_before_journal_read &&
++                after.all_authority_io_under_lock,
++            "CAS comparison did not run root-first under the full lock");
++    require_storage_released_after_return(
++        storage, "stale append retained an authority handle");
++
++    storage.reset_observations();
++    const auto compaction_before = storage.snapshot();
++    auto stale_compaction_journal = storage.make_journal(generous_limits());
++    auto compact_conflict =
++        stale_compaction_journal.compact_physical(std::move(stale_compaction));
++    require_result(compact_conflict, DurableJournalStatus::ConflictBeforeWrite,
++                   "stale authority compacted current storage");
++    const auto compaction_after = storage.snapshot();
++    require(!stale_compaction.available() &&
++                same_persistent_state(compaction_after, compaction_before) &&
++                !compaction_after.authority_mutation_attempted &&
++                compaction_after.all_authority_io_under_lock &&
++                storage.attempt_count(FaultOperation::RootRead) > 0 &&
++                storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                storage.attempt_count(FaultOperation::JournalRead) == 0 &&
++                !has_stage_operation(compaction_after),
++            "stale compaction read or staged beyond the root CAS");
++    require_storage_released_after_return(
++        storage, "stale compaction retained an authority handle");
++
++    for (const auto stage : {FixedAuthorityChild::JournalStage,
++                             FixedAuthorityChild::RootStage}) {
++        auto stage_storage = JournalTestStorage::seeded(
++            frame(chain.genesis),
++            std::string(chain.genesis_root.canonical_bytes()));
++        auto stage_authority =
++            recover(stage_storage, chain.genesis_root.canonical_bytes());
++        stage_storage.overwrite_fixed_child_bytes(
++            stage, stage == FixedAuthorityChild::JournalStage
++                       ? "peer-journal-stage"
++                       : "peer-root-stage");
++        stage_storage.reset_observations();
++        const auto stage_before = stage_storage.snapshot();
++        auto stage_journal = stage_storage.make_journal(generous_limits());
++        auto stage_conflict =
++            stage_journal.compact_physical(std::move(stage_authority));
++        const auto stage_after = stage_storage.snapshot();
++        require_result(stage_conflict,
++                       DurableJournalStatus::RecoveryRequired,
++                       "compaction ignored peer stage-presence drift");
++        require(!stage_authority.available() &&
++                    same_persistent_state(stage_after, stage_before) &&
++                    !stage_after.authority_mutation_attempted &&
++                    stage_after.all_authority_io_under_lock &&
++                    stage_storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++                    stage_storage.attempt_count(FaultOperation::JournalOpen) ==
++                        0 &&
++                    !has_stage_operation(stage_after),
++                "stage-drift compaction read or mutated authority");
++        require_storage_released_after_return(
++            stage_storage, "stage-drift compaction retained an authority handle");
++        auto stage_recovered = recover(
++            stage_storage, chain.genesis_root.canonical_bytes());
++        static_cast<void>(stage_recovered);
++    }
++}
++
++void require_history_invalid_append_is_write_free() {
++    const auto chain = make_chain();
++    const auto other = make_chain("journal/other");
++    const auto wrong_predecessor = take_record(
++        parse_record_candidate(wrong_predecessor_wire),
++        "wrong-predecessor fixture was not independently canonical");
++    const auto illegal_transition = take_record(
++        parse_record_candidate(illegal_transition_wire),
++        "illegal-transition fixture was not independently canonical");
++    for (const ParsedJournalRecord *candidate :
++         {&chain.genesis, &chain.third, &other.successor, &wrong_predecessor,
++          &illegal_transition}) {
++        auto storage = JournalTestStorage::seeded(
++            frame(chain.genesis),
++            std::string(chain.genesis_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        const auto before = storage.snapshot();
++        auto journal = storage.make_journal(generous_limits());
++        auto result =
++            journal.append_and_publish(std::move(authority), *candidate);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "history-invalid canonical append was accepted");
++        require(!authority.available() &&
++                    same_persistent_state(storage.snapshot(), before) &&
++                    !storage.snapshot().authority_mutation_attempted &&
++                    storage.attempt_count(FaultOperation::JournalWrite) == 0,
++                "history-invalid append reached authority mutation");
++        require_storage_released_after_return(
++            storage, "history-invalid append retained an authority handle");
++    }
++}
++
++void require_partial_io_and_interrupt_retries() {
++    const auto chain = make_chain();
++    const auto one_frame = frame(chain.genesis);
++
++    const auto append_fault = [&](FaultOperation operation,
++                                  std::vector<FaultAction> actions,
++                                  std::string_view label) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame, std::string(chain.genesis_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        storage.arm_fault_sequence(operation, FaultPosition::Before,
++                                   std::move(actions));
++        auto journal = storage.make_journal(generous_limits());
++        auto published =
++            journal.append_and_publish(std::move(authority), chain.successor);
++        require_result(published, DurableJournalStatus::Published, label);
++        const auto snapshot = storage.snapshot();
++        require(snapshot.journal_bytes == one_frame + frame(chain.successor) &&
++                    snapshot.authority_root_bytes ==
++                        chain.successor_root.canonical_bytes() &&
++                    snapshot.journal_closed && snapshot.open_handles.empty() &&
++                    storage.attempt_count(operation) > 1,
++                "retried publication did not preserve exact closed bytes");
++        require(storage.attempt_count(FaultOperation::JournalClose) == 1 &&
++                    storage.attempt_count(FaultOperation::RootStageClose) == 1,
++                "publication close was retried or omitted");
++    };
++
++    for (const auto operation :
++         {FaultOperation::JournalWrite, FaultOperation::RootStageWrite}) {
++        append_fault(operation, {FaultAction::ShortWrite},
++                     "short publication write did not complete");
++        append_fault(
++            operation,
++            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce},
++            "interrupted publication write did not retry");
++    }
++    for (const auto operation :
++         {FaultOperation::JournalFlush, FaultOperation::RootStageFlush,
++          FaultOperation::NamespaceDurability}) {
++        append_fault(
++            operation,
++            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce},
++            "interrupted publication durability did not retry");
++    }
++
++    auto lock_storage = JournalTestStorage::seeded(
++        one_frame, std::string(chain.genesis_root.canonical_bytes()));
++    lock_storage.arm_fault_sequence(
++        FaultOperation::AuthorityLockAcquire, FaultPosition::Before,
++        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
++    static_cast<void>(
++        recover(lock_storage, chain.genesis_root.canonical_bytes()));
++    require(lock_storage.attempt_count(FaultOperation::AuthorityLockAcquire) ==
++                3,
++            "interrupted whole-file lock was not retried");
++
++    for (const auto operation : {FaultOperation::TailRepairTruncate,
++                                 FaultOperation::TailRepairFlush}) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame + frame(chain.successor),
++            std::string(chain.genesis_root.canonical_bytes()));
++        storage.arm_fault_sequence(
++            operation, FaultPosition::Before,
++            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
++        static_cast<void>(
++            recover(storage, chain.genesis_root.canonical_bytes()));
++        require(storage.snapshot().journal_bytes == one_frame &&
++                    storage.attempt_count(operation) == 3 &&
++                    storage.attempt_count(FaultOperation::TailRepairClose) == 1,
++                "interrupted tail repair did not retry and close exactly");
++    }
++
++    for (const auto action :
++         {FaultAction::ShortWrite, FaultAction::InterruptedOnce}) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame + frame(chain.successor),
++            std::string(chain.successor_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        storage.arm_fault(FaultOperation::CompactionWrite,
++                          FaultPosition::Before, action);
++        auto journal = storage.make_journal(generous_limits());
++        auto compacted = journal.compact_physical(std::move(authority));
++        require_result(compacted, DurableJournalStatus::Published,
++                       "retryable compaction write did not complete");
++        require(storage.snapshot().journal_bytes ==
++                        one_frame + frame(chain.successor) &&
++                    storage.snapshot().authority_root_bytes ==
++                        chain.successor_root.canonical_bytes() &&
++                    storage.attempt_count(FaultOperation::CompactionWrite) >
++                        1 &&
++                    storage.attempt_count(FaultOperation::CompactionClose) == 1,
++                "compaction retry changed bytes or close discipline");
++    }
++
++    for (const auto operation :
++         {FaultOperation::CompactionFlush,
++          FaultOperation::CompactionNamespaceDurability}) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame + frame(chain.successor),
++            std::string(chain.successor_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        storage.arm_fault_sequence(
++            operation, FaultPosition::Before,
++            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
++        auto journal = storage.make_journal(generous_limits());
++        auto compacted = journal.compact_physical(std::move(authority));
++        require_result(compacted, DurableJournalStatus::Published,
++                       "interrupted compaction durability did not retry");
++        const auto snapshot = storage.snapshot();
++        require(snapshot.journal_bytes == one_frame + frame(chain.successor) &&
++                    snapshot.authority_root_bytes ==
++                        chain.successor_root.canonical_bytes() &&
++                    storage.attempt_count(operation) > 1 &&
++                    storage.attempt_count(FaultOperation::CompactionClose) == 1,
++                "compaction durability retry changed exact closed bytes");
++    }
++
++    const auto require_create_close = [&](FaultOperation operation,
++                                          FaultAction action,
++                                          FaultOperation close_operation) {
++        auto storage = JournalTestStorage::fresh();
++        storage.arm_fault(operation, FaultPosition::Before, action);
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "create close-path fault changed outcome");
++        require(storage.attempt_count(close_operation) == 1 &&
++                    storage.snapshot().open_handles.empty(),
++                "create failure omitted or retried checked close");
++    };
++    require_create_close(FaultOperation::InitialJournalCreate,
++                         FaultAction::EffectThenError,
++                         FaultOperation::JournalClose);
++    require_create_close(FaultOperation::JournalWrite, FaultAction::Error,
++                         FaultOperation::JournalClose);
++    require_create_close(FaultOperation::JournalFlush, FaultAction::Error,
++                         FaultOperation::JournalClose);
++    require_create_close(FaultOperation::JournalClose, FaultAction::Error,
++                         FaultOperation::JournalClose);
++    require_create_close(FaultOperation::RootStageCreate,
++                         FaultAction::EffectThenError,
++                         FaultOperation::RootStageClose);
++    require_create_close(FaultOperation::RootStageWrite, FaultAction::Error,
++                         FaultOperation::RootStageClose);
++    require_create_close(FaultOperation::RootStageFlush, FaultAction::Error,
++                         FaultOperation::RootStageClose);
++    require_create_close(FaultOperation::RootStageClose, FaultAction::Error,
++                         FaultOperation::RootStageClose);
++
++    const auto require_append_close = [&](FaultOperation operation,
++                                          FaultPosition position,
++                                          FaultAction action,
++                                          FaultOperation close_operation,
++                                          DurableJournalStatus expected) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame, std::string(chain.genesis_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        const auto before = storage.snapshot();
++        storage.arm_fault(operation, position, action);
++        auto journal = storage.make_journal(generous_limits());
++        auto result =
++            journal.append_and_publish(std::move(authority), chain.successor);
++        require_result(result, expected,
++                       "publication close-path fault changed outcome");
++        require(!authority.available() &&
++                    storage.attempt_count(close_operation) == 1 &&
++                    storage.snapshot().open_handles.empty(),
++                "publication failure omitted or retried checked close");
++        if (operation == FaultOperation::JournalAppendOpen) {
++            require(
++                same_persistent_state(storage.snapshot(), before) &&
++                    !storage.snapshot().authority_mutation_attempted &&
++                    storage.attempt_count(FaultOperation::JournalWrite) == 0 &&
++                    storage.attempt_count(FaultOperation::RootStageCreate) == 0,
++                "journal-open failure reached publication mutation");
++        }
++    };
++    require_append_close(FaultOperation::JournalAppendOpen,
++                         FaultPosition::Before, FaultAction::EffectThenError,
++                         FaultOperation::JournalClose,
++                         DurableJournalStatus::UnsupportedStorage);
++    require_append_close(FaultOperation::JournalAppendOpen,
++                         FaultPosition::After, FaultAction::Error,
++                         FaultOperation::JournalClose,
++                         DurableJournalStatus::UnsupportedStorage);
++    require_append_close(FaultOperation::JournalWrite, FaultPosition::Before,
++                         FaultAction::Error, FaultOperation::JournalClose,
++                         DurableJournalStatus::UnsupportedStorage);
++    require_append_close(FaultOperation::JournalFlush, FaultPosition::Before,
++                         FaultAction::Error, FaultOperation::JournalClose,
++                         DurableJournalStatus::RecoveryRequired);
++    require_append_close(FaultOperation::JournalClose, FaultPosition::Before,
++                         FaultAction::Error, FaultOperation::JournalClose,
++                         DurableJournalStatus::RecoveryRequired);
++    require_append_close(FaultOperation::RootStageCreate, FaultPosition::Before,
++                         FaultAction::EffectThenError,
++                         FaultOperation::RootStageClose,
++                         DurableJournalStatus::RecoveryRequired);
++    require_append_close(FaultOperation::RootStageWrite, FaultPosition::Before,
++                         FaultAction::Error, FaultOperation::RootStageClose,
++                         DurableJournalStatus::RecoveryRequired);
++    require_append_close(FaultOperation::RootStageFlush, FaultPosition::Before,
++                         FaultAction::Error, FaultOperation::RootStageClose,
++                         DurableJournalStatus::RecoveryRequired);
++    require_append_close(FaultOperation::RootStageClose, FaultPosition::Before,
++                         FaultAction::Error, FaultOperation::RootStageClose,
++                         DurableJournalStatus::RecoveryRequired);
++
++    for (const auto &[position, action] :
++         {std::pair{FaultPosition::Before, FaultAction::EffectThenError},
++          std::pair{FaultPosition::After, FaultAction::Error}}) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame + frame(chain.successor),
++            std::string(chain.genesis_root.canonical_bytes()));
++        storage.reset_observations();
++        const auto before = storage.snapshot();
++        storage.arm_fault(FaultOperation::TailRepairOpen, position, action);
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++        require_result(result, DurableJournalStatus::UnsupportedStorage,
++                       "tail-open close-path fault changed outcome");
++        const auto after = storage.snapshot();
++        require(storage.attempt_count(FaultOperation::TailRepairClose) == 1 &&
++                    storage.attempt_count(FaultOperation::TailRepairTruncate) ==
++                        0 &&
++                    after.open_handles.empty() &&
++                    same_persistent_state(after, before) &&
++                    !after.authority_mutation_attempted,
++                "tail-open failure omitted close or reached truncation");
++    }
++
++    for (const auto &[operation, expected] :
++         {std::pair{FaultOperation::TailRepairTruncate,
++                    DurableJournalStatus::UnsupportedStorage},
++          std::pair{FaultOperation::TailRepairFlush,
++                    DurableJournalStatus::RecoveryRequired},
++          std::pair{FaultOperation::TailRepairClose,
++                    DurableJournalStatus::RecoveryRequired}}) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame + frame(chain.successor),
++            std::string(chain.genesis_root.canonical_bytes()));
++        storage.reset_observations();
++        storage.arm_fault(operation, FaultPosition::Before, FaultAction::Error);
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++        require_result(result, expected,
++                       "tail close-path fault changed outcome");
++        require(storage.attempt_count(FaultOperation::TailRepairClose) == 1 &&
++                    storage.snapshot().open_handles.empty(),
++                "tail repair failure omitted or retried checked close");
++    }
++
++    for (const auto operation :
++         {FaultOperation::CompactionStageCreate,
++          FaultOperation::CompactionWrite, FaultOperation::CompactionFlush,
++          FaultOperation::CompactionClose}) {
++        auto storage = JournalTestStorage::seeded(
++            one_frame + frame(chain.successor),
++            std::string(chain.successor_root.canonical_bytes()));
++        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++        storage.reset_observations();
++        storage.arm_fault(operation, FaultPosition::Before,
++                          operation == FaultOperation::CompactionStageCreate
++                              ? FaultAction::EffectThenError
++                              : FaultAction::Error);
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.compact_physical(std::move(authority));
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "compaction close-path fault changed outcome");
++        require(storage.attempt_count(FaultOperation::CompactionClose) == 1 &&
++                    storage.snapshot().open_handles.empty(),
++                "compaction failure omitted or retried checked close");
++    }
++}
++
++void require_stable_lock_identity() {
++    const auto chain = make_chain();
++    for (const auto platform :
++         {PlatformContract::Linux, PlatformContract::Windows,
++          PlatformContract::MacOS}) {
++        auto storage = JournalTestStorage::seeded(
++            frame(chain.genesis),
++            std::string(chain.genesis_root.canonical_bytes()), platform);
++        storage.pause_after(FaultOperation::AuthorityLockAcquire);
++
++        std::optional<DurableJournalStatus> holder_status;
++        std::optional<DurableJournalStatus> waiter_status;
++        std::thread holder([&] {
++            auto journal = storage.make_journal(generous_limits());
++            holder_status =
++                journal
++                    .recover_existing(TrustedReplayFloor::exact_root(
++                        std::string(chain.genesis_root.canonical_bytes())))
++                    .status;
++        });
++        require(storage.wait_until_paused(5000),
++                "lock holder did not reach the deterministic pause");
++        const auto old_identity = storage.lock_identity();
++
++        std::thread waiter([&] {
++            auto journal = storage.make_journal(generous_limits());
++            waiter_status =
++                journal
++                    .recover_existing(TrustedReplayFloor::exact_root(
++                        std::string(chain.genesis_root.canonical_bytes())))
++                    .status;
++        });
++        const auto deadline =
++            std::chrono::steady_clock::now() + std::chrono::seconds(5);
++        while (storage.attempt_count(FaultOperation::AuthorityLockOpen) < 2) {
++            require(std::chrono::steady_clock::now() < deadline,
++                    "lock waiter did not open the stable entry");
++            std::this_thread::yield();
++        }
++
++        if (platform == PlatformContract::Windows) {
++            require(!storage.try_unlink_lock_file() &&
++                        !storage.try_recreate_lock_file() &&
++                        !storage.try_replace_lock_with_reparse_point(),
++                    "Windows lock handle allowed delete-sharing replacement");
++        } else {
++            require(storage.try_unlink_lock_file() &&
++                        storage.try_recreate_lock_file() &&
++                        storage.lock_identity() != old_identity,
++                    "POSIX lock replacement did not create a new identity");
++        }
++        storage.release_pause();
++        holder.join();
++        waiter.join();
++
++        if (platform == PlatformContract::Windows) {
++            require(holder_status == DurableJournalStatus::Published &&
++                        waiter_status == DurableJournalStatus::Published &&
++                        storage.lock_identity() == old_identity,
++                    "Windows stable lock did not serialize both readers");
++            auto unlocked = JournalTestStorage::fresh(platform);
++            require(unlocked.try_recreate_lock_file() &&
++                        unlocked.try_replace_lock_with_reparse_point(),
++                    "closed Windows lock lacked replacement positive control");
++        } else {
++            const std::multiset<DurableJournalStatus> statuses{*holder_status,
++                                                               *waiter_status};
++            const std::multiset<DurableJournalStatus> expected{
++                DurableJournalStatus::UnsupportedStorage,
++                DurableJournalStatus::UnsupportedStorage};
++            require(statuses == expected,
++                    "POSIX replaced-lock waiters did not fail closed");
++            const auto failed_waiters = storage.snapshot();
++            require(std::none_of(failed_waiters.observations.begin(),
++                                 failed_waiters.observations.end(),
++                                 [](const OperationObservation &observation) {
++                                     return observation.operation ==
++                                                FaultOperation::RootOpen ||
++                                            observation.operation ==
++                                                FaultOperation::RootRead ||
++                                            observation.operation ==
++                                                FaultOperation::JournalOpen ||
++                                            observation.operation ==
++                                                FaultOperation::JournalRead;
++                                 }) &&
++                        failed_waiters.open_handles.empty() &&
++                        !failed_waiters.authority_mutation_attempted,
++                    "replaced-lock waiter reached authority I/O before "
++                    "failing closed");
++            const auto replacement_identity = storage.lock_identity();
++            storage.reset_observations();
++            auto retry = storage.make_journal(generous_limits());
++            auto retried =
++                retry.recover_existing(TrustedReplayFloor::exact_root(
++                    std::string(chain.genesis_root.canonical_bytes())));
++            require_result(retried, DurableJournalStatus::Published,
++                           "stable replacement identity was not recoverable");
++            const auto retry_snapshot = storage.snapshot();
++            require(
++                std::all_of(
++                    retry_snapshot.observations.begin(),
++                    retry_snapshot.observations.end(),
++                    [&](const OperationObservation &observation) {
++                        if (observation.operation ==
++                                FaultOperation::AuthorityIdentityRead ||
++                            observation.operation == FaultOperation::RootOpen ||
++                            observation.operation == FaultOperation::RootRead ||
++                            observation.operation ==
++                                FaultOperation::JournalOpen ||
++                            observation.operation ==
++                                FaultOperation::JournalRead) {
++                            return observation.lock_held &&
++                                   observation.lock_identity ==
++                                       replacement_identity;
++                        }
++                        return true;
++                    }),
++                "new caller used the stale lock identity for authority I/O");
++        }
++        require(storage.snapshot().open_handles.empty() &&
++                    !storage.snapshot().authority_mutation_attempted,
++                "lock replacement leaked a handle or mutated authority");
++    }
++}
++
++void require_fence_epoch_cas_clear() {
++    const auto chain = make_chain();
++    const auto root = std::string(chain.genesis_root.canonical_bytes());
++    auto storage = JournalTestStorage::seeded(frame(chain.genesis), root);
++    auto during_unlock_peer = recover(storage, root);
++    auto after_unlock_peer = recover(storage, root);
++    storage.overwrite_fixed_child_bytes(
++        FixedAuthorityChild::Journal,
++        frame(chain.genesis) + frame(chain.successor));
++
++    storage.reset_observations();
++    storage.arm_fault(FaultOperation::AuthorityUnlock, FaultPosition::After,
++                      FaultAction::Error);
++    storage.pause_after(FaultOperation::AuthorityUnlock);
++    std::optional<DurableJournalResult> repairing_result;
++    std::thread repairing([&] {
++        auto journal = storage.make_journal(generous_limits());
++        repairing_result.emplace(journal.recover_existing(
++            TrustedReplayFloor::exact_root(root)));
++    });
++    require(storage.wait_until_paused(5000),
++            "tail repair did not pause after the unlock effect");
++
++    storage.reset_observations();
++    const auto during_unlock_before = storage.snapshot();
++    auto during_unlock_journal = storage.make_journal(generous_limits());
++    auto blocked_during_unlock = during_unlock_journal.append_and_publish(
++        std::move(during_unlock_peer), chain.successor);
++    const auto during_unlock_after = storage.snapshot();
++    require_result(blocked_during_unlock,
++                   DurableJournalStatus::RecoveryRequired,
++                   "tail repair exposed an unlock-before-fence window");
++    require(!during_unlock_peer.available() &&
++                storage.attempt_count(FaultOperation::AuthorityLockOpen) == 0 &&
++                same_persistent_state(during_unlock_after,
++                                      during_unlock_before) &&
++                !during_unlock_after.authority_mutation_attempted,
++            "tail-repair provisional fence allowed authority I/O");
++
++    storage.release_pause();
++    repairing.join();
++    require(repairing_result.has_value(),
++            "paused tail repair did not return after unlock");
++    require_result(*repairing_result, DurableJournalStatus::RecoveryRequired,
++                   "effectful unlock failure did not retain its fence");
++
++    storage.reset_observations();
++    const auto fenced_before = storage.snapshot();
++    auto blocked_writer = storage.make_journal(generous_limits());
++    auto blocked = blocked_writer.append_and_publish(
++        std::move(after_unlock_peer), chain.successor);
++    const auto fenced_after = storage.snapshot();
++    require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                   "unlock failure did not retain its provisional fence");
++    require(!after_unlock_peer.available() &&
++                storage.attempt_count(FaultOperation::AuthorityLockOpen) == 0 &&
++                same_persistent_state(fenced_after, fenced_before) &&
++                !fenced_after.authority_mutation_attempted,
++            "retained process fence allowed authority I/O or mutation");
++
++    auto recovered = recover(storage, root);
++    auto continuation = storage.make_journal(generous_limits());
++    auto continued = continuation.append_and_publish(std::move(recovered),
++                                                     chain.successor);
++    require_result(continued, DurableJournalStatus::Published,
++                   "locked recovery did not clear the retained process fence");
++
++    auto epoch_storage =
++        JournalTestStorage::seeded(frame(chain.genesis), root);
++    auto before_resume_peer = recover(epoch_storage, root);
++    auto after_resume_peer = recover(epoch_storage, root);
++    epoch_storage.overwrite_fixed_child_bytes(
++        FixedAuthorityChild::Journal,
++        frame(chain.genesis) + frame(chain.successor));
++
++    epoch_storage.reset_observations();
++    epoch_storage.pause_after(FaultOperation::AuthorityUnlock);
++    std::optional<DurableJournalResult> epoch_clearing_result;
++    std::thread epoch_clearing([&] {
++        auto journal = epoch_storage.make_journal(generous_limits());
++        epoch_clearing_result.emplace(journal.recover_existing(
++            TrustedReplayFloor::exact_root(root)));
++    });
++    require(epoch_storage.wait_until_paused(5000),
++            "epoch-clearing recovery did not pause after unlock");
++
++    epoch_storage.overwrite_fixed_child_bytes(
++        FixedAuthorityChild::Journal,
++        frame(chain.genesis) + frame(chain.successor));
++    epoch_storage.arm_fault(FaultOperation::TailRepairTruncate,
++                            FaultPosition::After, FaultAction::Error);
++    auto replacement_journal = epoch_storage.make_journal(generous_limits());
++    auto replacement = replacement_journal.recover_existing(
++        TrustedReplayFloor::exact_root(root));
++    require_result(replacement, DurableJournalStatus::RecoveryRequired,
++                   "effectful tail repair did not publish a replacement epoch");
++
++    epoch_storage.reset_observations();
++    const auto before_resume = epoch_storage.snapshot();
++    auto before_resume_journal =
++        epoch_storage.make_journal(generous_limits());
++    auto blocked_before_resume = before_resume_journal.append_and_publish(
++        std::move(before_resume_peer), chain.successor);
++    const auto after_blocked_before_resume = epoch_storage.snapshot();
++    require_result(blocked_before_resume, DurableJournalStatus::RecoveryRequired,
++                   "replacement epoch did not fence before older recovery");
++    require(!before_resume_peer.available() &&
++                epoch_storage.attempt_count(
++                    FaultOperation::AuthorityLockOpen) == 0 &&
++                same_persistent_state(after_blocked_before_resume,
++                                      before_resume) &&
++                !after_blocked_before_resume.authority_mutation_attempted,
++            "replacement epoch allowed pre-resume authority I/O");
++
++    epoch_storage.release_pause();
++    epoch_clearing.join();
++    require(epoch_clearing_result.has_value() &&
++                epoch_clearing_result->published(),
++            "older epoch recovery did not complete after successful unlock");
++
++    epoch_storage.reset_observations();
++    const auto after_resume = epoch_storage.snapshot();
++    auto after_resume_journal = epoch_storage.make_journal(generous_limits());
++    auto blocked_after_resume = after_resume_journal.append_and_publish(
++        std::move(after_resume_peer), chain.successor);
++    const auto after_blocked_after_resume = epoch_storage.snapshot();
++    require_result(blocked_after_resume, DurableJournalStatus::RecoveryRequired,
++                   "older recovery erased its replacement epoch");
++    require(!after_resume_peer.available() &&
++                epoch_storage.attempt_count(
++                    FaultOperation::AuthorityLockOpen) == 0 &&
++                same_persistent_state(after_blocked_after_resume,
++                                      after_resume) &&
++                !after_blocked_after_resume.authority_mutation_attempted,
++            "replacement epoch allowed post-resume authority I/O");
++
++    auto epoch_recovered = recover(epoch_storage, root);
++    auto epoch_continuation = epoch_storage.make_journal(generous_limits());
++    auto epoch_continued = epoch_continuation.append_and_publish(
++        std::move(epoch_recovered), chain.successor);
++    require_result(epoch_continued, DurableJournalStatus::Published,
++                   "locked recovery did not clear the replacement epoch");
++}
++
++void require_fake_storage_identity_binding() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    const auto root = std::string(chain.genesis_root.canonical_bytes());
++    auto storage_a = JournalTestStorage::seeded(committed, root);
++    auto storage_b = JournalTestStorage::seeded(committed, root);
++
++    auto initialize_a = recover(storage_a, root);
++    auto initialize_b = recover(storage_b, root);
++    static_cast<void>(initialize_a);
++    static_cast<void>(initialize_b);
++    storage_b.alias_lock_identity_from(storage_a);
++
++    auto append_token = recover(storage_a, root);
++    storage_b.reset_observations();
++    const auto append_before = storage_b.snapshot();
++    auto b_append = storage_b.make_journal(generous_limits());
++    auto append_result =
++        b_append.append_and_publish(std::move(append_token), chain.successor);
++    require_result(append_result, DurableJournalStatus::CorruptOrRollback,
++                   "cross-storage append accepted byte-identical authority");
++    require(!append_token.available() &&
++                same_persistent_state(storage_b.snapshot(), append_before) &&
++                !storage_b.snapshot().authority_mutation_attempted &&
++                storage_b.attempt_count(
++                    FaultOperation::AuthorityIdentityRead) == 1 &&
++                storage_b.attempt_count(FaultOperation::RootOpen) == 0 &&
++                storage_b.attempt_count(FaultOperation::RootRead) == 0 &&
++                storage_b.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                storage_b.attempt_count(FaultOperation::JournalRead) == 0 &&
++                storage_b.snapshot().all_authority_io_under_lock,
++            "cross-storage append read or mutated journal authority");
++    require_storage_released_after_return(
++        storage_b, "cross-storage append retained an authority handle");
++
++    auto compact_token = recover(storage_a, root);
++    storage_b.reset_observations();
++    const auto compact_before = storage_b.snapshot();
++    auto b_compact = storage_b.make_journal(generous_limits());
++    auto compact_result = b_compact.compact_physical(std::move(compact_token));
++    require_result(
++        compact_result, DurableJournalStatus::CorruptOrRollback,
++        "cross-storage compaction accepted byte-identical authority");
++    require(!compact_token.available() &&
++                same_persistent_state(storage_b.snapshot(), compact_before) &&
++                !storage_b.snapshot().authority_mutation_attempted &&
++                storage_b.attempt_count(
++                    FaultOperation::AuthorityIdentityRead) == 1 &&
++                storage_b.attempt_count(FaultOperation::RootOpen) == 0 &&
++                storage_b.attempt_count(FaultOperation::RootRead) == 0 &&
++                storage_b.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                storage_b.attempt_count(FaultOperation::JournalRead) == 0 &&
++                storage_b.snapshot().all_authority_io_under_lock,
++            "cross-storage compaction read or mutated journal authority");
++    require_storage_released_after_return(
++        storage_b, "cross-storage compaction retained an authority handle");
++
++    auto export_token = recover(storage_a, root);
++    storage_b.reset_observations();
++    const auto export_before = storage_b.snapshot();
++    auto b_export = storage_b.make_journal(generous_limits());
++    auto export_result = b_export.export_exact_schema_candidate(
++        export_token, supported_journal_schema, JournalQuiescence::Confirmed);
++    require(
++        export_result.status == ExactSchemaExportStatus::CorruptOrRollback &&
++            !export_result.exported() && !export_result.candidate.has_value() &&
++            export_token.available() &&
++            same_persistent_state(storage_b.snapshot(), export_before) &&
++            !storage_b.snapshot().authority_mutation_attempted &&
++            storage_b.attempt_count(FaultOperation::AuthorityIdentityRead) ==
++                1 &&
++            storage_b.attempt_count(FaultOperation::RootOpen) == 0 &&
++            storage_b.attempt_count(FaultOperation::RootRead) == 0 &&
++            storage_b.attempt_count(FaultOperation::JournalOpen) == 0 &&
++            storage_b.attempt_count(FaultOperation::JournalRead) == 0 &&
++            storage_b.snapshot().all_authority_io_under_lock,
++        "cross-storage export authorized or read byte-identical storage");
++    require_storage_released_after_return(
++        storage_b, "cross-storage export retained an authority handle");
++
++    auto same_storage = storage_a.make_journal(generous_limits());
++    auto published = same_storage.append_and_publish(std::move(export_token),
++                                                     chain.successor);
++    require_result(published, DurableJournalStatus::Published,
++                   "fresh adapter for the same storage rejected its token");
++}
++
++void require_fake_lock_recreation_invalidates_authority() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    const auto root = std::string(chain.genesis_root.canonical_bytes());
++
++    const auto replace_lock = [](JournalTestStorage &storage) {
++        const auto old_identity = storage.lock_identity();
++        require(old_identity != 0 && storage.try_unlink_lock_file() &&
++                    storage.try_recreate_lock_file() &&
++                    storage.lock_identity() != 0 &&
++                    storage.lock_identity() != old_identity,
++                "fake stable lock was not recreated with a new identity");
++        storage.reset_observations();
++    };
++    const auto require_rejection_trace = [](JournalTestStorage &storage,
++                                            const NamespaceSnapshot &before,
++                                            std::string_view label) {
++        const auto after = storage.snapshot();
++        require(same_persistent_state(after, before) &&
++                    !after.authority_mutation_attempted &&
++                    after.all_authority_io_under_lock &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityIdentityRead) == 1 &&
++                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++                    storage.attempt_count(FaultOperation::RootRead) == 0 &&
++                    storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                    storage.attempt_count(FaultOperation::JournalRead) == 0,
++                label);
++        require_storage_released_after_return(
++            storage, "recreated-lock rejection retained an authority handle");
++        auto rebound = recover(storage, before.authority_root_bytes);
++        require(rebound.available(),
++                "fresh recovery did not bind the recreated stable lock");
++    };
++
++    auto append_storage = JournalTestStorage::seeded(committed, root);
++    auto append_token = recover(append_storage, root);
++    replace_lock(append_storage);
++    const auto append_before = append_storage.snapshot();
++    auto append_journal = append_storage.make_journal(generous_limits());
++    auto append_result = append_journal.append_and_publish(
++        std::move(append_token), chain.successor);
++    require_result(append_result, DurableJournalStatus::UnsupportedStorage,
++                   "recreated stable lock accepted an old append token");
++    require(!append_token.available(),
++            "recreated-lock append did not consume its token");
++    require_rejection_trace(append_storage, append_before,
++                            "recreated-lock append reached authority I/O");
++
++    auto compact_storage = JournalTestStorage::seeded(committed, root);
++    auto compact_token = recover(compact_storage, root);
++    replace_lock(compact_storage);
++    const auto compact_before = compact_storage.snapshot();
++    auto compact_journal = compact_storage.make_journal(generous_limits());
++    auto compact_result =
++        compact_journal.compact_physical(std::move(compact_token));
++    require_result(compact_result, DurableJournalStatus::UnsupportedStorage,
++                   "recreated stable lock accepted an old compaction token");
++    require(!compact_token.available(),
++            "recreated-lock compaction did not consume its token");
++    require_rejection_trace(compact_storage, compact_before,
++                            "recreated-lock compaction reached authority I/O");
++
++    auto export_storage = JournalTestStorage::seeded(committed, root);
++    auto export_token = recover(export_storage, root);
++    replace_lock(export_storage);
++    const auto export_before = export_storage.snapshot();
++    auto export_journal = export_storage.make_journal(generous_limits());
++    auto export_result = export_journal.export_exact_schema_candidate(
++        export_token, supported_journal_schema, JournalQuiescence::Confirmed);
++    require(
++        export_result.status == ExactSchemaExportStatus::UnsupportedStorage &&
++            !export_result.exported() && !export_result.candidate.has_value() &&
++            export_token.available(),
++        "recreated stable lock accepted or consumed an old export token");
++    require_rejection_trace(export_storage, export_before,
++                            "recreated-lock export reached authority I/O");
++}
++
++void require_directory_lineage_fence_cleanup() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    const auto root = std::string(chain.genesis_root.canonical_bytes());
++    auto storage = JournalTestStorage::seeded(committed, root);
++    auto failing_authority = recover(storage, root);
++    auto stale_authority = recover(storage, root);
++
++    storage.arm_fault(FaultOperation::JournalWrite, FaultPosition::After,
++                      FaultAction::Error);
++    auto failing_journal = storage.make_journal(generous_limits());
++    auto failed = failing_journal.append_and_publish(
++        std::move(failing_authority), chain.successor);
++    require_result(failed, DurableJournalStatus::RecoveryRequired,
++                   "effectful append did not install a lineage fence");
++    require(storage.snapshot().journal_bytes ==
++                committed + frame(chain.successor) &&
++                storage.snapshot().authority_root_bytes == root,
++            "lineage-fence setup did not leave a recoverable tail");
++
++    const auto old_lock_identity = storage.lock_identity();
++    require(old_lock_identity != 0 && storage.try_unlink_lock_file() &&
++                storage.try_recreate_lock_file() &&
++                storage.lock_identity() != old_lock_identity,
++            "lineage-fence setup did not replace the stable lock");
++    auto rebound = recover(storage, root);
++
++    storage.reset_observations();
++    auto stale_journal = storage.make_journal(generous_limits());
++    auto stale = stale_journal.append_and_publish(std::move(stale_authority),
++                                                   chain.successor);
++    require_result(stale, DurableJournalStatus::UnsupportedStorage,
++                   "cleared lineage fence reauthorized an old lock token");
++    require(!stale_authority.available() &&
++                storage.attempt_count(FaultOperation::AuthorityLockOpen) == 1 &&
++                storage.attempt_count(
++                    FaultOperation::AuthorityIdentityRead) == 1 &&
++                storage.attempt_count(FaultOperation::RootOpen) == 0 &&
++                storage.attempt_count(FaultOperation::JournalOpen) == 0,
++            "directory-lineage cleanup retained an obsolete full-identity "
++            "fence");
++
++    auto continuation = storage.make_journal(generous_limits());
++    auto continued = continuation.append_and_publish(std::move(rebound),
++                                                      chain.successor);
++    require_result(continued, DurableJournalStatus::Published,
++                   "directory-lineage recovery did not clear its fence");
++}
++
++void require_fenced_fresh_create_reconciles() {
++    const auto chain = make_chain();
++    auto storage = JournalTestStorage::fresh();
++    storage.arm_fault(FaultOperation::InitialJournalCreate,
++                      FaultPosition::After, FaultAction::Error);
++    auto failed_create = storage.make_journal(generous_limits());
++    auto failed = failed_create.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(failed, DurableJournalStatus::RecoveryRequired,
++                   "effectful create did not install a process fence");
++    storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
++
++    storage.reset_observations();
++    const auto before_failed_inspection = storage.snapshot();
++    storage.arm_fault(FaultOperation::FixedNamespaceInspect,
++                      FaultPosition::Before, FaultAction::Error);
++    auto failed_inspector = storage.make_journal(generous_limits());
++    auto inspection_failure = failed_inspector.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(
++        inspection_failure, DurableJournalStatus::RecoveryRequired,
++        "failed fresh-namespace inspection discarded a retained fence");
++    require(!inspection_failure.journal.has_value() &&
++                same_persistent_state(storage.snapshot(),
++                                      before_failed_inspection) &&
++                !storage.snapshot().authority_mutation_attempted,
++            "failed fresh-namespace inspection changed authority");
++    require_storage_released_after_return(
++        storage, "failed fresh-namespace inspection retained a handle");
++
++    storage.reset_observations();
++    const auto before = storage.snapshot();
++    auto retried_create = storage.make_journal(generous_limits());
++    auto retried = retried_create.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    const auto after = storage.snapshot();
++    require_result(retried, DurableJournalStatus::Published,
++                   "fresh namespace create did not reconcile its fence");
++    require(retried.journal.has_value() && retried.journal->available() &&
++                !same_persistent_state(after, before) &&
++                after.authority_mutation_attempted &&
++                after.journal_bytes == frame(chain.genesis) &&
++                after.authority_root_bytes ==
++                    chain.genesis_root.canonical_bytes() &&
++                after.all_authority_io_under_lock,
++            "fenced create did not verify and publish a fresh namespace");
++    require_storage_released_after_return(
++        storage, "fenced create retained an authority handle");
++}
++
++template <typename Mutation>
++DurableJournalResult create_after_paused_operation(
++    JournalTestStorage &storage, const Chain &chain, FaultOperation operation,
++    Mutation mutation, std::string_view pause_failure,
++    std::size_t occurrence = 1) {
++    storage.pause_after_nth(operation, occurrence);
++    std::optional<DurableJournalResult> result;
++    std::thread creator([&] {
++        auto journal = storage.make_journal(generous_limits());
++        result.emplace(journal.create_new(TrustedReplayFloor::uninitialized(),
++                                          chain.genesis));
++    });
++    if (!storage.wait_until_paused(5000)) {
++        storage.release_pause();
++        creator.join();
++        require(false, pause_failure);
++    }
++    mutation();
++    storage.release_pause();
++    creator.join();
++    require(result.has_value(), "paused create did not return");
++    return std::move(*result);
++}
++
++void require_create_post_failure_clearance_proof() {
++    const auto chain = make_chain();
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto journal = storage.make_journal(generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::UnsupportedStorage,
++                       "proven before-effect create failure stayed fenced");
++        const auto after = storage.snapshot();
++        require(after.journal_bytes.empty() &&
++                    after.authority_root_bytes.empty() &&
++                    after.stage_files_absent &&
++                    !after.authority_mutation_attempted,
++                "before-effect create failure changed authority");
++        auto retry = storage.make_journal(generous_limits());
++        auto retried = retry.create_new(TrustedReplayFloor::uninitialized(),
++                                        chain.genesis);
++        require_result(retried, DurableJournalStatus::Published,
++                       "proven before-effect create failure retained its fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::After, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
++            },
++            "create did not pause after an effect-uncertain failure", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "effect-uncertain create cleared a fresh fence");
++        const auto after = storage.snapshot();
++        require(after.journal_bytes.empty() &&
++                    after.authority_root_bytes.empty() &&
++                    after.stage_files_absent &&
++                    after.authority_mutation_attempted,
++                "effect-uncertain create fixture changed its final namespace");
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear an effect-uncertain fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        auto stale_peer = create(storage, chain);
++        storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
++        storage.remove_fixed_child_file(FixedAuthorityChild::Root);
++        storage.reset_observations();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                storage.arm_fault(FaultOperation::FixedNamespaceInspect,
++                                  FaultPosition::After, FaultAction::Error);
++            },
++            "create did not pause during post-create inspection", 2);
++        require_result(
++            result, DurableJournalStatus::RecoveryRequired,
++            "failed post-create inspection cleared a provisional fence");
++        const auto fenced = storage.snapshot();
++        require(fenced.journal_bytes.empty() &&
++                    fenced.authority_root_bytes.empty() &&
++                    fenced.stage_files_absent &&
++                    !fenced.authority_mutation_attempted,
++                "failed post-create inspection changed authority");
++        storage.reset_observations();
++        const auto before_peer = storage.snapshot();
++        auto peer = storage.make_journal(generous_limits());
++        auto blocked = peer.append_and_publish(std::move(stale_peer),
++                                               chain.successor);
++        require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                       "failed post-create inspection did not retain its fence");
++        const auto after_peer = storage.snapshot();
++        require(!stale_peer.available() &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityLockOpen) == 0 &&
++                    same_persistent_state(after_peer, before_peer) &&
++                    !after_peer.authority_mutation_attempted,
++                "post-create inspection fence allowed peer authority I/O");
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear an inspection fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        auto stale_peer = create(storage, chain);
++        storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
++        storage.remove_fixed_child_file(FixedAuthorityChild::Root);
++        storage.reset_observations();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                storage.arm_fault(FaultOperation::AuthorityIdentityRead,
++                                  FaultPosition::Before,
++                                  FaultAction::Error);
++            },
++            "create did not pause before post-create identity validation", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "failed post-create identity read cleared its fence");
++        require(!result.published() && !result.journal.has_value(),
++                "failed post-create identity read returned authority");
++        const auto fenced = storage.snapshot();
++        require(fenced.journal_bytes.empty() &&
++                    fenced.authority_root_bytes.empty() &&
++                    fenced.stage_files_absent &&
++                    !fenced.authority_mutation_attempted,
++                "failed post-create identity read changed authority");
++        storage.reset_observations();
++        const auto before_peer = storage.snapshot();
++        auto peer = storage.make_journal(generous_limits());
++        auto blocked = peer.append_and_publish(std::move(stale_peer),
++                                               chain.successor);
++        require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                       "failed identity read did not retain its fence");
++        const auto after_peer = storage.snapshot();
++        require(!stale_peer.available() &&
++                    storage.attempt_count(
++                        FaultOperation::AuthorityLockOpen) == 0 &&
++                    same_persistent_state(after_peer, before_peer) &&
++                    !after_peer.authority_mutation_attempted,
++                "identity-read fence allowed peer authority I/O");
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear an identity-read fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                storage.seed_untrusted_file("journal.jsonl",
++                                            "post-create-journal");
++            },
++            "create did not pause during post-create journal inspection", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "post-create journal residue cleared its fence");
++        const auto fenced = storage.snapshot();
++        require(fenced.journal_bytes == "post-create-journal" &&
++                    fenced.authority_root_bytes.empty() &&
++                    fenced.stage_files_absent &&
++                    !fenced.authority_mutation_attempted,
++                "before-effect create changed post-create journal residue");
++        auto peer = storage.make_journal(generous_limits());
++        auto blocked = peer.create_new(TrustedReplayFloor::uninitialized(),
++                                       chain.genesis);
++        require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                       "post-create journal residue did not retain its fence");
++        require(same_persistent_state(storage.snapshot(), fenced),
++                "fenced peer changed post-create journal residue");
++        storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear a journal residue fence");
++    }
++
++    for (const auto child : {FixedAuthorityChild::Root,
++                             FixedAuthorityChild::JournalStage,
++                             FixedAuthorityChild::RootStage}) {
++        auto storage = JournalTestStorage::fresh();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                storage.replace_fixed_child_file(child,
++                                                 "compound-fixed-residue");
++            },
++            "create did not pause during compound namespace inspection", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "compound fixed residue cleared a provisional fence");
++        const auto fenced = storage.snapshot();
++        const auto compound_entries = static_cast<std::size_t>(std::count_if(
++            fenced.live_file_bytes.begin(), fenced.live_file_bytes.end(),
++            [](const auto &entry) {
++                return entry.second == "compound-fixed-residue";
++            }));
++        require(fenced.journal_bytes.empty() &&
++                    compound_entries == 1 &&
++                    !fenced.authority_mutation_attempted,
++                "before-effect create changed compound fixed residue");
++        auto peer = storage.make_journal(generous_limits());
++        auto blocked = peer.create_new(TrustedReplayFloor::uninitialized(),
++                                       chain.genesis);
++        require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                       "compound fixed residue did not retain its fence");
++        require(same_persistent_state(storage.snapshot(), fenced),
++                "fenced peer changed compound fixed residue");
++        storage.remove_fixed_child_file(child);
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear a compound residue fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh();
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                storage.arm_fault(FaultOperation::AuthorityUnlock,
++                                  FaultPosition::After, FaultAction::Error);
++            },
++            "create did not pause before its post-create unlock", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "failed post-create unlock cleared its fence");
++        const auto after = storage.snapshot();
++        require(after.journal_bytes.empty() &&
++                    after.authority_root_bytes.empty() &&
++                    after.stage_files_absent &&
++                    !after.authority_mutation_attempted,
++                "failed post-create unlock changed authority");
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear an unlock fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh(PlatformContract::Linux);
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                require(storage.try_unlink_lock_file(),
++                        "post-create lock fixture did not remove the lock");
++            },
++            "create did not pause during post-create lock validation", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "missing post-create lock cleared its fence");
++        const auto after = storage.snapshot();
++        require(after.journal_bytes.empty() &&
++                    after.authority_root_bytes.empty() &&
++                    after.stage_files_absent &&
++                    !after.authority_mutation_attempted,
++                "missing post-create lock changed authority");
++        require(storage.try_recreate_lock_file(),
++                "post-create lock fixture did not restore the lock");
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear a missing-lock fence");
++    }
++
++    {
++        auto storage = JournalTestStorage::fresh(PlatformContract::Linux);
++        storage.arm_fault(FaultOperation::InitialJournalCreate,
++                          FaultPosition::Before, FaultAction::Error);
++        auto result = create_after_paused_operation(
++            storage, chain, FaultOperation::FixedNamespaceInspect,
++            [&] {
++                const auto original_identity = storage.lock_identity();
++                require(original_identity != 0 &&
++                            storage.try_unlink_lock_file() &&
++                            storage.try_recreate_lock_file() &&
++                            storage.lock_identity() != original_identity,
++                        "post-create identity fixture did not rebind the lock");
++            },
++            "create did not pause during post-create identity validation", 2);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "rebound post-create identity cleared its fence");
++        const auto after = storage.snapshot();
++        require(after.journal_bytes.empty() &&
++                    after.authority_root_bytes.empty() &&
++                    after.stage_files_absent &&
++                    !after.authority_mutation_attempted,
++                "rebound post-create identity changed authority");
++        auto recovery = storage.make_journal(generous_limits());
++        auto recovered = recovery.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(recovered, DurableJournalStatus::Published,
++                       "locked create did not clear a rebound identity fence");
++    }
++}
++
++void require_retained_fresh_create_requires_live_lock() {
++    const auto chain = make_chain();
++    auto storage = JournalTestStorage::fresh(PlatformContract::Linux);
++    storage.arm_fault(FaultOperation::InitialJournalCreate,
++                      FaultPosition::After, FaultAction::Error);
++    auto faulting = storage.make_journal(generous_limits());
++    auto failed = faulting.create_new(TrustedReplayFloor::uninitialized(),
++                                      chain.genesis);
++    require_result(failed, DurableJournalStatus::RecoveryRequired,
++                   "effectful create did not establish a retained fence");
++    storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
++    storage.reset_observations();
++
++    auto blocked = create_after_paused_operation(
++        storage, chain, FaultOperation::FixedNamespaceInspect,
++        [&] {
++            require(storage.try_unlink_lock_file(),
++                    "retained-fence fixture did not remove the live lock");
++        },
++        "retained create did not pause during fixed inspection");
++    require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                   "retained create accepted a missing live lock");
++    const auto after = storage.snapshot();
++    require(after.journal_bytes.empty() && after.authority_root_bytes.empty() &&
++                after.stage_files_absent &&
++                !after.authority_mutation_attempted,
++            "retained create mutated a namespace without its live lock");
++    require(storage.try_recreate_lock_file(),
++            "retained-fence fixture did not restore the live lock");
++    auto recovery = storage.make_journal(generous_limits());
++    auto recovered = recovery.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++    require_result(recovered, DurableJournalStatus::Published,
++                   "locked create did not clear a missing-lock fence");
++}
++
++const std::vector<FaultOperation> repair_operations = [] {
++    auto operations = pre_authority_operations;
++    operations.insert(operations.end(), {
++                                            FaultOperation::RootOpen,
++                                            FaultOperation::RootRead,
++                                            FaultOperation::RootClose,
++                                            FaultOperation::JournalOpen,
++                                            FaultOperation::JournalRead,
++                                            FaultOperation::JournalReadClose,
++                                            FaultOperation::TailRepairOpen,
++                                            FaultOperation::TailRepairTruncate,
++                                            FaultOperation::TailRepairFlush,
++                                            FaultOperation::TailRepairClose,
++                                            FaultOperation::AuthorityUnlock,
++                                            FaultOperation::AuthorityLockClose,
++                                        });
++    return operations;
++}();
++
++const std::vector<FaultOperation> compaction_operations = [] {
++    auto operations = pre_authority_operations;
++    operations.insert(operations.end(),
++                      {
++                          FaultOperation::RootOpen,
++                          FaultOperation::RootRead,
++                          FaultOperation::RootClose,
++                          FaultOperation::JournalOpen,
++                          FaultOperation::JournalRead,
++                          FaultOperation::JournalReadClose,
++                          FaultOperation::CompactionStageCreate,
++                          FaultOperation::CompactionWrite,
++                          FaultOperation::CompactionFlush,
++                          FaultOperation::CompactionClose,
++                          FaultOperation::CompactionReplace,
++                          FaultOperation::CompactionNamespaceDurability,
++                          FaultOperation::AuthorityUnlock,
++                          FaultOperation::AuthorityLockClose,
++                      });
++    return operations;
++}();
++
++const std::vector<FaultOperation> read_only_recovery_operations = [] {
++    auto operations = pre_authority_operations;
++    operations.insert(operations.end(), {
++                                            FaultOperation::RootOpen,
++                                            FaultOperation::RootRead,
++                                            FaultOperation::RootClose,
++                                            FaultOperation::JournalOpen,
++                                            FaultOperation::JournalRead,
++                                            FaultOperation::JournalReadClose,
++                                            FaultOperation::AuthorityUnlock,
++                                            FaultOperation::AuthorityLockClose,
++                                        });
++    return operations;
++}();
++
++void require_read_only_recovery_faults() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    for (const auto operation : read_only_recovery_operations) {
++        for (const auto position :
++             {FaultPosition::Before, FaultPosition::After}) {
++            auto storage = JournalTestStorage::seeded(
++                committed, std::string(chain.genesis_root.canonical_bytes()));
++            auto peer =
++                recover(storage, chain.genesis_root.canonical_bytes());
++            storage.reset_observations();
++            const auto before = storage.snapshot();
++            storage.arm_fault(operation, position, FaultAction::Error);
++            auto journal = storage.make_journal(generous_limits());
++            auto result =
++                journal.recover_existing(TrustedReplayFloor::exact_root(
++                    std::string(chain.genesis_root.canonical_bytes())));
++            const auto expected =
++                preflight_may_have_effect(operation, position,
++                                          FaultAction::Error)
++                    ? DurableJournalStatus::RecoveryRequired
++                    : DurableJournalStatus::UnsupportedStorage;
++            require_result(result, expected,
++                           "read-only recovery fault changed stable outcome");
++            const auto after = storage.snapshot();
++            require(after.journal_bytes == before.journal_bytes &&
++                        after.authority_root_bytes ==
++                            before.authority_root_bytes &&
++                        !after.authority_mutation_attempted &&
++                        after.open_handles.empty() && after.stage_files_absent,
++                    "read-only recovery fault mutated or leaked authority");
++            if (operation == FaultOperation::RootClose ||
++                operation == FaultOperation::JournalReadClose ||
++                operation == FaultOperation::AuthorityLockClose) {
++                require(storage.attempt_count(operation) == 1,
++                        "read-only checked close was retried or omitted");
++            }
++            require_storage_released_after_return(
++                storage, "read-only recovery fault retained a handle");
++
++            if (preflight_may_have_effect(operation, position,
++                                          FaultAction::Error)) {
++                storage.reset_observations();
++                const auto before_fenced_write = storage.snapshot();
++                auto writer = storage.make_journal(generous_limits());
++                auto blocked = writer.append_and_publish(
++                    std::move(peer), chain.successor);
++                require_result(
++                    blocked, DurableJournalStatus::RecoveryRequired,
++                    "effect-uncertain preflight did not retain its fence");
++                const auto after_fenced_write = storage.snapshot();
++                require(
++                    !peer.available() &&
++                        same_persistent_state(after_fenced_write,
++                                              before_fenced_write) &&
++                        !after_fenced_write.authority_mutation_attempted,
++                    "preflight fence allowed a peer write");
++                require_storage_released_after_return(
++                    storage, "preflight fence retained a handle");
++            }
++
++            storage.reset_observations();
++            auto retry = storage.make_journal(generous_limits());
++            auto retried =
++                retry.recover_existing(TrustedReplayFloor::exact_root(
++                    std::string(chain.genesis_root.canonical_bytes())));
++            require_result(retried, DurableJournalStatus::Published,
++                           "read-only recovery did not retry cleanly");
++            require(storage.snapshot().journal_bytes == committed &&
++                        storage.snapshot().stage_files_absent &&
++                        storage.snapshot().durable_stage_files_absent &&
++                        storage.snapshot().open_handles.empty(),
++                    "read-only retry left probe or handle residue");
++            require_storage_released_after_return(
++                storage, "read-only recovery retry retained a handle");
++        }
++    }
++}
++
++bool flow_may_have_mutated(const std::vector<FaultOperation> &operations,
++                           FaultOperation first_mutation,
++                           FaultOperation operation, FaultPosition position,
++                           FaultAction action) {
++    if (operation == first_mutation) {
++        return position == FaultPosition::After ||
++               action == FaultAction::EffectThenError;
++    }
++    const auto found =
++        std::find(operations.begin(), operations.end(), operation);
++    const auto mutation =
++        std::find(operations.begin(), operations.end(), first_mutation);
++    return found > mutation;
++}
++
++void require_repair_faults() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    const auto with_tail =
++        committed + frame(chain.successor) + frame(chain.fork);
++
++    for (const auto operation : repair_operations) {
++        for (const auto position :
++             {FaultPosition::Before, FaultPosition::After}) {
++            for (const auto action : {FaultAction::Error, FaultAction::Crash,
++                                      FaultAction::EffectThenError}) {
++                auto storage = JournalTestStorage::seeded(
++                    committed,
++                    std::string(chain.genesis_root.canonical_bytes()));
++                auto peer =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                storage.overwrite_fixed_child_bytes(
++                    FixedAuthorityChild::Journal, with_tail);
++                storage.reset_observations();
++                storage.arm_fault(operation, position, action);
++                auto journal = storage.make_journal(generous_limits());
++                auto result =
++                    journal.recover_existing(TrustedReplayFloor::exact_root(
++                        std::string(chain.genesis_root.canonical_bytes())));
++                const bool authority_may_have_mutated = flow_may_have_mutated(
++                    repair_operations, FaultOperation::TailRepairTruncate,
++                    operation, position, action);
++                const auto expected =
++                    (authority_may_have_mutated || preflight_may_have_effect(
++                                                       operation, position,
++                                                       action))
++                        ? DurableJournalStatus::RecoveryRequired
++                        : DurableJournalStatus::UnsupportedStorage;
++                require_result(result, expected,
++                               "tail-repair fault returned the wrong outcome");
++                if (action != FaultAction::Crash) {
++                    require_storage_released_after_return(
++                        storage,
++                        "tail-repair fault retained an authority handle");
++                }
++                if (authority_may_have_mutated ||
++                    preflight_may_have_effect(operation, position, action)) {
++                    const auto before_fence = storage.snapshot();
++                    storage.reset_observations();
++                    auto fence = storage.make_journal(generous_limits());
++                    auto fenced = fence.append_and_publish(std::move(peer),
++                                                           chain.successor);
++                    require_result(
++                        fenced, DurableJournalStatus::RecoveryRequired,
++                        "possibly-effectful repair did not fence a pre-fault "
++                        "authority token");
++                    const auto after_fence = storage.snapshot();
++                    require(
++                        !peer.available() &&
++                            same_persistent_state(after_fence, before_fence) &&
++                            !after_fence.authority_mutation_attempted,
++                        "repair fence attempt changed authority");
++                    if (action != FaultAction::Crash) {
++                        require_storage_released_after_return(
++                            storage,
++                            "repair fence retained an authority handle");
++                    }
++                }
++                storage.restart();
++                storage.reset_observations();
++                auto recovered =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                require(recovered.root_bytes() ==
++                            chain.genesis_root.canonical_bytes(),
++                        "tail-repair crash changed authority");
++                require(
++                    storage.snapshot().journal_bytes == committed &&
++                        storage.snapshot().journal_durable &&
++                        storage.snapshot().journal_closed &&
++                        storage.snapshot().stage_files_absent,
++                    "tail repair was not durable before write-ready recovery");
++                auto continuation = storage.make_journal(generous_limits());
++                auto continued = continuation.append_and_publish(
++                    std::move(recovered), chain.successor);
++                require_result(continued, DurableJournalStatus::Published,
++                               "repaired journal could not continue appending");
++            }
++        }
++    }
++}
++
++void require_physical_compaction() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis) + frame(chain.successor);
++    auto baseline = JournalTestStorage::seeded(
++        committed, std::string(chain.successor_root.canonical_bytes()));
++    const auto exact_snapshot = baseline.snapshot();
++
++    auto success = baseline.clone();
++    auto authority = recover(success, chain.genesis_root.canonical_bytes());
++    auto journal = success.make_journal(generous_limits());
++    auto compacted = journal.compact_physical(std::move(authority));
++    require_result(compacted, DurableJournalStatus::Published,
++                   "physical compaction was rejected");
++    require(!authority.available() && compacted.journal->available() &&
++                success.snapshot().journal_bytes ==
++                    exact_snapshot.journal_bytes &&
++                success.snapshot().authority_root_bytes ==
++                    exact_snapshot.authority_root_bytes &&
++                success.snapshot().open_handles.empty() &&
++                success.snapshot().all_authority_io_under_lock,
++            "physical compaction duplicated or changed authority");
++
++    for (const auto operation : compaction_operations) {
++        for (const auto position :
++             {FaultPosition::Before, FaultPosition::After}) {
++            for (const auto action : {FaultAction::Error, FaultAction::Crash,
++                                      FaultAction::EffectThenError}) {
++                auto storage = baseline.clone();
++                auto live =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                auto peer =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                storage.reset_observations();
++                storage.arm_fault(operation, position, action);
++                auto faulting_journal = storage.make_journal(generous_limits());
++                auto result =
++                    faulting_journal.compact_physical(std::move(live));
++                const bool authority_may_have_mutated = flow_may_have_mutated(
++                    compaction_operations,
++                    FaultOperation::CompactionStageCreate, operation, position,
++                    action);
++                const auto expected =
++                    (authority_may_have_mutated || preflight_may_have_effect(
++                                                       operation, position,
++                                                       action))
++                        ? DurableJournalStatus::RecoveryRequired
++                        : DurableJournalStatus::UnsupportedStorage;
++                require_result(
++                    result, expected,
++                    "compaction fault returned the wrong stable outcome");
++                require(!live.available(),
++                        "compaction fault retained a write-capable handle");
++                if (action != FaultAction::Crash) {
++                    require_storage_released_after_return(
++                        storage,
++                        "compaction fault retained an authority handle");
++                }
++                if (authority_may_have_mutated ||
++                    preflight_may_have_effect(operation, position, action)) {
++                    const auto before_fence = storage.snapshot();
++                    storage.reset_observations();
++                    auto fence = storage.make_journal(generous_limits());
++                    auto fenced =
++                        fence.append_and_publish(std::move(peer), chain.third);
++                    require_result(
++                        fenced, DurableJournalStatus::RecoveryRequired,
++                        "possibly-effectful compaction did not fence a "
++                        "pre-fault authority token");
++                    const auto after_fence = storage.snapshot();
++                    require(
++                        !peer.available() &&
++                            same_persistent_state(after_fence, before_fence) &&
++                            !after_fence.authority_mutation_attempted,
++                        "compaction fence attempt changed authority");
++                    if (action != FaultAction::Crash) {
++                        require_storage_released_after_return(
++                            storage,
++                            "compaction fence retained an authority handle");
++                    }
++                }
++                storage.restart();
++                const auto restart_snapshot = storage.snapshot();
++                storage.reset_observations();
++                auto recovered =
++                    recover(storage, chain.genesis_root.canonical_bytes());
++                require(recovered.root_bytes() ==
++                            chain.successor_root.canonical_bytes(),
++                        "compaction crash changed authority");
++                require(
++                    storage.snapshot().journal_bytes ==
++                            exact_snapshot.journal_bytes &&
++                        storage.snapshot().authority_root_bytes ==
++                            exact_snapshot.authority_root_bytes &&
++                        stage_files_unchanged(restart_snapshot,
++                                              storage.snapshot()) &&
++                        storage.snapshot().journal_durable,
++                    "compaction crash did not preserve byte-identical storage");
++                auto continuation = storage.make_journal(generous_limits());
++                auto continued = continuation.append_and_publish(
++                    std::move(recovered), chain.third);
++                require_result(
++                    continued, DurableJournalStatus::Published,
++                    "compaction recovery could not continue appending");
++            }
++        }
++    }
++}
++
++void require_exact_schema_export() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis) + frame(chain.successor);
++    auto storage = JournalTestStorage::seeded(
++        committed, std::string(chain.successor_root.canonical_bytes()));
++    auto authority = recover(storage, chain.genesis_root.canonical_bytes());
++    const auto before = storage.snapshot();
++    auto journal = storage.make_journal(generous_limits());
++
++    auto unconfirmed = journal.export_exact_schema_candidate(
++        authority, supported_journal_schema, JournalQuiescence::Unconfirmed);
++    require(!unconfirmed.exported() && !unconfirmed.candidate.has_value() &&
++                unconfirmed.status ==
++                    ExactSchemaExportStatus::QuiescenceRequired,
++            "unconfirmed export returned a candidate");
++    require(storage.snapshot() == before,
++            "unconfirmed export readied or changed storage");
++
++    auto exported = journal.export_exact_schema_candidate(
++        authority, supported_journal_schema, JournalQuiescence::Confirmed);
++    require(exported.status == ExactSchemaExportStatus::ExportedCandidate &&
++                exported.exported() && exported.candidate.has_value(),
++            "confirmed exact-schema export was rejected");
++    require(exported.candidate->schema.major ==
++                    supported_journal_schema.major &&
++                exported.candidate->schema.minor ==
++                    supported_journal_schema.minor &&
++                exported.candidate->journal_bytes == committed &&
++                exported.candidate->authority_root_bytes ==
++                    chain.successor_root.canonical_bytes(),
++            "exact-schema export changed bytes or schema");
++    require(authority.available(),
++            "nonauthorizing export consumed live authority");
++    require(same_persistent_state(storage.snapshot(), before) &&
++                storage.snapshot().open_handles.empty() &&
++                storage.snapshot().all_authority_io_under_lock,
++            "exact-schema export changed or leaked live storage");
++
++    for (const auto operation : read_only_recovery_operations) {
++        for (const auto position :
++             {FaultPosition::Before, FaultPosition::After}) {
++            auto fault_storage = JournalTestStorage::seeded(
++                committed, std::string(chain.successor_root.canonical_bytes()));
++            auto fault_authority =
++                recover(fault_storage, chain.genesis_root.canonical_bytes());
++            auto fault_peer =
++                recover(fault_storage, chain.genesis_root.canonical_bytes());
++            fault_storage.reset_observations();
++            const auto fault_before = fault_storage.snapshot();
++            fault_storage.arm_fault(operation, position, FaultAction::Error);
++            auto fault_journal = fault_storage.make_journal(generous_limits());
++            auto fault_export = fault_journal.export_exact_schema_candidate(
++                fault_authority, supported_journal_schema,
++                JournalQuiescence::Confirmed);
++            const auto expected =
++                preflight_may_have_effect(operation, position,
++                                          FaultAction::Error)
++                    ? ExactSchemaExportStatus::RecoveryRequired
++                    : ExactSchemaExportStatus::UnsupportedStorage;
++            require(fault_export.status ==
++                            expected &&
++                        !fault_export.exported() &&
++                        !fault_export.candidate.has_value() &&
++                        fault_authority.available(),
++                    "export storage fault returned authority bytes");
++            const auto fault_after = fault_storage.snapshot();
++            require(authority_files_unchanged(fault_before, fault_after) &&
++                        !fault_after.authority_mutation_attempted &&
++                        fault_after.open_handles.empty(),
++                    "export storage fault changed or leaked authority");
++            require_storage_released_after_return(
++                fault_storage, "export storage fault retained a handle");
++
++            if (preflight_may_have_effect(operation, position,
++                                          FaultAction::Error)) {
++                fault_storage.reset_observations();
++                const auto before_fenced_write = fault_storage.snapshot();
++                auto writer = fault_storage.make_journal(generous_limits());
++                auto blocked = writer.append_and_publish(
++                    std::move(fault_peer), chain.third);
++                require_result(
++                    blocked, DurableJournalStatus::RecoveryRequired,
++                    "effect-uncertain export preflight did not retain its "
++                    "fence");
++                const auto after_fenced_write = fault_storage.snapshot();
++                require(
++                    !fault_peer.available() &&
++                        same_persistent_state(after_fenced_write,
++                                              before_fenced_write) &&
++                        !after_fenced_write.authority_mutation_attempted,
++                    "export preflight fence allowed a peer write");
++                require_storage_released_after_return(
++                    fault_storage, "export preflight fence retained a handle");
++
++                fault_storage.reset_observations();
++                const auto before_fenced_export = fault_storage.snapshot();
++                auto fenced_exporter =
++                    fault_storage.make_journal(generous_limits());
++                auto fenced_export =
++                    fenced_exporter.export_exact_schema_candidate(
++                        fault_authority, supported_journal_schema,
++                        JournalQuiescence::Confirmed);
++                require(
++                    fenced_export.status ==
++                            ExactSchemaExportStatus::RecoveryRequired &&
++                        !fenced_export.exported() &&
++                        !fenced_export.candidate.has_value() &&
++                        fault_authority.available() &&
++                        same_persistent_state(fault_storage.snapshot(),
++                                              before_fenced_export) &&
++                        !fault_storage.snapshot().authority_mutation_attempted,
++                    "fenced export consumed authority or read storage");
++                require_storage_released_after_return(
++                    fault_storage, "fenced export retained a handle");
++
++                fault_storage.reset_observations();
++                auto recovered = recover(
++                    fault_storage, chain.genesis_root.canonical_bytes());
++                require(recovered.root_bytes() ==
++                            chain.successor_root.canonical_bytes(),
++                        "locked recovery did not clear the export preflight "
++                        "fence");
++            }
++
++            fault_storage.reset_observations();
++            auto retry = fault_storage.make_journal(generous_limits());
++            auto retried = retry.export_exact_schema_candidate(
++                fault_authority, supported_journal_schema,
++                JournalQuiescence::Confirmed);
++            require(retried.status ==
++                            ExactSchemaExportStatus::ExportedCandidate &&
++                        retried.exported() && retried.candidate.has_value() &&
++                        same_persistent_state(fault_storage.snapshot(),
++                                              fault_before),
++                    "export storage fault did not retry cleanly");
++            require_storage_released_after_return(
++                fault_storage, "export retry retained an authority handle");
++        }
++    }
++
++    storage.reset_observations();
++    const auto schema_before = storage.snapshot();
++    for (const auto schema :
++         {SchemaVersion{0, 0},
++          SchemaVersion{supported_journal_schema.major + 1, 0},
++          SchemaVersion{supported_journal_schema.major,
++                        supported_journal_schema.minor + 1}}) {
++        auto rejected = journal.export_exact_schema_candidate(
++            authority, schema, JournalQuiescence::Confirmed);
++        require(rejected.status == ExactSchemaExportStatus::SchemaMismatch &&
++                    !rejected.exported() && !rejected.candidate.has_value() &&
++                    authority.available(),
++                "different-schema export returned a candidate");
++        require(storage.snapshot() == schema_before,
++                "different-schema export changed live storage");
++    }
++
++    auto stale_storage = JournalTestStorage::seeded(
++        frame(chain.genesis),
++        std::string(chain.genesis_root.canonical_bytes()));
++    auto stale = recover(stale_storage, chain.genesis_root.canonical_bytes());
++    auto winner = recover(stale_storage, chain.genesis_root.canonical_bytes());
++    auto winning_journal = stale_storage.make_journal(generous_limits());
++    auto advanced =
++        winning_journal.append_and_publish(std::move(winner), chain.successor);
++    require_result(advanced, DurableJournalStatus::Published,
++                   "export stale-authority fixture did not advance");
++    stale_storage.reset_observations();
++    const auto stale_before = stale_storage.snapshot();
++    auto stale_journal = stale_storage.make_journal(generous_limits());
++    auto stale_export = stale_journal.export_exact_schema_candidate(
++        stale, supported_journal_schema, JournalQuiescence::Confirmed);
++    require(stale_export.status ==
++                    ExactSchemaExportStatus::ConflictBeforeRead &&
++                !stale_export.exported() &&
++                !stale_export.candidate.has_value() && stale.available() &&
++                stale_storage.attempt_count(FaultOperation::RootRead) > 0 &&
++                stale_storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
++                stale_storage.attempt_count(FaultOperation::JournalRead) == 0 &&
++                !stale_storage.snapshot().authority_mutation_attempted &&
++                stale_storage.snapshot().all_authority_io_under_lock,
++            "stale authority exported a candidate");
++    require(same_persistent_state(stale_storage.snapshot(), stale_before),
++            "stale export changed authority storage");
++    require_storage_released_after_return(
++        stale_storage, "stale export retained an authority handle");
++
++    auto unsupported_storage = JournalTestStorage::seeded(
++        committed, std::string(chain.successor_root.canonical_bytes()));
++    auto unsupported_authority =
++        recover(unsupported_storage, chain.genesis_root.canonical_bytes());
++    unsupported_storage.arm_fault(FaultOperation::RootOpen,
++                                  FaultPosition::Before, FaultAction::Error);
++    const auto unsupported_before = unsupported_storage.snapshot();
++    auto unsupported_journal =
++        unsupported_storage.make_journal(generous_limits());
++    auto unsupported_export = unsupported_journal.export_exact_schema_candidate(
++        unsupported_authority, supported_journal_schema,
++        JournalQuiescence::Confirmed);
++    require(unsupported_export.status ==
++                    ExactSchemaExportStatus::UnsupportedStorage &&
++                !unsupported_export.exported() &&
++                !unsupported_export.candidate.has_value(),
++            "export storage failure returned a candidate");
++    require(unsupported_storage.snapshot().journal_bytes ==
++                    unsupported_before.journal_bytes &&
++                unsupported_storage.snapshot().authority_root_bytes ==
++                    unsupported_before.authority_root_bytes,
++            "unsupported export changed authority storage");
++
++    auto limited_storage = JournalTestStorage::seeded(
++        committed, std::string(chain.successor_root.canonical_bytes()));
++    auto limited_authority =
++        recover(limited_storage, chain.genesis_root.canonical_bytes());
++    auto export_limits = generous_limits();
++    export_limits.max_committed_bytes = committed.size() - 1;
++    const auto limited_before = limited_storage.snapshot();
++    auto limited_journal = limited_storage.make_journal(export_limits);
++    auto limited_export = limited_journal.export_exact_schema_candidate(
++        limited_authority, supported_journal_schema,
++        JournalQuiescence::Confirmed);
++    require(limited_export.status == ExactSchemaExportStatus::LimitExceeded &&
++                !limited_export.exported() &&
++                !limited_export.candidate.has_value(),
++            "over-limit export returned a candidate");
++    require(limited_storage.snapshot() == limited_before,
++            "over-limit export changed authority storage");
++
++    auto corrupt_storage = JournalTestStorage::seeded(
++        committed, std::string(chain.successor_root.canonical_bytes()));
++    auto corrupt_authority =
++        recover(corrupt_storage, chain.genesis_root.canonical_bytes());
++    corrupt_storage.overwrite_fixed_child_bytes(FixedAuthorityChild::Root, "{");
++    corrupt_storage.reset_observations();
++    const auto corrupt_before = corrupt_storage.snapshot();
++    auto corrupt_journal = corrupt_storage.make_journal(generous_limits());
++    auto corrupt_export = corrupt_journal.export_exact_schema_candidate(
++        corrupt_authority, supported_journal_schema,
++        JournalQuiescence::Confirmed);
++    require(
++        corrupt_export.status == ExactSchemaExportStatus::CorruptOrRollback &&
++            !corrupt_export.exported() &&
++            !corrupt_export.candidate.has_value() &&
++            corrupt_authority.available() &&
++            same_persistent_state(corrupt_storage.snapshot(), corrupt_before) &&
++            !corrupt_storage.snapshot().authority_mutation_attempted,
++        "corrupt stored authority exported or triggered mutation");
++}
++
++void require_unsupported_preflight() {
++    const auto chain = make_chain();
++    for (const auto platform :
++         {PlatformContract::Linux, PlatformContract::Windows,
++          PlatformContract::MacOS}) {
++        for (const auto capability :
++             {DurabilityCapability::RegularFileFlush,
++              DurabilityCapability::TailTruncateAndFlush,
++              DurabilityCapability::SameDirectoryReplace,
++              DurabilityCapability::NamespaceDurability}) {
++            auto storage = JournalTestStorage::fresh(platform);
++            storage.make_capability_unavailable(capability);
++            const auto before = storage.snapshot();
++            auto journal = storage.make_journal(generous_limits());
++            auto result = journal.create_new(
++                TrustedReplayFloor::uninitialized(), chain.genesis);
++            require_result(
++                result, DurableJournalStatus::UnsupportedStorage,
++                "unavailable native durability did not refuse publication");
++            const auto after = storage.snapshot();
++            require(authority_files_unchanged(before, after) &&
++                        !after.authority_mutation_attempted &&
++                        after.open_handles.empty(),
++                    "unsupported adapter changed authority during create "
++                    "preflight");
++
++            auto existing = JournalTestStorage::seeded(
++                frame(chain.genesis),
++                std::string(chain.genesis_root.canonical_bytes()), platform);
++            existing.make_capability_unavailable(capability);
++            const auto existing_before = existing.snapshot();
++            auto existing_journal = existing.make_journal(generous_limits());
++            auto existing_result = existing_journal.recover_existing(
++                TrustedReplayFloor::exact_root(
++                    std::string(chain.genesis_root.canonical_bytes())));
++            require_result(
++                existing_result, DurableJournalStatus::UnsupportedStorage,
++                "unavailable native durability did not refuse recovery");
++            const auto existing_after = existing.snapshot();
++            require(
++                authority_files_unchanged(existing_before, existing_after) &&
++                    !existing_after.authority_mutation_attempted &&
++                    existing_after.open_handles.empty(),
++                "unsupported adapter changed authority during recovery "
++                "preflight");
++        }
++
++        for (const auto child :
++             {FixedAuthorityChild::Journal, FixedAuthorityChild::Root,
++              FixedAuthorityChild::Lock, FixedAuthorityChild::JournalStage,
++              FixedAuthorityChild::RootStage}) {
++            for (const auto kind : {UnsupportedEntryKind::Symlink,
++                                    UnsupportedEntryKind::NonRegular,
++                                    UnsupportedEntryKind::ReparsePoint}) {
++                auto storage = JournalTestStorage::fresh(platform);
++                storage.poison_fixed_child(child, kind);
++                const auto before = storage.snapshot();
++                auto journal = storage.make_journal(generous_limits());
++                auto result = journal.create_new(
++                    TrustedReplayFloor::uninitialized(), chain.genesis);
++                require_result(result, DurableJournalStatus::UnsupportedStorage,
++                               "unsafe fixed child was accepted");
++                const auto after = storage.snapshot();
++                require(authority_files_unchanged(before, after) &&
++                            !after.authority_mutation_attempted &&
++                            after.open_handles.empty(),
++                        "unsafe fixed-child preflight changed authority");
++                if (child != FixedAuthorityChild::Lock) {
++                    require(storage.attempt_count(
++                                FaultOperation::PreflightProbe) > 0 &&
++                                storage.attempt_count(
++                                    FaultOperation::RootOpen) == 0 &&
++                                storage.attempt_count(
++                                    FaultOperation::JournalOpen) == 0,
++                            "unsafe fixed child was discovered after authority "
++                            "I/O");
++                }
++            }
++        }
++
++        auto missing =
++            JournalTestStorage::missing_authority_directory(platform);
++        const auto missing_before = missing.snapshot();
++        auto missing_journal = missing.make_journal(generous_limits());
++        auto missing_result = missing_journal.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(missing_result, DurableJournalStatus::UnsupportedStorage,
++                       "missing authority directory was created implicitly");
++        require(same_persistent_state(missing.snapshot(), missing_before),
++                "missing authority directory changed its parent");
++    }
++}
++
++std::filesystem::path extended_length_path(const std::filesystem::path &path) {
++#ifdef _WIN32
++    const auto absolute = std::filesystem::absolute(path).lexically_normal();
++    const auto native = absolute.native();
++    if (native.rfind(L"\\\\?\\", 0) == 0) {
++        return absolute;
++    }
++    if (native.rfind(L"\\\\", 0) == 0) {
++        return std::filesystem::path(L"\\\\?\\UNC\\" + native.substr(2));
++    }
++    return std::filesystem::path(L"\\\\?\\" + native);
++#else
++    return path;
++#endif
++}
++
++class NativeDirectory {
++public:
++    explicit NativeDirectory(std::string_view label) {
++        const auto nonce =
++            std::chrono::steady_clock::now().time_since_epoch().count();
++        path_ = std::filesystem::temp_directory_path() /
++                (std::string("lemonade-") + std::string(label) + "-" +
++                 std::to_string(nonce));
++        std::filesystem::create_directories(path_);
++    }
++
++    ~NativeDirectory() {
++        std::error_code error;
++        std::filesystem::remove_all(extended_length_path(path_), error);
++    }
++
++    NativeDirectory(const NativeDirectory &) = delete;
++    NativeDirectory &operator=(const NativeDirectory &) = delete;
++
++    const std::filesystem::path &path() const noexcept { return path_; }
++
++private:
++    std::filesystem::path path_;
++};
++
++class ScopedCurrentPath {
++public:
++    ScopedCurrentPath() : lock_(mutex()), original_(std::filesystem::current_path()) {}
++
++    ~ScopedCurrentPath() {
++        std::error_code error;
++        std::filesystem::current_path(original_, error);
++        require(!error, "test current directory could not be restored");
++    }
++
++    ScopedCurrentPath(const ScopedCurrentPath &) = delete;
++    ScopedCurrentPath &operator=(const ScopedCurrentPath &) = delete;
++
++    void change_to(const std::filesystem::path &path) {
++        std::filesystem::current_path(path);
++    }
++
++private:
++    static std::mutex &mutex() {
++        static std::mutex value;
++        return value;
++    }
++
++    std::unique_lock<std::mutex> lock_;
++    std::filesystem::path original_;
++};
++
++std::string read_bytes(const std::filesystem::path &path) {
++    std::ifstream stream(path, std::ios::binary);
++    return std::string(std::istreambuf_iterator<char>(stream),
++                       std::istreambuf_iterator<char>());
++}
++
++void write_bytes(const std::filesystem::path &path, std::string_view bytes) {
++    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
++    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
++    require(stream.good(), "test control file write failed");
++}
++
++void append_bytes(const std::filesystem::path &path, std::string_view bytes) {
++    std::ofstream stream(path, std::ios::binary | std::ios::app);
++    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
++    require(stream.good(), "test control file append failed");
++}
++
++std::map<std::string, std::string>
++snapshot_regular_files(const std::filesystem::path &root) {
++    std::map<std::string, std::string> snapshot;
++    for (const auto &entry :
++         std::filesystem::recursive_directory_iterator(root)) {
++        if (entry.is_regular_file()) {
++            snapshot.emplace(
++                entry.path().lexically_relative(root).generic_string(),
++                read_bytes(entry.path()));
++        }
++    }
++    return snapshot;
++}
++
++PublishedJournal create_native(const std::filesystem::path &directory,
++                               const Chain &chain) {
++    auto journal = DurableJournal::native(directory, generous_limits());
++    auto result =
++        journal.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(result, DurableJournalStatus::Published,
++                   "native create did not publish authority");
++    return std::move(*result.journal);
++}
++
++PublishedJournal recover_native(const std::filesystem::path &directory,
++                                std::string_view floor) {
++    auto journal = DurableJournal::native(directory, generous_limits());
++    auto result = journal.recover_existing(
++        TrustedReplayFloor::exact_root(std::string(floor)));
++    require_result(result, DurableJournalStatus::Published,
++                   "native recovery did not return authority");
++    return std::move(*result.journal);
++}
++
++void require_native_preflight_identity_phase_residue() {
++    const auto chain = make_chain();
++    using lemon::residency::detail::DurablePreflightTestFault;
++    for (const auto fault :
++         {DurablePreflightTestFault::ProbeIdentityCaptureFailureOnce,
++          DurablePreflightTestFault::StageIdentityCaptureFailureOnce}) {
++        NativeDirectory directory("task020-native-preflight-phase-failure");
++        auto adapter = lemon::residency::detail::
++            make_platform_durable_file_adapter_for_test(directory.path(),
++                                                        fault);
++        auto journal = lemon::residency::detail::make_durable_journal_for_test(
++            std::move(adapter), generous_limits());
++
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::RecoveryRequired,
++                       "post-create identity failure was not effect-uncertain");
++        require(!result.published() && !result.journal.has_value(),
++                "post-create identity failure returned authority");
++
++        const auto after_failure = snapshot_regular_files(directory.path());
++        const auto anonymous_residue =
++            std::find_if(after_failure.begin(), after_failure.end(),
++                         [](const auto &entry) {
++                             return entry.first != "authority.lock" &&
++                                    entry.second.empty();
++                         });
++        const bool stage_residue =
++            anonymous_residue != after_failure.end() &&
++            std::filesystem::path(anonymous_residue->first).extension() ==
++                ".stage";
++        const bool expected_stage_residue =
++            fault ==
++            DurablePreflightTestFault::StageIdentityCaptureFailureOnce;
++        require(after_failure.size() == 2 &&
++                    anonymous_residue != after_failure.end() &&
++                    stage_residue == expected_stage_residue &&
++                    after_failure.count("authority.lock") == 1,
++                "post-create identity failure changed anonymous residue");
++        const auto uncertain_residue_path = anonymous_residue->first;
++        const auto uncertain_residue_bytes = anonymous_residue->second;
++
++        auto reconciler = DurableJournal::native(directory.path(),
++                                                 generous_limits());
++        auto reconciled = reconciler.create_new(
++            TrustedReplayFloor::uninitialized(), chain.genesis);
++        require_result(reconciled, DurableJournalStatus::Published,
++                       "locked create did not reconcile a fresh fence");
++        const auto published = snapshot_regular_files(directory.path());
++        const auto retained_residue =
++            published.find(uncertain_residue_path);
++        require(published.size() == 4 &&
++                    published.at("journal.jsonl") == frame(chain.genesis) &&
++                    published.at("authority-root.json") ==
++                        chain.genesis_root.canonical_bytes() &&
++                    published.count("authority.lock") == 1 &&
++                    retained_residue != published.end() &&
++                    retained_residue->second == uncertain_residue_bytes,
++                "fresh fence reconciliation changed authority or residue");
++    }
++}
++
++void require_native_preflight_fence_blocks_nonfresh_authority() {
++    const auto chain = make_chain();
++    NativeDirectory directory("task020-native-preflight-nonfresh-fence");
++    auto peer = create_native(directory.path(), chain);
++    const auto stable = snapshot_regular_files(directory.path());
++    auto adapter = lemon::residency::detail::
++        make_platform_durable_file_adapter_for_test(
++            directory.path(), lemon::residency::detail::
++                                  DurablePreflightTestFault::
++                                      ProbeIdentityCaptureFailureOnce);
++    auto journal = lemon::residency::detail::make_durable_journal_for_test(
++        std::move(adapter), generous_limits());
++
++    auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++        std::string(chain.genesis_root.canonical_bytes())));
++    require_result(result, DurableJournalStatus::RecoveryRequired,
++                   "post-create identity failure was not effect-uncertain");
++    require(!result.published() && !result.journal.has_value(),
++            "post-create identity failure returned authority");
++
++    const auto after_failure = snapshot_regular_files(directory.path());
++    const auto uncertain_entries = static_cast<std::size_t>(std::count_if(
++        after_failure.begin(), after_failure.end(), [&](const auto &entry) {
++            return stable.count(entry.first) == 0 && entry.second.empty();
++        }));
++    require(after_failure.size() == stable.size() + 1 &&
++                uncertain_entries == 1 &&
++                after_failure.at("journal.jsonl") == frame(chain.genesis) &&
++                after_failure.at("authority-root.json") ==
++                    chain.genesis_root.canonical_bytes(),
++            "post-create identity failure did not preserve uncertain residue");
++
++    auto blocked_create = DurableJournal::native(directory.path(),
++                                                 generous_limits());
++    auto create_result = blocked_create.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(create_result, DurableJournalStatus::RecoveryRequired,
++                   "fenced existing authority admitted a fresh create");
++    require(snapshot_regular_files(directory.path()) == after_failure,
++            "fenced create changed existing authority");
++
++    auto blocked_writer = DurableJournal::native(directory.path(),
++                                                 generous_limits());
++    auto blocked = blocked_writer.append_and_publish(std::move(peer),
++                                                     chain.successor);
++    require_result(blocked, DurableJournalStatus::RecoveryRequired,
++                   "post-create identity failure did not fence peer writes");
++    require(!peer.available() &&
++                snapshot_regular_files(directory.path()) == after_failure,
++            "preflight identity fence changed authority");
++
++    auto recovered =
++        recover_native(directory.path(), chain.genesis_root.canonical_bytes());
++    auto continuation = DurableJournal::native(directory.path(),
++                                               generous_limits());
++    auto continued = continuation.append_and_publish(std::move(recovered),
++                                                     chain.successor);
++    require_result(continued, DurableJournalStatus::Published,
++                   "locked recovery did not clear the preflight fence");
++}
++
++void require_native_preflight_preserves_siblings() {
++    const auto chain = make_chain();
++    NativeDirectory directory("task020-native-preflight-siblings");
++
++    write_bytes(directory.path() / ".durability-probe", "legacy-primary");
++    write_bytes(directory.path() / ".durability-probe.stage", "legacy-stage");
++
++    static_cast<void>(create_native(directory.path(), chain));
++
++    const auto files = snapshot_regular_files(directory.path());
++    require(files.size() == 5 &&
++                files.at(".durability-probe") == "legacy-primary" &&
++                files.at(".durability-probe.stage") == "legacy-stage" &&
++                files.at("journal.jsonl") == frame(chain.genesis) &&
++                files.at("authority-root.json") ==
++                    chain.genesis_root.canonical_bytes() &&
++                files.count("authority.lock") == 1,
++            "native preflight changed sibling files or left residue");
++}
++
++void require_native_preflight_stage_collision_exhaustion_is_fenced() {
++    const auto chain = make_chain();
++    NativeDirectory directory("task020-native-preflight-stage-collisions");
++    auto adapter = lemon::residency::detail::
++        make_platform_durable_file_adapter_for_test(
++            directory.path(), lemon::residency::detail::
++                                  DurablePreflightTestFault::
++                                      StageCreateCollisionExhaustion);
++    auto journal = lemon::residency::detail::make_durable_journal_for_test(
++        std::move(adapter), generous_limits());
++
++    auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                     chain.genesis);
++    require_result(result, DurableJournalStatus::RecoveryRequired,
++                   "exhausted stage collisions were not effect-uncertain");
++    require(!result.published() && !result.journal.has_value(),
++            "exhausted stage collisions returned authority");
++
++    const auto after_failure = snapshot_regular_files(directory.path());
++    std::map<std::string, std::string> collision_sentinels;
++    for (const auto &[name, bytes] : after_failure) {
++        if (name != "authority.lock") {
++            collision_sentinels.emplace(name, bytes);
++        }
++    }
++    require(after_failure.size() == collision_sentinels.size() + 1 &&
++                after_failure.count("authority.lock") == 1 &&
++                !collision_sentinels.empty() &&
++                std::all_of(collision_sentinels.begin(),
++                            collision_sentinels.end(), [](const auto &entry) {
++                                return entry.second ==
++                                       "caller-owned-stage-collision";
++                            }),
++            "stage collision exhaustion changed sentinels or left residue");
++
++    auto reconciler = DurableJournal::native(directory.path(),
++                                             generous_limits());
++    auto reconciled = reconciler.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(reconciled, DurableJournalStatus::Published,
++                   "locked create did not reconcile the collision fence");
++    const auto published = snapshot_regular_files(directory.path());
++    require(published.size() == collision_sentinels.size() + 3 &&
++                published.at("journal.jsonl") == frame(chain.genesis) &&
++                published.at("authority-root.json") ==
++                    chain.genesis_root.canonical_bytes() &&
++                published.count("authority.lock") == 1,
++            "collision fence reconciliation did not publish authority");
++    for (const auto &[name, bytes] : collision_sentinels) {
++        const auto preserved = published.find(name);
++        require(preserved != published.end() && preserved->second == bytes,
++                "collision fence reconciliation changed a sentinel");
++    }
++}
++
++void require_native_relative_directory_binding() {
++    const auto chain = make_chain();
++    NativeDirectory parent("task020-relative-directory-binding");
++    const auto original_parent = parent.path() / "original";
++    const auto decoy_parent = parent.path() / "decoy";
++    const auto original_authority = original_parent / "authority";
++    const auto decoy_authority = decoy_parent / "authority";
++    std::filesystem::create_directories(original_authority);
++    std::filesystem::create_directories(decoy_authority);
++    write_bytes(original_parent / "sentinel.bin", "original-sentinel");
++    write_bytes(decoy_parent / "sentinel.bin", "decoy-sentinel");
++
++    {
++        ScopedCurrentPath current_path;
++        current_path.change_to(original_parent);
++        auto journal =
++            DurableJournal::native("authority", generous_limits());
++        current_path.change_to(decoy_parent);
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::Published,
++                       "relative native authority did not publish");
++    }
++
++    const auto original_files = snapshot_regular_files(original_authority);
++    require(original_files.size() == 3 &&
++                original_files.at("journal.jsonl") == frame(chain.genesis) &&
++                original_files.at("authority-root.json") ==
++                    chain.genesis_root.canonical_bytes() &&
++                original_files.count("authority.lock") == 1,
++            "relative native authority drifted from its opened directory");
++    require(snapshot_regular_files(decoy_authority).empty() &&
++                read_bytes(original_parent / "sentinel.bin") ==
++                    "original-sentinel" &&
++                read_bytes(decoy_parent / "sentinel.bin") ==
++                    "decoy-sentinel",
++            "current-directory drift redirected native authority I/O");
++}
++
++void require_native_unbound_adapter_preserves_working_directory() {
++    NativeDirectory parent("task020-native-unbound-adapter");
++    const auto blocking_file = parent.path() / "not-a-directory";
++    const auto working_directory = parent.path() / "working-directory";
++    write_bytes(blocking_file, "blocking-file");
++    std::filesystem::create_directories(working_directory);
++    write_bytes(working_directory / "journal.jsonl", "working-journal");
++    write_bytes(working_directory / "authority-root.json", "working-root");
++    write_bytes(working_directory / "journal.jsonl.stage",
++                "working-journal-stage");
++    write_bytes(working_directory / "authority-root.json.stage",
++                "working-root-stage");
++    write_bytes(working_directory / "authority.lock", "working-lock");
++    const auto before = snapshot_regular_files(working_directory);
++
++    auto adapter =
++        lemon::residency::detail::make_platform_durable_file_adapter(
++            blocking_file / "authority");
++    {
++        ScopedCurrentPath current_path;
++        current_path.change_to(working_directory);
++        const auto inspected = adapter->inspect_fixed_namespace();
++        const auto root = adapter->read_root(1024);
++        const auto journal = adapter->read_journal(1024);
++        const auto created = adapter->create_journal("created");
++        const auto appended = adapter->append_journal("appended");
++        const auto truncated = adapter->truncate_journal(0);
++        const auto replaced_journal = adapter->replace_journal("replacement");
++        const auto replaced_root = adapter->replace_root("replacement");
++        require(!inspected.result.succeeded() && !root.result.succeeded() &&
++                    !journal.result.succeeded() && !created.succeeded() &&
++                    !appended.succeeded() && !truncated.succeeded() &&
++                    !replaced_journal.succeeded() &&
++                    !replaced_root.succeeded(),
++                "unbound native adapter accepted a path operation");
++    }
++    require(snapshot_regular_files(working_directory) == before,
++            "unbound native adapter changed the working directory");
++}
++
++void require_native_bounded_read_boundaries() {
++    const auto chain = make_chain();
++    const auto committed = frame(chain.genesis);
++    auto limits = generous_limits();
++    limits.max_committed_bytes = committed.size();
++    limits.max_crash_tail_bytes = 1;
++
++    NativeDirectory exact("task020-native-read-exact-cap");
++    static_cast<void>(create_native(exact.path(), chain));
++    append_bytes(exact.path() / "journal.jsonl", "x");
++    auto exact_journal = DurableJournal::native(exact.path(), limits);
++    auto exact_result =
++        exact_journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++    require_result(exact_result, DurableJournalStatus::Published,
++                   "native exact-cap journal read was rejected");
++    require(read_bytes(exact.path() / "journal.jsonl") == committed &&
++                read_bytes(exact.path() / "authority-root.json") ==
++                    chain.genesis_root.canonical_bytes(),
++            "native exact-cap recovery did not repair the exact tail");
++
++    for (const auto &[label, tail] :
++         {std::pair{std::string("task020-native-read-cap-plus-one"),
++                    std::string("xy")},
++          std::pair{std::string("task020-native-read-cap-plus-many"),
++                    std::string(64, 'z')}}) {
++        NativeDirectory over(label);
++        static_cast<void>(create_native(over.path(), chain));
++        append_bytes(over.path() / "journal.jsonl", tail);
++        const auto before = snapshot_regular_files(over.path());
++        auto journal = DurableJournal::native(over.path(), limits);
++        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
++            std::string(chain.genesis_root.canonical_bytes())));
++        require_result(result, DurableJournalStatus::LimitExceeded,
++                       "native over-cap journal read was not limited");
++        require(snapshot_regular_files(over.path()) == before,
++                "native over-cap read changed authority bytes");
++    }
++}
++
++void require_native_literal_children() {
++    const std::vector<std::string> journal_ids{
++        "../escape",
++        "/absolute",
++        "C:\\root\\journal",
++        "\\\\?\\C:\\device",
++        "CON",
++        "con",
++        "A",
++        "a",
++        "%2e%2e%2fescape",
++        "..\\escape",
++        "aux.txt",
++        "PRN",
++        "COM1",
++        "LPT1",
++        "authority-root.json",
++        "authority.lock",
++        "JOURNAL.JSONL",
++        "\\\\server\\share",
++    };
++    const std::set<std::string> expected_children{
++        "authority-root.json", "authority.lock", "journal.jsonl"};
++    NativeDirectory parent("task020-unicode-parent");
++    write_bytes(parent.path() / "outside-sentinel.bin", "outside-authority");
++    for (std::size_t index = 0; index < journal_ids.size(); ++index) {
++        const auto authority_directory =
++            parent.path() / ("authority-case-" + std::to_string(index));
++        std::filesystem::create_directories(authority_directory);
++        static_cast<void>(
++            create_native(authority_directory, make_chain(journal_ids[index])));
++        std::set<std::string> children;
++        for (const auto &entry :
++             std::filesystem::directory_iterator(authority_directory)) {
++            children.insert(entry.path().filename().string());
++        }
++        require(children == expected_children,
++                "native identity influenced the fixed child set");
++    }
++    const auto parent_snapshot = snapshot_regular_files(parent.path());
++    require(parent_snapshot.at("outside-sentinel.bin") == "outside-authority" &&
++                parent_snapshot.size() == journal_ids.size() * 3 + 1,
++            "native identifier escaped or changed its selected directory");
++
++    const auto missing_directory = parent.path() / "missing-authority";
++    auto missing_journal =
++        DurableJournal::native(missing_directory, generous_limits());
++    auto missing_result = missing_journal.create_new(
++        TrustedReplayFloor::uninitialized(), make_chain().genesis);
++    require_result(missing_result, DurableJournalStatus::UnsupportedStorage,
++                   "native persistence created a missing authority directory");
++    require(!std::filesystem::exists(missing_directory) &&
++                read_bytes(parent.path() / "outside-sentinel.bin") ==
++                    "outside-authority",
++            "native missing-directory refusal changed its parent");
++
++    auto authority_directory = extended_length_path(
++        parent.path() /
++        std::filesystem::u8path(u8"authority-\u4F4F\u5B85-\u00E9-\U0001F680"));
++    for (int index = 0; index < 7; ++index) {
++        authority_directory /= std::string(48, static_cast<char>('a' + index));
++    }
++    std::filesystem::create_directories(authority_directory);
++    const auto long_path_chain = make_chain("../C:\\PRN/authority-root.json");
++    static_cast<void>(create_native(authority_directory, long_path_chain));
++    std::set<std::string> children;
++    for (const auto &entry :
++         std::filesystem::directory_iterator(authority_directory)) {
++        children.insert(entry.path().filename().string());
++    }
++    require(children == expected_children,
++            "native long Unicode parent changed fixed child names");
++    require(read_bytes(authority_directory / "journal.jsonl") ==
++                frame(long_path_chain.genesis),
++            "native path handling changed journal bytes");
++}
++
++std::set<std::string>
++direct_child_names(const std::filesystem::path &directory) {
++    std::set<std::string> names;
++    for (const auto &entry : std::filesystem::directory_iterator(directory)) {
++        names.insert(entry.path().filename().generic_string());
++    }
++    return names;
++}
++
++void require_native_fresh_namespace_asymmetry() {
++    const auto chain = make_chain();
++    const std::vector<std::pair<std::string, std::string>> blockers{
++        {"authority-root.json",
++         std::string(chain.genesis_root.canonical_bytes())},
++        {"journal.jsonl", frame(chain.genesis)},
++        {".authority-root.json.stage", "root-stage-residue"},
++        {".journal.jsonl.stage", "journal-stage-residue"},
++        {"authority-root.json", ""},
++        {"journal.jsonl", ""},
++    };
++    NativeDirectory parent("task020-native-create-asymmetry");
++    write_bytes(parent.path() / "parent-sentinel.bin", "parent-sentinel");
++
++    for (std::size_t index = 0; index < blockers.size(); ++index) {
++        const auto authority_directory =
++            parent.path() / ("incomplete-" + std::to_string(index));
++        std::filesystem::create_directory(authority_directory);
++        const auto &[name, bytes] = blockers[index];
++        write_bytes(authority_directory / "authority.lock", "");
++        write_bytes(authority_directory / name, bytes);
++        const auto before = snapshot_regular_files(authority_directory);
++
++        auto journal =
++            DurableJournal::native(authority_directory, generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "native create overwrote incomplete fixed namespace");
++        const auto after = snapshot_regular_files(authority_directory);
++        const auto preserved = after.find(name);
++        require(preserved != after.end() && preserved->second == bytes &&
++                    after == before,
++                "native create changed incomplete fixed evidence");
++        for (const auto &child : direct_child_names(authority_directory)) {
++            require(child == name || child == "authority.lock",
++                    "native create added authority files to an incomplete "
++                    "namespace");
++        }
++        require(read_bytes(parent.path() / "parent-sentinel.bin") ==
++                    "parent-sentinel",
++                "native incomplete create changed its parent");
++    }
++
++    const auto duplicate_directory = parent.path() / "complete-duplicate";
++    std::filesystem::create_directory(duplicate_directory);
++    static_cast<void>(create_native(duplicate_directory, chain));
++    const auto duplicate_before = snapshot_regular_files(duplicate_directory);
++    auto duplicate_journal =
++        DurableJournal::native(duplicate_directory, generous_limits());
++    auto duplicate = duplicate_journal.create_new(
++        TrustedReplayFloor::uninitialized(), chain.genesis);
++    require_result(duplicate, DurableJournalStatus::ConflictBeforeWrite,
++                   "native complete namespace was not a create conflict");
++    require(snapshot_regular_files(duplicate_directory) == duplicate_before,
++            "native duplicate create changed complete authority");
++
++    for (const auto &[stage_name, stage_bytes] :
++         {std::pair{std::string(".authority-root.json.stage"),
++                    std::string("root-stage-with-complete-authority")},
++          std::pair{std::string(".journal.jsonl.stage"),
++                    std::string("journal-stage-with-complete-authority")}}) {
++        const auto authority_directory =
++            parent.path() / (stage_name == ".authority-root.json.stage"
++                                 ? "complete-with-root-stage"
++                                 : "complete-with-journal-stage");
++        std::filesystem::create_directory(authority_directory);
++        static_cast<void>(create_native(authority_directory, chain));
++        write_bytes(authority_directory / stage_name, stage_bytes);
++        const auto before = snapshot_regular_files(authority_directory);
++
++        auto journal =
++            DurableJournal::native(authority_directory, generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         chain.genesis);
++        require_result(result, DurableJournalStatus::CorruptOrRollback,
++                       "native stage did not override complete-create "
++                       "conflict classification");
++        require(snapshot_regular_files(authority_directory) == before &&
++                    read_bytes(authority_directory / stage_name) == stage_bytes,
++                "native create changed complete authority with stage "
++                "residue");
++        require(read_bytes(parent.path() / "parent-sentinel.bin") ==
++                    "parent-sentinel",
++                "native complete-with-stage create changed its parent");
++    }
++
++    const auto lock_only_directory = parent.path() / "lock-only";
++    std::filesystem::create_directory(lock_only_directory);
++    write_bytes(lock_only_directory / "authority.lock", "");
++    static_cast<void>(create_native(lock_only_directory, chain));
++
++    const auto sentinel_directory = parent.path() / "unrelated-sentinel";
++    std::filesystem::create_directory(sentinel_directory);
++    write_bytes(sentinel_directory / "sentinel.bin", "unrelated-sentinel");
++    static_cast<void>(create_native(sentinel_directory, chain));
++    require(read_bytes(sentinel_directory / "sentinel.bin") ==
++                "unrelated-sentinel",
++            "native create changed an unrelated sentinel");
++}
++
++bool is_explicit_symlink_fixture_unavailability(const std::error_code &error) {
++#ifdef _WIN32
++    if (error.category() == std::system_category() &&
++        error.value() == ERROR_PRIVILEGE_NOT_HELD) {
++        return true;
++    }
++#endif
++    return error == std::errc::operation_not_permitted ||
++           error == std::errc::permission_denied ||
++           error == std::errc::function_not_supported ||
++           error == std::errc::not_supported ||
++           error == std::errc::read_only_file_system;
++}
++
++void require_symlink_fixture_unavailability_contract() {
++#ifdef _WIN32
++    require(is_explicit_symlink_fixture_unavailability(std::error_code(
++                ERROR_PRIVILEGE_NOT_HELD, std::system_category())),
++            "Windows symlink privilege failure was not treated as fixture "
++            "unavailability");
++    require(!is_explicit_symlink_fixture_unavailability(
++                std::error_code(ERROR_INVALID_NAME, std::system_category())),
++            "unrelated Windows symlink failure was treated as fixture "
++            "unavailability");
++#endif
++}
++
++void require_native_fixed_child_poisoning() {
++    const std::vector<std::string> fixed_children{
++        "journal.jsonl", "authority-root.json", "authority.lock",
++        ".journal.jsonl.stage", ".authority-root.json.stage"};
++    NativeDirectory parent("task020-fixed-child-poison");
++    const auto outside_directory = parent.path() / "outside";
++    std::filesystem::create_directory(outside_directory);
++    write_bytes(parent.path() / "parent-sentinel.bin", "parent-sentinel");
++    write_bytes(outside_directory / "target.bin", "outside-target");
++    const auto outside_before = snapshot_regular_files(outside_directory);
++
++    const auto require_unchanged_boundaries = [&] {
++        require(read_bytes(parent.path() / "parent-sentinel.bin") ==
++                        "parent-sentinel" &&
++                    snapshot_regular_files(outside_directory) == outside_before,
++                "fixed-child poison changed parent or outside bytes");
++    };
++    const auto require_only_poison_and_lock =
++        [&](const std::filesystem::path &authority_directory,
++            std::string_view poison_name) {
++            const auto children = direct_child_names(authority_directory);
++            for (const auto &child : children) {
++                require(child == poison_name || child == "authority.lock",
++                        "fixed-child refusal retained an unexpected child");
++            }
++            require(children.count(std::string(poison_name)) == 1,
++                    "fixed-child refusal replaced the poison entry");
++            if (poison_name != "authority.lock" &&
++                children.count("authority.lock") != 0) {
++                const auto lock_status = std::filesystem::symlink_status(
++                    authority_directory / "authority.lock");
++                require(std::filesystem::is_regular_file(lock_status) &&
++                            !std::filesystem::is_symlink(lock_status),
++                        "fixed-child refusal produced an unsafe lock entry");
++            }
++        };
++
++    for (std::size_t index = 0; index < fixed_children.size(); ++index) {
++        const auto authority_directory =
++            parent.path() / ("directory-poison-" + std::to_string(index));
++        std::filesystem::create_directory(authority_directory);
++        const auto poison = authority_directory / fixed_children[index];
++        std::filesystem::create_directory(poison);
++        write_bytes(poison / "sentinel.bin", "poison-sentinel");
++
++        auto journal =
++            DurableJournal::native(authority_directory, generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         make_chain().genesis);
++        require_result(result, DurableJournalStatus::UnsupportedStorage,
++                       "native fixed directory was treated as a regular file");
++        require(std::filesystem::is_directory(
++                    std::filesystem::symlink_status(poison)) &&
++                    direct_child_names(poison) ==
++                        std::set<std::string>{"sentinel.bin"} &&
++                    read_bytes(poison / "sentinel.bin") == "poison-sentinel",
++                "native fixed directory was followed or replaced");
++        require_only_poison_and_lock(authority_directory,
++                                     fixed_children[index]);
++        require_unchanged_boundaries();
++    }
++
++    bool symlink_fixture_unavailable = false;
++    for (std::size_t index = 0; index < fixed_children.size(); ++index) {
++        const auto authority_directory =
++            parent.path() / ("symlink-poison-" + std::to_string(index));
++        std::filesystem::create_directory(authority_directory);
++        const auto poison = authority_directory / fixed_children[index];
++        std::error_code symlink_error;
++        std::filesystem::create_symlink(outside_directory / "target.bin",
++                                        poison, symlink_error);
++        if (symlink_error) {
++            require(index == 0 && is_explicit_symlink_fixture_unavailability(
++                                      symlink_error),
++                    "native symlink poison fixture failed unexpectedly");
++            symlink_fixture_unavailable = true;
++            break;
++        }
++
++        auto journal =
++            DurableJournal::native(authority_directory, generous_limits());
++        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
++                                         make_chain().genesis);
++        require_result(result, DurableJournalStatus::UnsupportedStorage,
++                       "native fixed symlink was followed as authority");
++        require(std::filesystem::is_symlink(
++                    std::filesystem::symlink_status(poison)),
++                "native fixed symlink was replaced");
++        require_only_poison_and_lock(authority_directory,
++                                     fixed_children[index]);
++        require_unchanged_boundaries();
++    }
++    if (symlink_fixture_unavailable) {
++        require(snapshot_regular_files(outside_directory) == outside_before,
++                "unavailable symlink fixture changed outside bytes");
++    }
++}
++
++void require_native_storage_identity_binding() {
++    const auto chain = make_chain();
++    NativeDirectory directory_a("task020-identity-a");
++    NativeDirectory directory_b("task020-identity-b");
++    static_cast<void>(create_native(directory_a.path(), chain));
++    static_cast<void>(create_native(directory_b.path(), chain));
++
++    std::error_code hard_link_error;
++    std::filesystem::remove(directory_b.path() / "authority.lock",
++                            hard_link_error);
++    require(!hard_link_error,
++            "native alias fixture could not remove the closed lock entry");
++    std::filesystem::create_hard_link(directory_a.path() / "authority.lock",
++                                      directory_b.path() / "authority.lock",
++                                      hard_link_error);
++    require(!hard_link_error,
++            "native alias fixture could not hard-link lock identities");
++
++    const auto b_before = snapshot_regular_files(directory_b.path());
++    auto append_authority = recover_native(
++        directory_a.path(), chain.genesis_root.canonical_bytes());
++    auto append_journal =
++        DurableJournal::native(directory_b.path(), generous_limits());
++    auto append_result = append_journal.append_and_publish(
++        std::move(append_authority), chain.successor);
++    require_result(append_result, DurableJournalStatus::CorruptOrRollback,
++                   "cross-directory authority token appended by byte identity");
++    require(!append_authority.available() &&
++                snapshot_regular_files(directory_b.path()) == b_before,
++            "cross-directory append changed authority storage");
++
++    auto compact_authority = recover_native(
++        directory_a.path(), chain.genesis_root.canonical_bytes());
++    auto compact_journal =
++        DurableJournal::native(directory_b.path(), generous_limits());
++    auto compact_result =
++        compact_journal.compact_physical(std::move(compact_authority));
++    require_result(
++        compact_result, DurableJournalStatus::CorruptOrRollback,
++        "cross-directory authority token compacted by byte identity");
++    require(!compact_authority.available() &&
++                snapshot_regular_files(directory_b.path()) == b_before,
++            "cross-directory compaction changed authority storage");
++
++    auto export_authority = recover_native(
++        directory_a.path(), chain.genesis_root.canonical_bytes());
++    auto export_journal =
++        DurableJournal::native(directory_b.path(), generous_limits());
++    auto export_result = export_journal.export_exact_schema_candidate(
++        export_authority, supported_journal_schema,
++        JournalQuiescence::Confirmed);
++    require(
++        export_result.status == ExactSchemaExportStatus::CorruptOrRollback &&
++            !export_result.exported() && !export_result.candidate.has_value() &&
++            export_authority.available() &&
++            snapshot_regular_files(directory_b.path()) == b_before,
++        "cross-directory authority token exported by byte identity");
++
++    auto same_storage_journal =
++        DurableJournal::native(directory_a.path(), generous_limits());
++    auto published = same_storage_journal.append_and_publish(
++        std::move(export_authority), chain.successor);
++    require_result(published, DurableJournalStatus::Published,
++                   "fresh adapter for the same directory rejected authority");
++}
++
++void require_native_lock_recreation_invalidates_authority() {
++    const auto chain = make_chain();
++    const auto root = std::string(chain.genesis_root.canonical_bytes());
++    const auto replace_lock = [](const std::filesystem::path &directory) {
++        const auto lock = directory / "authority.lock";
++        const auto retired = directory / "retired-authority-lock.bin";
++        std::error_code error;
++        std::filesystem::create_hard_link(lock, retired, error);
++        require(!error,
++                "native recreated-lock fixture could not retain old identity");
++        std::filesystem::remove(lock, error);
++        require(!error,
++                "native recreated-lock fixture could not unlink old entry");
++        write_bytes(lock, {});
++    };
++    const auto require_rebound = [&](const std::filesystem::path &directory) {
++        auto rebound = recover_native(directory, root);
++        require(rebound.available(),
++                "fresh native recovery did not bind recreated stable lock");
++    };
++
++    NativeDirectory append_directory("task020-recreated-lock-append");
++    auto append_token = create_native(append_directory.path(), chain);
++    replace_lock(append_directory.path());
++    const auto append_before = snapshot_regular_files(append_directory.path());
++    auto append_journal =
++        DurableJournal::native(append_directory.path(), generous_limits());
++    auto append_result = append_journal.append_and_publish(
++        std::move(append_token), chain.successor);
++    require_result(append_result, DurableJournalStatus::UnsupportedStorage,
++                   "recreated native lock accepted an old append token");
++    require(!append_token.available() &&
++                snapshot_regular_files(append_directory.path()) ==
++                    append_before,
++            "recreated-lock append changed authority bytes or retained token");
++    require_rebound(append_directory.path());
++
++    NativeDirectory compact_directory("task020-recreated-lock-compact");
++    auto compact_token = create_native(compact_directory.path(), chain);
++    replace_lock(compact_directory.path());
++    const auto compact_before =
++        snapshot_regular_files(compact_directory.path());
++    auto compact_journal =
++        DurableJournal::native(compact_directory.path(), generous_limits());
++    auto compact_result =
++        compact_journal.compact_physical(std::move(compact_token));
++    require_result(compact_result, DurableJournalStatus::UnsupportedStorage,
++                   "recreated native lock accepted an old compaction token");
++    require(!compact_token.available() &&
++                snapshot_regular_files(compact_directory.path()) ==
++                    compact_before,
++            "recreated-lock compaction changed bytes or retained token");
++    require_rebound(compact_directory.path());
++
++    NativeDirectory export_directory("task020-recreated-lock-export");
++    auto export_token = create_native(export_directory.path(), chain);
++    replace_lock(export_directory.path());
++    const auto export_before = snapshot_regular_files(export_directory.path());
++    auto export_journal =
++        DurableJournal::native(export_directory.path(), generous_limits());
++    auto export_result = export_journal.export_exact_schema_candidate(
++        export_token, supported_journal_schema, JournalQuiescence::Confirmed);
++    require(
++        export_result.status == ExactSchemaExportStatus::UnsupportedStorage &&
++            !export_result.exported() && !export_result.candidate.has_value() &&
++            export_token.available() &&
++            snapshot_regular_files(export_directory.path()) == export_before,
++        "recreated native lock accepted, consumed, or changed export "
++        "authority");
++    require_rebound(export_directory.path());
++}
++
++void require_native_lock_path_revalidation() {
++    NativeDirectory directory("task020-live-lock-path");
++    const auto probe =
++        probe_native_lock_path_revalidation(directory.path().string());
++    require(probe.nonblocking_probe_rejected &&
++                probe.first_unlock_succeeded &&
++                probe.contender_succeeded,
++            "native replacement lock was not serialized with the held "
++            "authority lock");
++#ifdef _WIN32
++    require(probe.replacement_prevented_while_held &&
++                !probe.contender_rebound &&
++                probe.replacement_after_release_rebound,
++            "Windows authority lock path was replaceable while held or did "
++            "not rebind after release");
++#else
++    require(!probe.replacement_prevented_while_held &&
++                probe.stale_identity_rejected && probe.contender_rebound,
++            "POSIX authority identity did not reject and serialize a replaced "
++            "live lock path");
++#endif
++}
++
++void require_same_process_cas_race() {
++    const auto chain = make_chain();
++    NativeDirectory directory("task020-same-process");
++    static_cast<void>(create_native(directory.path(), chain));
++    auto left =
++        recover_native(directory.path(), chain.genesis_root.canonical_bytes());
++    auto right =
++        recover_native(directory.path(), chain.genesis_root.canonical_bytes());
++
++    std::mutex mutex;
++    std::condition_variable condition;
++    int ready = 0;
++    bool go = false;
++    std::optional<DurableJournalStatus> left_status;
++    std::optional<DurableJournalStatus> right_status;
++    const auto run = [&](PublishedJournal authority,
++                         std::optional<DurableJournalStatus> &status) mutable {
++        {
++            std::unique_lock lock(mutex);
++            ++ready;
++            condition.notify_all();
++            condition.wait(lock, [&] { return go; });
++        }
++        auto journal =
++            DurableJournal::native(directory.path(), generous_limits());
++        status =
++            journal.append_and_publish(std::move(authority), chain.successor)
++                .status;
++    };
++    std::thread left_thread(run, std::move(left), std::ref(left_status));
++    std::thread right_thread(run, std::move(right), std::ref(right_status));
++    {
++        std::unique_lock lock(mutex);
++        condition.wait(lock, [&] { return ready == 2; });
++        go = true;
++    }
++    condition.notify_all();
++    left_thread.join();
++    right_thread.join();
++
++    const std::multiset<DurableJournalStatus> observed{*left_status,
++                                                       *right_status};
++    const std::multiset<DurableJournalStatus> expected{
++        DurableJournalStatus::Published,
++        DurableJournalStatus::ConflictBeforeWrite};
++    require(observed == expected,
++            "same-process CAS race did not select exactly one writer");
++    require(read_bytes(directory.path() / "journal.jsonl") ==
++                    frame(chain.genesis) + frame(chain.successor) &&
++                read_bytes(directory.path() / "authority-root.json") ==
++                    chain.successor_root.canonical_bytes(),
++            "losing same-process writer changed authority bytes");
++}
++
++std::string_view status_wire(DurableJournalStatus status) {
++    switch (status) {
++    case DurableJournalStatus::Published:
++        return "published";
++    case DurableJournalStatus::ConflictBeforeWrite:
++        return "conflict_before_write";
++    case DurableJournalStatus::UnsupportedStorage:
++        return "unsupported_storage";
++    case DurableJournalStatus::CorruptOrRollback:
++        return "corrupt_or_rollback";
++    case DurableJournalStatus::LimitExceeded:
++        return "limit_exceeded";
++    case DurableJournalStatus::RecoveryRequired:
++        return "recovery_required";
++    }
++    return "unknown";
++}
++
++int race_init(const std::filesystem::path &directory,
++              const std::filesystem::path &floor_file) {
++    const auto chain = make_chain();
++    const auto authority = create_native(directory, chain);
++    write_bytes(floor_file, authority.root_bytes());
++    return 0;
++}
++
++int race_worker(const std::filesystem::path &directory,
++                const std::filesystem::path &floor_file,
++                const std::filesystem::path &ready_file,
++                const std::filesystem::path &go_file) {
++    const auto chain = make_chain();
++    auto authority = recover_native(directory, read_bytes(floor_file));
++    write_bytes(ready_file, "ready");
++    const auto deadline =
++        std::chrono::steady_clock::now() + std::chrono::seconds(30);
++    while (!std::filesystem::exists(go_file)) {
++        require(std::chrono::steady_clock::now() < deadline,
++                "cross-process race start timed out");
++        std::this_thread::sleep_for(std::chrono::milliseconds(5));
++    }
++    auto journal = DurableJournal::native(directory, generous_limits());
++    const auto result =
++        journal.append_and_publish(std::move(authority), chain.successor);
++    std::cout << status_wire(result.status) << '\n';
++    return 0;
++}
++
++int race_verify(const std::filesystem::path &directory,
++                const std::filesystem::path &floor_file) {
++    const auto chain = make_chain();
++    const auto authority = recover_native(directory, read_bytes(floor_file));
++    require(authority.root_bytes() == chain.successor_root.canonical_bytes(),
++            "cross-process race recovered the wrong root");
++    require(read_bytes(directory / "journal.jsonl") ==
++                    frame(chain.genesis) + frame(chain.successor) &&
++                read_bytes(directory / "authority-root.json") ==
++                    chain.successor_root.canonical_bytes(),
++            "cross-process CAS loser changed authority bytes");
++    return 0;
++}
++
++int run_command(int argc, char **argv) {
++    if (argc == 4 && std::string_view(argv[1]) == "--race-init") {
++        return race_init(argv[2], argv[3]);
++    }
++    if (argc == 6 && std::string_view(argv[1]) == "--race-worker") {
++        return race_worker(argv[2], argv[3], argv[4], argv[5]);
++    }
++    if (argc == 4 && std::string_view(argv[1]) == "--race-verify") {
++        return race_verify(argv[2], argv[3]);
++    }
++    return -1;
++}
++
++} // namespace
++
++int main(int argc, char **argv) {
++    if (argc != 1) {
++        const auto command_result = run_command(argc, argv);
++        require(command_result >= 0,
++                "unsupported durable-journal public-seam arguments");
++        return command_result;
++    }
++
++    require_public_shape();
++    require_shared_io_helpers();
++    require_exact_initial_publication();
++    require_durable_journal_moves();
++    require_explicit_floor_states();
++    require_fresh_namespace_asymmetry();
++    require_unique_authority_moves();
++    require_fixed_paths();
++    require_identifier_boundaries_precede_persistence();
++    require_replay_and_floors();
++    require_surviving_stage_recovery();
++    require_root_parser_is_task019();
++    require_committed_origin_verification();
++    require_origin_verifier_publication_and_lifetime();
++    require_tail_classification_and_repair();
++    require_explicit_limits();
++    require_durability_ordering();
++    require_stage_replacement_swap_is_fail_closed();
++    require_paused_read_replacement_is_fail_closed();
++    require_paused_read_holds_authority_lock();
++    require_paused_write_observes_completed_effect();
++    require_fake_adapter_destructor_closes_open_lock();
++    require_final_under_lock_revalidation();
++    require_preflight_and_bounded_read_trace();
++    require_create_faults();
++    require_append_and_fault_recovery();
++    require_stale_cas_is_write_free();
++    require_history_invalid_append_is_write_free();
++    require_partial_io_and_interrupt_retries();
++    require_stable_lock_identity();
++    require_fence_epoch_cas_clear();
++    require_fake_storage_identity_binding();
++    require_fake_lock_recreation_invalidates_authority();
++    require_directory_lineage_fence_cleanup();
++    require_fenced_fresh_create_reconciles();
++    require_create_post_failure_clearance_proof();
++    require_retained_fresh_create_requires_live_lock();
++    require_repair_faults();
++    require_read_only_recovery_faults();
++    require_physical_compaction();
++    require_exact_schema_export();
++    require_unsupported_preflight();
++    require_native_preflight_identity_phase_residue();
++    require_native_preflight_fence_blocks_nonfresh_authority();
++    require_native_preflight_preserves_siblings();
++    require_native_preflight_stage_collision_exhaustion_is_fenced();
++    require_native_relative_directory_binding();
++    require_native_unbound_adapter_preserves_working_directory();
++    require_native_bounded_read_boundaries();
++    require_native_literal_children();
++    require_native_fresh_namespace_asymmetry();
++    require_symlink_fixture_unavailability_contract();
++    require_native_fixed_child_poisoning();
++    require_native_storage_identity_binding();
++    require_native_lock_recreation_invalidates_authority();
++    require_native_lock_path_revalidation();
++    require_same_process_cas_race();
++    return 0;
++}
+diff --git c/test/residency/recovery/journal_persistence_test_support.cpp i/test/residency/recovery/journal_persistence_test_support.cpp
+new file mode 100644
+index 0000000000000000000000000000000000000000..f61bc001776943e816e5bae272effdbc75300f1d
+--- /dev/null
++++ i/test/residency/recovery/journal_persistence_test_support.cpp
+@@ -0,0 +1,2294 @@
++#include "journal_persistence_test_support.h"
++
++#include "platform/durable_file_adapter.h"
++
++#include <algorithm>
++#include <atomic>
++#include <cerrno>
++#include <chrono>
++#include <condition_variable>
++#include <cstddef>
++#include <cstdint>
++#include <deque>
++#include <filesystem>
++#include <fstream>
++#include <map>
++#include <memory>
++#include <mutex>
++#include <optional>
++#include <set>
++#include <string>
++#include <string_view>
++#include <utility>
++#include <vector>
++
++#ifdef _WIN32
++#include <windows.h>
++#else
++#include <fcntl.h>
++#include <sys/file.h>
++#include <unistd.h>
++#endif
++
++namespace lemon::residency::testing {
++
++namespace {
++
++using detail::DurableFileChannel;
++using detail::DurableFileResult;
++using detail::DurableFileStatus;
++using detail::DurableInterruptibleCall;
++using detail::DurableReadChannel;
++using detail::DurableReadChunkResult;
++using detail::DurableWriteResult;
++
++constexpr std::string_view journal_name = "journal.jsonl";
++constexpr std::string_view root_name = "authority-root.json";
++constexpr std::string_view lock_name = "authority.lock";
++constexpr std::string_view journal_stage_name = ".journal.jsonl.stage";
++constexpr std::string_view root_stage_name = ".authority-root.json.stage";
++constexpr std::string_view preflight_probe_name = ".durability-probe";
++constexpr std::string_view preflight_stage_name = ".durability-probe.stage";
++
++std::atomic<std::uint64_t> next_directory_identity{1};
++std::atomic<std::uint64_t> next_entry_identity{1};
++std::atomic<std::uint64_t> next_handle_identity{1};
++
++DurableFileResult result(DurableFileStatus status) {
++    return DurableFileResult{status, {}};
++}
++
++DurableFileResult succeeded() { return result(DurableFileStatus::Succeeded); }
++
++bool is_succeeded(const DurableFileResult &value) {
++    return value.status == DurableFileStatus::Succeeded;
++}
++
++DurableFileResult
++promote_after_persistent_effect(DurableFileResult value) {
++    if (is_succeeded(value) ||
++        value.status == DurableFileStatus::EffectMayHaveOccurred) {
++        return value;
++    }
++    return {DurableFileStatus::EffectMayHaveOccurred,
++            std::move(value.diagnostic)};
++}
++
++HelperResultKind helper_result_kind(DurableFileStatus status) {
++    switch (status) {
++    case DurableFileStatus::Succeeded:
++        return HelperResultKind::Succeeded;
++    case DurableFileStatus::Interrupted:
++        return HelperResultKind::Interrupted;
++    case DurableFileStatus::EffectMayHaveOccurred:
++        return HelperResultKind::EffectMayHaveOccurred;
++    case DurableFileStatus::Unsupported:
++    case DurableFileStatus::NotFound:
++    case DurableFileStatus::AlreadyExists:
++    case DurableFileStatus::FailedBeforeEffect:
++        return HelperResultKind::FailedBeforeEffect;
++    }
++    return HelperResultKind::FailedBeforeEffect;
++}
++
++bool is_authority_operation(FaultOperation operation) {
++    switch (operation) {
++    case FaultOperation::AuthorityIdentityRead:
++    case FaultOperation::FixedNamespaceInspect:
++    case FaultOperation::RootOpen:
++    case FaultOperation::RootRead:
++    case FaultOperation::RootClose:
++    case FaultOperation::JournalOpen:
++    case FaultOperation::JournalRead:
++    case FaultOperation::JournalReadClose:
++    case FaultOperation::JournalAppendOpen:
++    case FaultOperation::InitialJournalCreate:
++    case FaultOperation::JournalWrite:
++    case FaultOperation::JournalFlush:
++    case FaultOperation::JournalClose:
++    case FaultOperation::RootStageCreate:
++    case FaultOperation::RootStageWrite:
++    case FaultOperation::RootStageFlush:
++    case FaultOperation::RootStageClose:
++    case FaultOperation::RootReplace:
++    case FaultOperation::NamespaceDurability:
++    case FaultOperation::TailRepairOpen:
++    case FaultOperation::TailRepairTruncate:
++    case FaultOperation::TailRepairFlush:
++    case FaultOperation::TailRepairClose:
++    case FaultOperation::CompactionStageCreate:
++    case FaultOperation::CompactionWrite:
++    case FaultOperation::CompactionFlush:
++    case FaultOperation::CompactionClose:
++    case FaultOperation::CompactionReplace:
++    case FaultOperation::CompactionNamespaceDurability:
++        return true;
++    default:
++        return false;
++    }
++}
++
++class ScriptedProbeChannel final : public DurableFileChannel {
++public:
++    explicit ScriptedProbeChannel(std::vector<FaultAction> script,
++                                  std::string initial = {})
++        : script_(std::move(script)), bytes_(std::move(initial)) {}
++
++    DurableWriteResult write_some(std::string_view bytes) override {
++        ++attempts_;
++        const auto action = next_action();
++        if (!action.has_value()) {
++            bytes_.append(bytes);
++            return {succeeded(), bytes.size()};
++        }
++        switch (*action) {
++        case FaultAction::ShortWrite: {
++            const auto transferred =
++                bytes.size() <= 1 ? bytes.size() : bytes.size() / 2;
++            bytes_.append(bytes.substr(0, transferred));
++            return {succeeded(), transferred};
++        }
++        case FaultAction::InterruptedOnce:
++            return {result(DurableFileStatus::Interrupted), 0};
++        case FaultAction::ZeroProgress:
++            return {succeeded(), 0};
++        case FaultAction::OverreportedWrite:
++            return {succeeded(), bytes.size() + 1};
++        case FaultAction::EffectThenError:
++            bytes_.append(bytes);
++            return {result(DurableFileStatus::EffectMayHaveOccurred),
++                    bytes.size()};
++        case FaultAction::Error:
++        case FaultAction::Crash:
++            return {result(DurableFileStatus::FailedBeforeEffect), 0};
++        }
++        return {result(DurableFileStatus::Unsupported), 0};
++    }
++
++    DurableFileResult flush() override {
++        ++attempts_;
++        return scripted_call([] {});
++    }
++
++    DurableFileResult truncate(std::size_t bytes) override {
++        ++attempts_;
++        return scripted_call(
++            [&] { bytes_.resize(std::min(bytes, bytes_.size())); });
++    }
++
++    DurableFileResult close() override {
++        ++attempts_;
++        return scripted_call([] {});
++    }
++
++    const std::string &bytes() const noexcept { return bytes_; }
++    std::size_t attempts() const noexcept { return attempts_; }
++
++private:
++    std::optional<FaultAction> next_action() {
++        if (next_action_ == script_.size()) {
++            return std::nullopt;
++        }
++        return script_[next_action_++];
++    }
++
++    template <typename Effect> DurableFileResult scripted_call(Effect effect) {
++        const auto action = next_action();
++        if (!action.has_value()) {
++            effect();
++            return succeeded();
++        }
++        switch (*action) {
++        case FaultAction::InterruptedOnce:
++            return result(DurableFileStatus::Interrupted);
++        case FaultAction::Error:
++        case FaultAction::Crash:
++        case FaultAction::ZeroProgress:
++        case FaultAction::OverreportedWrite:
++            return result(DurableFileStatus::FailedBeforeEffect);
++        case FaultAction::EffectThenError:
++            effect();
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        case FaultAction::ShortWrite:
++            effect();
++            return succeeded();
++        }
++        return result(DurableFileStatus::Unsupported);
++    }
++
++    std::vector<FaultAction> script_;
++    std::size_t next_action_ = 0;
++    std::string bytes_;
++    std::size_t attempts_ = 0;
++};
++
++class ScriptedOrchestrationChannel final : public DurableFileChannel {
++public:
++    ScriptedOrchestrationChannel(std::vector<FaultAction> write_script,
++                                 std::vector<FaultAction> flush_script,
++                                 std::vector<FaultAction> truncate_script,
++                                 std::vector<FaultAction> close_script,
++                                 std::string initial = {})
++        : write_script_(std::move(write_script)),
++          flush_script_(std::move(flush_script)),
++          truncate_script_(std::move(truncate_script)),
++          close_script_(std::move(close_script)), bytes_(std::move(initial)) {}
++
++    DurableWriteResult write_some(std::string_view bytes) override {
++        ++write_attempts_;
++        const auto action = next_action(write_script_, next_write_action_);
++        if (!action.has_value()) {
++            bytes_.append(bytes);
++            return {succeeded(), bytes.size()};
++        }
++        switch (*action) {
++        case FaultAction::ShortWrite: {
++            const auto transferred =
++                bytes.size() <= 1 ? bytes.size() : bytes.size() / 2;
++            bytes_.append(bytes.substr(0, transferred));
++            return {succeeded(), transferred};
++        }
++        case FaultAction::InterruptedOnce:
++            return {result(DurableFileStatus::Interrupted), 0};
++        case FaultAction::ZeroProgress:
++            return {succeeded(), 0};
++        case FaultAction::OverreportedWrite:
++            return {succeeded(), bytes.size() + 1};
++        case FaultAction::EffectThenError:
++            bytes_.append(bytes);
++            return {result(DurableFileStatus::EffectMayHaveOccurred),
++                    bytes.size()};
++        case FaultAction::Error:
++        case FaultAction::Crash:
++            return {result(DurableFileStatus::FailedBeforeEffect), 0};
++        }
++        return {result(DurableFileStatus::Unsupported), 0};
++    }
++
++    DurableFileResult flush() override {
++        ++flush_attempts_;
++        return scripted_call(flush_script_, next_flush_action_, [] {});
++    }
++
++    DurableFileResult truncate(std::size_t bytes) override {
++        ++truncate_attempts_;
++        return scripted_call(truncate_script_, next_truncate_action_, [&] {
++            bytes_.resize(std::min(bytes, bytes_.size()));
++        });
++    }
++
++    DurableFileResult close() override {
++        ++close_attempts_;
++        return scripted_call(close_script_, next_close_action_, [] {});
++    }
++
++    const std::string &bytes() const noexcept { return bytes_; }
++    std::size_t write_attempts() const noexcept { return write_attempts_; }
++    std::size_t flush_attempts() const noexcept { return flush_attempts_; }
++    std::size_t truncate_attempts() const noexcept {
++        return truncate_attempts_;
++    }
++    std::size_t close_attempts() const noexcept { return close_attempts_; }
++
++private:
++    static std::optional<FaultAction>
++    next_action(const std::vector<FaultAction> &script, std::size_t &next) {
++        if (next == script.size()) {
++            return std::nullopt;
++        }
++        return script[next++];
++    }
++
++    template <typename Effect>
++    static DurableFileResult
++    scripted_call(const std::vector<FaultAction> &script, std::size_t &next,
++                  Effect effect) {
++        const auto action = next_action(script, next);
++        if (!action.has_value()) {
++            effect();
++            return succeeded();
++        }
++        switch (*action) {
++        case FaultAction::InterruptedOnce:
++            return result(DurableFileStatus::Interrupted);
++        case FaultAction::Error:
++        case FaultAction::Crash:
++        case FaultAction::ZeroProgress:
++        case FaultAction::OverreportedWrite:
++            return result(DurableFileStatus::FailedBeforeEffect);
++        case FaultAction::EffectThenError:
++            effect();
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        case FaultAction::ShortWrite:
++            effect();
++            return succeeded();
++        }
++        return result(DurableFileStatus::Unsupported);
++    }
++
++    std::vector<FaultAction> write_script_;
++    std::vector<FaultAction> flush_script_;
++    std::vector<FaultAction> truncate_script_;
++    std::vector<FaultAction> close_script_;
++    std::size_t next_write_action_ = 0;
++    std::size_t next_flush_action_ = 0;
++    std::size_t next_truncate_action_ = 0;
++    std::size_t next_close_action_ = 0;
++    std::string bytes_;
++    std::size_t write_attempts_ = 0;
++    std::size_t flush_attempts_ = 0;
++    std::size_t truncate_attempts_ = 0;
++    std::size_t close_attempts_ = 0;
++};
++
++class ScriptedReadChannel final : public DurableReadChannel {
++public:
++    ScriptedReadChannel(std::string bytes, std::vector<FaultAction> read_script,
++                        std::vector<FaultAction> close_script)
++        : bytes_(std::move(bytes)), read_script_(std::move(read_script)),
++          close_script_(std::move(close_script)) {}
++
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        ++read_attempts_;
++        requested_bytes_.push_back(max_bytes);
++        const auto action = next_action(read_script_, next_read_action_);
++        if (action == FaultAction::InterruptedOnce) {
++            return record_chunk(
++                {result(DurableFileStatus::Interrupted), {}, false});
++        }
++        if (action == FaultAction::ZeroProgress) {
++            return record_chunk({succeeded(), {}, false});
++        }
++        if (action == FaultAction::OverreportedWrite) {
++            return record_chunk(
++                {succeeded(), std::string(max_bytes + 1, 'x'), false});
++        }
++        if (action == FaultAction::Error || action == FaultAction::Crash) {
++            return record_chunk(
++                {result(DurableFileStatus::FailedBeforeEffect), {}, false});
++        }
++
++        auto transferred = std::min(max_bytes, bytes_.size() - offset_);
++        if (action == FaultAction::ShortWrite && transferred > 1) {
++            transferred /= 2;
++        }
++        auto chunk = bytes_.substr(offset_, transferred);
++        offset_ += transferred;
++        const auto end_of_file = transferred == 0 && offset_ == bytes_.size();
++        if (action == FaultAction::EffectThenError) {
++            return record_chunk(
++                {result(DurableFileStatus::EffectMayHaveOccurred),
++                 std::move(chunk), end_of_file});
++        }
++        return record_chunk({succeeded(), std::move(chunk), end_of_file});
++    }
++
++    DurableFileResult close() override {
++        ++close_attempts_;
++        const auto action = next_action(close_script_, next_close_action_);
++        if (!action.has_value() || action == FaultAction::ShortWrite) {
++            return succeeded();
++        }
++        if (action == FaultAction::InterruptedOnce) {
++            return result(DurableFileStatus::Interrupted);
++        }
++        if (action == FaultAction::EffectThenError) {
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        }
++        return result(DurableFileStatus::FailedBeforeEffect);
++    }
++
++    const std::vector<std::size_t> &requested_bytes() const noexcept {
++        return requested_bytes_;
++    }
++    const std::vector<std::size_t> &returned_bytes() const noexcept {
++        return returned_bytes_;
++    }
++    std::size_t read_attempts() const noexcept { return read_attempts_; }
++    std::size_t close_attempts() const noexcept { return close_attempts_; }
++
++private:
++    static std::optional<FaultAction>
++    next_action(const std::vector<FaultAction> &script, std::size_t &next) {
++        if (next == script.size()) {
++            return std::nullopt;
++        }
++        return script[next++];
++    }
++
++    DurableReadChunkResult record_chunk(DurableReadChunkResult chunk) {
++        returned_bytes_.push_back(chunk.bytes.size());
++        return chunk;
++    }
++
++    std::string bytes_;
++    std::vector<FaultAction> read_script_;
++    std::vector<FaultAction> close_script_;
++    std::vector<std::size_t> requested_bytes_;
++    std::vector<std::size_t> returned_bytes_;
++    std::size_t offset_ = 0;
++    std::size_t next_read_action_ = 0;
++    std::size_t next_close_action_ = 0;
++    std::size_t read_attempts_ = 0;
++    std::size_t close_attempts_ = 0;
++};
++
++} // namespace
++
++struct JournalTestStorage::State {
++    enum class EntryKind { Regular, Symlink, NonRegular, ReparsePoint };
++
++    struct Entry {
++        EntryKind kind = EntryKind::Regular;
++        std::string live_bytes;
++        std::string durable_bytes;
++        bool live_exists = false;
++        bool durable_exists = false;
++        bool durable_content_available = false;
++        std::uint64_t identity = 0;
++    };
++
++    struct FaultScript {
++        FaultOperation operation;
++        FaultPosition position;
++        std::deque<FaultAction> actions;
++    };
++
++    explicit State(PlatformContract selected_platform, bool directory_present)
++        : platform(selected_platform),
++          authority_directory_exists(directory_present),
++          directory_identity(next_directory_identity.fetch_add(1)) {}
++
++    void add_durable_regular(std::string_view name, std::string bytes) {
++        auto &entry = entries[std::string(name)];
++        entry.kind = EntryKind::Regular;
++        entry.live_bytes = bytes;
++        entry.durable_bytes = std::move(bytes);
++        entry.live_exists = true;
++        entry.durable_exists = true;
++        entry.durable_content_available = true;
++        if (entry.identity == 0) {
++            entry.identity = next_entry_identity.fetch_add(1);
++        }
++    }
++
++    Entry *live_entry(std::string_view name) {
++        const auto found = entries.find(std::string(name));
++        if (found == entries.end() || !found->second.live_exists) {
++            return nullptr;
++        }
++        return &found->second;
++    }
++
++    const Entry *live_entry(std::string_view name) const {
++        const auto found = entries.find(std::string(name));
++        if (found == entries.end() || !found->second.live_exists) {
++            return nullptr;
++        }
++        return &found->second;
++    }
++
++    void observe(FaultOperation operation, bool lock_held,
++                 bool mutation_attempted, std::uint64_t lock_identity,
++                 std::size_t requested_bytes = 0,
++                 std::size_t transferred_bytes = 0) {
++        observations.push_back(OperationObservation{
++            operation, lock_held, mutation_attempted, lock_identity,
++            requested_bytes, transferred_bytes});
++    }
++
++    std::optional<FaultAction> take_fault(FaultOperation operation,
++                                          FaultPosition position) {
++        if (!fault.has_value() || fault->operation != operation ||
++            fault->position != position || fault->actions.empty()) {
++            return std::nullopt;
++        }
++        const auto action = fault->actions.front();
++        fault->actions.pop_front();
++        if (fault->actions.empty()) {
++            fault.reset();
++        }
++        return action;
++    }
++
++    void restart() {
++        if (simulated_crash) {
++            for (auto &[name, entry] : entries) {
++                static_cast<void>(name);
++                if (entry.kind == EntryKind::Regular && entry.live_exists &&
++                    entry.durable_content_available) {
++                    entry.durable_exists = true;
++                }
++            }
++        }
++        for (auto &[name, entry] : entries) {
++            static_cast<void>(name);
++            entry.live_exists = entry.durable_exists;
++            entry.live_bytes = entry.durable_bytes;
++        }
++        held_lock_identities.clear();
++        blocked_lock_waiters = 0;
++        fault.reset();
++        pause_operation.reset();
++        pause_occurrence = 0;
++        paused = false;
++        pause_released = false;
++        open_entries.clear();
++        open_lock_handles.clear();
++        simulated_crash = false;
++        condition.notify_all();
++    }
++
++    PlatformContract platform;
++    bool authority_directory_exists;
++    const std::uint64_t directory_identity;
++    std::map<std::string, Entry> entries;
++    std::set<DurabilityCapability> unavailable_capabilities;
++    std::optional<FaultScript> fault;
++    std::vector<OperationObservation> observations;
++    std::set<std::uint64_t> held_lock_identities;
++    std::size_t blocked_lock_waiters = 0;
++    std::optional<FaultOperation> pause_operation;
++    std::size_t pause_occurrence = 0;
++    bool pause_consumed = false;
++    bool paused = false;
++    bool pause_released = false;
++    std::set<std::string> open_entries;
++    std::set<std::uint64_t> open_lock_handles;
++    bool simulated_crash = false;
++    mutable std::mutex mutex;
++    std::condition_variable condition;
++};
++
++HelperProbeResult probe_write_all(std::string bytes,
++                                  std::vector<FaultAction> script) {
++    ScriptedProbeChannel channel(std::move(script));
++    const auto call_result = detail::write_all(channel, bytes);
++    return {helper_result_kind(call_result.status), channel.bytes(),
++            channel.attempts()};
++}
++
++HelperProbeResult probe_flush_retry(std::vector<FaultAction> script) {
++    ScriptedProbeChannel channel(std::move(script));
++    const auto call_result = detail::flush_retrying_interrupts(channel);
++    return {helper_result_kind(call_result.status), channel.bytes(),
++            channel.attempts()};
++}
++
++HelperProbeResult probe_truncate_retry(std::string bytes,
++                                       std::size_t truncate_to,
++                                       std::vector<FaultAction> script) {
++    ScriptedProbeChannel channel(std::move(script), std::move(bytes));
++    const auto call_result =
++        detail::truncate_retrying_interrupts(channel, truncate_to);
++    return {helper_result_kind(call_result.status), channel.bytes(),
++            channel.attempts()};
++}
++
++HelperProbeResult probe_close_once(std::vector<FaultAction> script) {
++    ScriptedProbeChannel channel(std::move(script));
++    const auto call_result = detail::close_once(channel);
++    return {helper_result_kind(call_result.status), channel.bytes(),
++            channel.attempts()};
++}
++
++HelperOrchestrationProbeResult
++probe_write_flush_close(std::string bytes,
++                        std::vector<FaultAction> write_script,
++                        std::vector<FaultAction> flush_script,
++                        std::vector<FaultAction> close_script) {
++    ScriptedOrchestrationChannel channel(std::move(write_script),
++                                         std::move(flush_script), {},
++                                         std::move(close_script));
++    const auto call_result = detail::write_flush_close(channel, bytes);
++    return {helper_result_kind(call_result.status),
++            channel.bytes(),
++            channel.write_attempts(),
++            channel.flush_attempts(),
++            channel.truncate_attempts(),
++            channel.close_attempts()};
++}
++
++HelperOrchestrationProbeResult
++probe_truncate_flush_close(std::string bytes, std::size_t truncate_to,
++                           std::vector<FaultAction> truncate_script,
++                           std::vector<FaultAction> flush_script,
++                           std::vector<FaultAction> close_script) {
++    ScriptedOrchestrationChannel channel(
++        {}, std::move(flush_script), std::move(truncate_script),
++        std::move(close_script), std::move(bytes));
++    const auto call_result = detail::truncate_flush_close(channel, truncate_to);
++    return {helper_result_kind(call_result.status),
++            channel.bytes(),
++            channel.write_attempts(),
++            channel.flush_attempts(),
++            channel.truncate_attempts(),
++            channel.close_attempts()};
++}
++
++ReadHelperProbeResult
++probe_read_bounded_close(std::string bytes, std::size_t max_bytes,
++                         std::vector<FaultAction> read_script,
++                         std::vector<FaultAction> close_script) {
++    ScriptedReadChannel channel(std::move(bytes), std::move(read_script),
++                                std::move(close_script));
++    const auto call_result = detail::read_bounded_close(channel, max_bytes);
++    return {helper_result_kind(call_result.result.status),
++            std::move(call_result.bytes),
++            call_result.truncated,
++            channel.requested_bytes(),
++            channel.returned_bytes(),
++            channel.read_attempts(),
++            channel.close_attempts()};
++}
++
++NativeLockPathProbeResult
++probe_native_lock_path_revalidation(std::string directory) {
++    const auto root = std::filesystem::path(std::move(directory));
++    const auto lock_path = root / "authority.lock";
++    auto first = detail::make_platform_durable_file_adapter(root);
++    auto second = detail::make_platform_durable_file_adapter(root);
++    const auto first_lock = first->lock_authority();
++    const auto first_identity = first->authority_identity();
++    if (!first_lock.succeeded() || !first_identity.result.succeeded()) {
++        return {};
++    }
++
++    std::error_code error;
++    const auto removed_while_held = std::filesystem::remove(lock_path, error);
++    const bool replacement_prevented = !removed_while_held || error;
++    bool stale_identity_rejected = false;
++    if (!replacement_prevented) {
++        std::ofstream(lock_path, std::ios::binary).close();
++        stale_identity_rejected =
++            !first->authority_identity().result.succeeded();
++    }
++
++#ifdef _WIN32
++    const auto probe_handle = ::CreateFileW(
++        lock_path.c_str(), GENERIC_READ | GENERIC_WRITE,
++        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
++        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
++    OVERLAPPED overlapped{};
++    const auto probe_locked =
++        probe_handle != INVALID_HANDLE_VALUE &&
++        ::LockFileEx(probe_handle,
++                     LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0,
++                     MAXDWORD, MAXDWORD, &overlapped) != FALSE;
++    const auto nonblocking_probe_rejected =
++        !probe_locked && ::GetLastError() == ERROR_LOCK_VIOLATION;
++    if (probe_locked) {
++        static_cast<void>(
++            ::UnlockFileEx(probe_handle, 0, MAXDWORD, MAXDWORD, &overlapped));
++    }
++    if (probe_handle != INVALID_HANDLE_VALUE) {
++        static_cast<void>(::CloseHandle(probe_handle));
++    }
++#else
++    const auto probe_fd =
++        ::open(root.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
++    errno = 0;
++    const auto probe_locked =
++        probe_fd >= 0 && ::flock(probe_fd, LOCK_EX | LOCK_NB) == 0;
++    const auto nonblocking_probe_rejected =
++        !probe_locked && (errno == EWOULDBLOCK || errno == EAGAIN);
++    if (probe_locked) {
++        static_cast<void>(::flock(probe_fd, LOCK_UN));
++    }
++    if (probe_fd >= 0) {
++        static_cast<void>(::close(probe_fd));
++    }
++#endif
++    const auto first_unlock = first->unlock_authority();
++    detail::DurableFileResult contender_lock;
++    detail::DurableIdentityResult contender_identity;
++    detail::DurableFileResult contender_unlock;
++    if (first_unlock.succeeded()) {
++        contender_lock = second->lock_authority();
++        if (contender_lock.succeeded()) {
++            contender_identity = second->authority_identity();
++            contender_unlock = second->unlock_authority();
++        }
++    }
++
++    const bool contender_succeeded =
++        contender_lock.succeeded() && contender_identity.result.succeeded() &&
++        contender_unlock.succeeded();
++    const bool contender_rebound =
++        contender_succeeded &&
++        contender_identity.identity != first_identity.identity;
++
++    bool replacement_after_release_rebound = false;
++    if (replacement_prevented && contender_succeeded) {
++        error.clear();
++        const auto removed_after_release =
++            std::filesystem::remove(lock_path, error);
++        if (removed_after_release && !error) {
++            std::ofstream(lock_path, std::ios::binary).close();
++            auto rebound = detail::make_platform_durable_file_adapter(root);
++            const auto rebound_lock = rebound->lock_authority();
++            const auto rebound_identity = rebound->authority_identity();
++            const auto rebound_unlock = rebound->unlock_authority();
++            replacement_after_release_rebound =
++                rebound_lock.succeeded() &&
++                rebound_identity.result.succeeded() &&
++                rebound_identity.identity != first_identity.identity &&
++                rebound_unlock.succeeded();
++        }
++    }
++
++    return {replacement_prevented,
++            stale_identity_rejected,
++            nonblocking_probe_rejected,
++            first_unlock.succeeded(),
++            contender_succeeded,
++            contender_rebound,
++            replacement_after_release_rebound};
++}
++
++class JournalTestStorage::Adapter final : public detail::DurableFileAdapter {
++public:
++    explicit Adapter(std::shared_ptr<State> state)
++        : state_(std::move(state)),
++          lock_handle_identity_(next_handle_identity.fetch_add(1)) {}
++
++    ~Adapter() override {
++        std::lock_guard lock(state_->mutex);
++        release_owned_lock();
++        if (!state_->simulated_crash) {
++            close_open_lock_handle();
++        }
++    }
++
++    DurableFileResult lock_authority() override {
++        {
++            std::unique_lock lock(state_->mutex);
++            const auto opened =
++                run_step(lock, FaultOperation::AuthorityLockOpen, false, [&] {
++                    if (!state_->authority_directory_exists) {
++                        return;
++                    }
++                    if (state_->live_entry(lock_name) == nullptr) {
++                        state_->add_durable_regular(lock_name, {});
++                    }
++                    state_->open_lock_handles.insert(lock_handle_identity_);
++                });
++            if (!is_succeeded(opened)) {
++                return close_lock_after(lock, opened);
++            }
++            const auto *entry = state_->live_entry(lock_name);
++            if (!state_->authority_directory_exists || entry == nullptr ||
++                entry->kind != State::EntryKind::Regular) {
++                return close_lock_after(lock,
++                                        result(DurableFileStatus::Unsupported));
++            }
++            opened_lock_identity_ = entry->identity;
++        }
++
++        class AcquireCall final : public DurableInterruptibleCall {
++        public:
++            explicit AcquireCall(Adapter &adapter) : adapter_(adapter) {}
++
++            DurableFileResult attempt() override {
++                return adapter_.acquire_opened_lock_once();
++            }
++
++        private:
++            Adapter &adapter_;
++        } acquire_call(*this);
++
++        const auto acquired = detail::retry_interrupted(acquire_call);
++        if (!is_succeeded(acquired)) {
++            std::unique_lock lock(state_->mutex);
++            return close_lock_after(lock, acquired);
++        }
++
++        std::unique_lock lock(state_->mutex);
++        const auto *current = state_->live_entry(lock_name);
++        if (current != nullptr && current->kind == State::EntryKind::Regular &&
++            current->identity == opened_lock_identity_) {
++            pause_if_requested(lock, FaultOperation::AuthorityLockAcquire);
++            current = state_->live_entry(lock_name);
++            if (current != nullptr &&
++                current->kind == State::EntryKind::Regular &&
++                current->identity == opened_lock_identity_) {
++                return succeeded();
++            }
++        }
++        const auto unlocked = run_step(lock, FaultOperation::AuthorityUnlock,
++                                       false, [&] { release_owned_lock(); });
++        return close_lock_after(
++            lock, combine_results(result(DurableFileStatus::FailedBeforeEffect),
++                                  unlocked));
++    }
++
++    detail::DurableIdentityResult authority_identity() override {
++        std::unique_lock lock(state_->mutex);
++        const auto checked =
++            run_step(lock, FaultOperation::AuthorityIdentityRead, false, [] {});
++        if (!is_succeeded(checked)) {
++            return {checked, {}};
++        }
++        const auto *current = state_->live_entry(lock_name);
++        if (!owns_lock() || current == nullptr ||
++            current->kind != State::EntryKind::Regular ||
++            current->identity != opened_lock_identity_) {
++            return {result(DurableFileStatus::FailedBeforeEffect), {}};
++        }
++        return {succeeded(),
++                "directory:" + std::to_string(state_->directory_identity) +
++                    "/lock:" + std::to_string(opened_lock_identity_)};
++    }
++
++    DurableFileResult preflight_capabilities() override {
++        const std::vector<
++            std::pair<FaultOperation, std::optional<DurabilityCapability>>>
++            operations{
++                {FaultOperation::PreflightProbe, std::nullopt},
++                {FaultOperation::PreflightFlushCreate, std::nullopt},
++                {FaultOperation::PreflightFlushWrite, std::nullopt},
++                {FaultOperation::PreflightFlushFileFlush,
++                 DurabilityCapability::RegularFileFlush},
++                {FaultOperation::PreflightFlushClose, std::nullopt},
++                {FaultOperation::PreflightTruncate,
++                 DurabilityCapability::TailTruncateAndFlush},
++                {FaultOperation::PreflightTruncateFlush,
++                 DurabilityCapability::TailTruncateAndFlush},
++                {FaultOperation::PreflightTruncateClose, std::nullopt},
++                {FaultOperation::PreflightReplaceStageCreate, std::nullopt},
++                {FaultOperation::PreflightReplaceStageWrite, std::nullopt},
++                {FaultOperation::PreflightReplaceStageFlush, std::nullopt},
++                {FaultOperation::PreflightReplaceStageClose, std::nullopt},
++                {FaultOperation::PreflightReplace,
++                 DurabilityCapability::SameDirectoryReplace},
++                {FaultOperation::PreflightNamespaceDurability,
++                 DurabilityCapability::NamespaceDurability},
++                {FaultOperation::PreflightCleanup, std::nullopt},
++            };
++
++        for (const auto &[operation, capability] : operations) {
++            class PreflightCall final : public DurableInterruptibleCall {
++            public:
++                PreflightCall(Adapter &adapter, FaultOperation operation)
++                    : adapter_(adapter), operation_(operation) {}
++
++                DurableFileResult attempt() override {
++                    std::unique_lock lock(adapter_.state_->mutex);
++                    return adapter_.run_step(lock, operation_, false, [&] {
++                        adapter_.apply_preflight_operation(operation_);
++                    });
++                }
++
++            private:
++                Adapter &adapter_;
++                FaultOperation operation_;
++            } call(*this, operation);
++            const auto checked = is_preflight_close(operation)
++                                     ? call.attempt()
++                                     : detail::retry_interrupted(call);
++            if (!is_succeeded(checked)) {
++                return finish_preflight_failure(operation, checked);
++            }
++            if (is_preflight_close(operation)) {
++                std::lock_guard lock(state_->mutex);
++                close_preflight_handle(operation);
++            }
++            bool unavailable = false;
++            bool unsafe_fixed_entry = false;
++            {
++                std::lock_guard lock(state_->mutex);
++                unavailable =
++                    capability.has_value() &&
++                    state_->unavailable_capabilities.count(*capability) != 0;
++                unsafe_fixed_entry =
++                    operation == FaultOperation::PreflightProbe &&
++                    !fixed_entries_are_safe();
++            }
++            if (unavailable) {
++                return finish_preflight_failure(
++                    operation, result(DurableFileStatus::Unsupported));
++            }
++            if (unsafe_fixed_entry) {
++                return result(DurableFileStatus::Unsupported);
++            }
++        }
++        return succeeded();
++    }
++
++    detail::DurableFixedNamespaceResult inspect_fixed_namespace() override {
++        std::unique_lock lock(state_->mutex);
++        const auto inspected =
++            run_step(lock, FaultOperation::FixedNamespaceInspect, false, [] {});
++        if (!is_succeeded(inspected)) {
++            return {inspected, false, false, false, false, false};
++        }
++        if (!owns_lock() || !fixed_entries_are_safe()) {
++            return {result(DurableFileStatus::Unsupported),
++                    false,
++                    false,
++                    false,
++                    false,
++                    false};
++        }
++        return {succeeded(),
++                state_->live_entry(journal_name) != nullptr,
++                state_->live_entry(root_name) != nullptr,
++                state_->live_entry(journal_stage_name) != nullptr,
++                state_->live_entry(root_stage_name) != nullptr,
++                state_->live_entry(lock_name) != nullptr};
++    }
++
++    detail::DurableReadResult read_root(std::size_t max_bytes) override {
++        return read_fixed(root_name, FaultOperation::RootOpen,
++                          FaultOperation::RootRead, FaultOperation::RootClose,
++                          max_bytes);
++    }
++
++    detail::DurableReadResult read_journal(std::size_t max_bytes) override {
++        return read_fixed(journal_name, FaultOperation::JournalOpen,
++                          FaultOperation::JournalRead,
++                          FaultOperation::JournalReadClose, max_bytes);
++    }
++
++    DurableFileResult create_journal(std::string_view bytes) override {
++        {
++            std::unique_lock lock(state_->mutex);
++            if (state_->live_entry(journal_name) != nullptr) {
++                return result(DurableFileStatus::AlreadyExists);
++            }
++            const auto created =
++                run_step(lock, FaultOperation::InitialJournalCreate, true, [&] {
++                    auto &entry = state_->entries[std::string(journal_name)];
++                    entry.kind = State::EntryKind::Regular;
++                    entry.live_exists = true;
++                    entry.live_bytes.clear();
++                    entry.identity = next_entry_identity.fetch_add(1);
++                    state_->open_entries.insert(std::string(journal_name));
++                });
++            if (!is_succeeded(created)) {
++                if (state_->open_entries.count(std::string(journal_name)) ==
++                        0 ||
++                    state_->simulated_crash) {
++                    return created;
++                }
++                const auto closed =
++                    run_step(lock, FaultOperation::JournalClose, false, [&] {
++                        state_->open_entries.erase(std::string(journal_name));
++                    });
++                state_->open_entries.erase(std::string(journal_name));
++                return combine_results(created, closed);
++            }
++        }
++        Channel channel(
++            *this, journal_name, false, FaultOperation::JournalWrite,
++            FaultOperation::JournalFlush, FaultOperation::JournalWrite,
++            FaultOperation::JournalClose);
++        return promote_after_persistent_effect(
++            detail::write_flush_close(channel, bytes));
++    }
++
++    DurableFileResult append_journal(std::string_view bytes) override {
++        {
++            std::unique_lock lock(state_->mutex);
++            const auto journal_exists =
++                state_->live_entry(journal_name) != nullptr;
++            const auto opened =
++                run_step(lock, FaultOperation::JournalAppendOpen, false, [&] {
++                    if (journal_exists) {
++                        state_->open_entries.insert(std::string(journal_name));
++                    }
++                });
++            if (!is_succeeded(opened)) {
++                if (state_->open_entries.count(std::string(journal_name)) ==
++                        0 ||
++                    state_->simulated_crash) {
++                    return result(DurableFileStatus::FailedBeforeEffect);
++                }
++                const auto closed =
++                    run_step(lock, FaultOperation::JournalClose, false, [&] {
++                        state_->open_entries.erase(std::string(journal_name));
++                    });
++                state_->open_entries.erase(std::string(journal_name));
++                static_cast<void>(closed);
++                return result(DurableFileStatus::FailedBeforeEffect);
++            }
++            if (state_->live_entry(journal_name) == nullptr) {
++                return result(DurableFileStatus::NotFound);
++            }
++        }
++        Channel channel(*this, journal_name, true, FaultOperation::JournalWrite,
++                        FaultOperation::JournalFlush,
++                        FaultOperation::JournalWrite,
++                        FaultOperation::JournalClose);
++        return detail::write_flush_close(channel, bytes);
++    }
++
++    DurableFileResult truncate_journal(std::size_t bytes) override {
++        {
++            std::unique_lock lock(state_->mutex);
++            const auto journal_exists =
++                state_->live_entry(journal_name) != nullptr;
++            const auto opened =
++                run_step(lock, FaultOperation::TailRepairOpen, false, [&] {
++                    if (journal_exists) {
++                        state_->open_entries.insert(std::string(journal_name));
++                    }
++                });
++            if (!is_succeeded(opened)) {
++                if (state_->open_entries.count(std::string(journal_name)) ==
++                        0 ||
++                    state_->simulated_crash) {
++                    return result(DurableFileStatus::FailedBeforeEffect);
++                }
++                const auto closed =
++                    run_step(lock, FaultOperation::TailRepairClose, false, [&] {
++                        state_->open_entries.erase(std::string(journal_name));
++                    });
++                state_->open_entries.erase(std::string(journal_name));
++                static_cast<void>(closed);
++                return result(DurableFileStatus::FailedBeforeEffect);
++            }
++            if (state_->live_entry(journal_name) == nullptr) {
++                return result(DurableFileStatus::NotFound);
++            }
++        }
++        Channel channel(
++            *this, journal_name, false, FaultOperation::JournalWrite,
++            FaultOperation::TailRepairFlush, FaultOperation::TailRepairTruncate,
++            FaultOperation::TailRepairClose);
++        return detail::truncate_flush_close(channel, bytes);
++    }
++
++    DurableFileResult replace_journal(std::string_view bytes) override {
++        return replace_fixed(
++            journal_stage_name, journal_name, bytes,
++            FaultOperation::CompactionStageCreate,
++            FaultOperation::CompactionWrite, FaultOperation::CompactionFlush,
++            FaultOperation::CompactionClose, FaultOperation::CompactionReplace,
++            FaultOperation::CompactionNamespaceDurability);
++    }
++
++    DurableFileResult replace_root(std::string_view bytes) override {
++        return replace_fixed(
++            root_stage_name, root_name, bytes, FaultOperation::RootStageCreate,
++            FaultOperation::RootStageWrite, FaultOperation::RootStageFlush,
++            FaultOperation::RootStageClose, FaultOperation::RootReplace,
++            FaultOperation::NamespaceDurability);
++    }
++
++    DurableFileResult unlock_authority() override {
++        std::unique_lock lock(state_->mutex);
++        const auto unlocked = run_step(lock, FaultOperation::AuthorityUnlock,
++                                       false, [&] { release_owned_lock(); });
++        return close_lock_after(lock, unlocked);
++    }
++
++private:
++    DurableFileResult
++    close_lock_after(std::unique_lock<std::mutex> &lock,
++                     const DurableFileResult &operation_result) {
++        if (state_->simulated_crash || !lock_handle_is_open()) {
++            return operation_result;
++        }
++        const auto closed =
++            run_step(lock, FaultOperation::AuthorityLockClose, false, [&] {
++                release_owned_lock();
++                close_open_lock_handle();
++            });
++        if (!state_->simulated_crash) {
++            release_owned_lock();
++            close_open_lock_handle();
++        }
++        return combine_results(operation_result, closed);
++    }
++
++    class Channel final : public DurableFileChannel {
++    public:
++        Channel(Adapter &adapter, std::string_view name, bool append,
++                FaultOperation write_operation, FaultOperation flush_operation,
++                FaultOperation truncate_operation,
++                FaultOperation close_operation)
++            : adapter_(adapter), name_(name), append_(append),
++              write_operation_(write_operation),
++              flush_operation_(flush_operation),
++              truncate_operation_(truncate_operation),
++              close_operation_(close_operation) {}
++
++        DurableWriteResult write_some(std::string_view bytes) override {
++            return adapter_.write_some(name_, bytes, append_ && wrote_any_,
++                                       append_ && !wrote_any_, write_operation_,
++                                       wrote_any_);
++        }
++
++        DurableFileResult flush() override {
++            std::unique_lock lock(adapter_.state_->mutex);
++            return adapter_.run_step(lock, flush_operation_, true, [&] {
++                auto *entry = adapter_.state_->live_entry(name_);
++                if (entry != nullptr) {
++                    entry->durable_bytes = entry->live_bytes;
++                    entry->durable_content_available = true;
++                }
++            });
++        }
++
++        DurableFileResult truncate(std::size_t bytes) override {
++            std::unique_lock lock(adapter_.state_->mutex);
++            return adapter_.run_step(
++                lock, truncate_operation_, true,
++                [&] {
++                    auto *entry = adapter_.state_->live_entry(name_);
++                    if (entry != nullptr) {
++                        entry->live_bytes.resize(
++                            std::min(bytes, entry->live_bytes.size()));
++                    }
++                },
++                bytes, bytes);
++        }
++
++        DurableFileResult close() override {
++            std::unique_lock lock(adapter_.state_->mutex);
++            if (adapter_.state_->simulated_crash) {
++                return result(DurableFileStatus::EffectMayHaveOccurred);
++            }
++            const auto closed =
++                adapter_.run_step(lock, close_operation_, false, [&] {
++                    adapter_.state_->open_entries.erase(name_);
++                });
++            if (!adapter_.state_->simulated_crash) {
++                adapter_.state_->open_entries.erase(name_);
++            }
++            return closed;
++        }
++
++    private:
++        Adapter &adapter_;
++        std::string name_;
++        bool append_;
++        FaultOperation write_operation_;
++        FaultOperation flush_operation_;
++        FaultOperation truncate_operation_;
++        FaultOperation close_operation_;
++        bool wrote_any_ = false;
++    };
++
++    class ReadChannel final : public DurableReadChannel {
++    public:
++        ReadChannel(Adapter &adapter, std::string_view name,
++                    FaultOperation read_operation,
++                    FaultOperation close_operation)
++            : adapter_(adapter), name_(name), read_operation_(read_operation),
++              close_operation_(close_operation) {}
++
++        DurableReadChunkResult read_some(std::size_t max_bytes) override {
++            std::unique_lock lock(adapter_.state_->mutex);
++            const auto *entry = adapter_.state_->live_entry(name_);
++            if (entry == nullptr) {
++                return {result(DurableFileStatus::NotFound), {}, false};
++            }
++            if (entry->kind != State::EntryKind::Regular) {
++                return {result(DurableFileStatus::Unsupported), {}, false};
++            }
++            const auto available =
++                offset_ < entry->live_bytes.size()
++                    ? entry->live_bytes.size() - offset_
++                    : 0;
++            const auto transferred = std::min(max_bytes, available);
++            std::string bytes;
++            bool end_of_file = false;
++            const auto read = adapter_.run_step(
++                lock, read_operation_, false,
++                [&] {
++                    if (transferred != 0) {
++                        bytes = entry->live_bytes.substr(offset_, transferred);
++                        offset_ += transferred;
++                    }
++                    end_of_file = available == 0;
++                },
++                max_bytes, transferred);
++            if (!is_succeeded(read) &&
++                read.status != DurableFileStatus::EffectMayHaveOccurred) {
++                return {read, {}, false};
++            }
++            return {read, std::move(bytes), end_of_file};
++        }
++
++        DurableFileResult close() override {
++            std::unique_lock lock(adapter_.state_->mutex);
++            if (adapter_.state_->simulated_crash) {
++                return result(DurableFileStatus::EffectMayHaveOccurred);
++            }
++            const auto closed =
++                adapter_.run_step(lock, close_operation_, false, [&] {
++                    adapter_.state_->open_entries.erase(name_);
++                });
++            if (!adapter_.state_->simulated_crash) {
++                adapter_.state_->open_entries.erase(name_);
++            }
++            return closed;
++        }
++
++    private:
++        Adapter &adapter_;
++        std::string name_;
++        FaultOperation read_operation_;
++        FaultOperation close_operation_;
++        std::size_t offset_ = 0;
++    };
++
++    DurableFileResult acquire_opened_lock_once() {
++        std::unique_lock lock(state_->mutex);
++        const auto before = state_->take_fault(
++            FaultOperation::AuthorityLockAcquire, FaultPosition::Before);
++        if (before.has_value()) {
++            if (*before == FaultAction::Crash) {
++                state_->simulated_crash = true;
++            }
++            if (*before == FaultAction::InterruptedOnce) {
++                state_->observe(FaultOperation::AuthorityLockAcquire, false,
++                                false, opened_lock_identity_);
++                return result(DurableFileStatus::Interrupted);
++            }
++            if (*before != FaultAction::EffectThenError) {
++                state_->observe(FaultOperation::AuthorityLockAcquire, false,
++                                false, opened_lock_identity_);
++                return result(DurableFileStatus::FailedBeforeEffect);
++            }
++        }
++        const bool must_wait =
++            state_->held_lock_identities.count(opened_lock_identity_) != 0;
++        if (must_wait) {
++            ++state_->blocked_lock_waiters;
++            state_->condition.notify_all();
++        }
++        state_->condition.wait(lock, [&] {
++            return state_->held_lock_identities.count(opened_lock_identity_) ==
++                   0;
++        });
++        if (must_wait) {
++            --state_->blocked_lock_waiters;
++        }
++        state_->held_lock_identities.insert(opened_lock_identity_);
++        owned_lock_identity_ = opened_lock_identity_;
++        state_->observe(FaultOperation::AuthorityLockAcquire, true, false,
++                        opened_lock_identity_);
++        const auto after = state_->take_fault(
++            FaultOperation::AuthorityLockAcquire, FaultPosition::After);
++        if (before.has_value() || after.has_value()) {
++            if (after == FaultAction::Crash) {
++                state_->simulated_crash = true;
++            }
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        }
++        return succeeded();
++    }
++
++    template <typename Effect>
++    DurableFileResult run_step(std::unique_lock<std::mutex> &lock,
++                               FaultOperation operation, bool mutation,
++                               Effect effect, std::size_t requested_bytes = 0,
++                               std::size_t transferred_bytes = 0) {
++        const auto before =
++            state_->take_fault(operation, FaultPosition::Before);
++        if (before.has_value()) {
++            if (*before == FaultAction::Crash) {
++                state_->simulated_crash = true;
++            }
++            if (*before == FaultAction::InterruptedOnce) {
++                state_->observe(operation, owns_lock(), false,
++                                owned_lock_identity_, requested_bytes, 0);
++                return result(DurableFileStatus::Interrupted);
++            }
++            if (*before != FaultAction::EffectThenError) {
++                state_->observe(operation, owns_lock(), false,
++                                owned_lock_identity_, requested_bytes, 0);
++                return result(DurableFileStatus::FailedBeforeEffect);
++            }
++            effect();
++            state_->observe(operation, owns_lock(), mutation,
++                            owned_lock_identity_, requested_bytes,
++                            mutation ? transferred_bytes : 0);
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        }
++
++        effect();
++        state_->observe(operation, owns_lock(), mutation, owned_lock_identity_,
++                        requested_bytes, transferred_bytes);
++        pause_if_requested(lock, operation);
++        const auto after = state_->take_fault(operation, FaultPosition::After);
++        if (after.has_value()) {
++            if (*after == FaultAction::Crash) {
++                state_->simulated_crash = true;
++            }
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        }
++        return succeeded();
++    }
++
++    void pause_if_requested(std::unique_lock<std::mutex> &lock,
++                            FaultOperation operation) {
++        if (state_->pause_operation != operation || state_->pause_consumed) {
++            return;
++        }
++        if (state_->pause_occurrence > 1) {
++            --state_->pause_occurrence;
++            return;
++        }
++        state_->pause_consumed = true;
++        state_->paused = true;
++        state_->condition.notify_all();
++        state_->condition.wait(lock, [&] { return state_->pause_released; });
++        state_->paused = false;
++    }
++
++    detail::DurableReadResult read_fixed(std::string_view name,
++                                         FaultOperation open_operation,
++                                         FaultOperation read_operation,
++                                         FaultOperation close_operation,
++                                         std::size_t max_bytes) {
++        std::unique_lock lock(state_->mutex);
++        const auto *entry_before_open = state_->live_entry(name);
++        const auto opened = run_step(
++            lock, open_operation, false,
++            [&] {
++                if (entry_before_open != nullptr) {
++                    state_->open_entries.insert(std::string(name));
++                }
++            },
++            max_bytes);
++        if (!is_succeeded(opened)) {
++            if (state_->open_entries.count(std::string(name)) == 0 ||
++                state_->simulated_crash) {
++                return {opened, {}, false};
++            }
++            lock.unlock();
++            ReadChannel opened_channel(*this, name, read_operation,
++                                       close_operation);
++            const auto closed_after_open =
++                detail::close_read_once(opened_channel);
++            return {combine_results(opened, closed_after_open), {}, false};
++        }
++        const auto *entry = state_->live_entry(name);
++        if (entry == nullptr) {
++            return {result(DurableFileStatus::NotFound), {}, false};
++        }
++        if (entry->kind != State::EntryKind::Regular) {
++            const auto unsupported = result(DurableFileStatus::Unsupported);
++            lock.unlock();
++            ReadChannel unsafe_channel(*this, name, read_operation,
++                                       close_operation);
++            const auto closed_unsafe = detail::close_read_once(unsafe_channel);
++            return {combine_results(unsupported, closed_unsafe), {}, false};
++        }
++        lock.unlock();
++        ReadChannel channel(*this, name, read_operation, close_operation);
++        return detail::read_bounded_close(channel, max_bytes);
++    }
++
++    DurableWriteResult write_some(std::string_view name, std::string_view bytes,
++                                  bool append_after_partial,
++                                  bool append_initial, FaultOperation operation,
++                                  bool &wrote_any) {
++        std::unique_lock lock(state_->mutex);
++        auto *entry = state_->live_entry(name);
++        if (entry == nullptr || entry->kind != State::EntryKind::Regular) {
++            return {result(DurableFileStatus::NotFound), 0};
++        }
++        const auto before =
++            state_->take_fault(operation, FaultPosition::Before);
++        if (before.has_value()) {
++            if (*before == FaultAction::Crash) {
++                state_->simulated_crash = true;
++            }
++            switch (*before) {
++            case FaultAction::InterruptedOnce:
++                state_->observe(operation, owns_lock(), false,
++                                owned_lock_identity_, bytes.size(), 0);
++                return {result(DurableFileStatus::Interrupted), 0};
++            case FaultAction::ZeroProgress:
++                state_->observe(operation, owns_lock(), false,
++                                owned_lock_identity_, bytes.size(), 0);
++                return {succeeded(), 0};
++            case FaultAction::OverreportedWrite:
++                state_->observe(operation, owns_lock(), false,
++                                owned_lock_identity_, bytes.size(),
++                                bytes.size() + 1);
++                return {succeeded(), bytes.size() + 1};
++            case FaultAction::ShortWrite: {
++                const auto transferred =
++                    bytes.size() <= 1 ? bytes.size() : bytes.size() / 2;
++                apply_write(*entry, bytes.substr(0, transferred),
++                            append_after_partial, append_initial, wrote_any);
++                state_->observe(operation, owns_lock(), true,
++                                owned_lock_identity_, bytes.size(),
++                                transferred);
++                return {succeeded(), transferred};
++            }
++            case FaultAction::EffectThenError:
++                apply_write(*entry, bytes, append_after_partial, append_initial,
++                            wrote_any);
++                state_->observe(operation, owns_lock(), true,
++                                owned_lock_identity_, bytes.size(),
++                                bytes.size());
++                return {result(DurableFileStatus::EffectMayHaveOccurred),
++                        bytes.size()};
++            case FaultAction::Error:
++            case FaultAction::Crash:
++                state_->observe(operation, owns_lock(), false,
++                                owned_lock_identity_, bytes.size(), 0);
++                return {result(DurableFileStatus::FailedBeforeEffect), 0};
++            }
++        }
++        apply_write(*entry, bytes, append_after_partial, append_initial,
++                    wrote_any);
++        state_->observe(operation, owns_lock(), true, owned_lock_identity_,
++                        bytes.size(), bytes.size());
++        pause_if_requested(lock, operation);
++        const auto after = state_->take_fault(operation, FaultPosition::After);
++        if (after.has_value()) {
++            if (*after == FaultAction::Crash) {
++                state_->simulated_crash = true;
++            }
++            return {result(DurableFileStatus::EffectMayHaveOccurred),
++                    bytes.size()};
++        }
++        return {succeeded(), bytes.size()};
++    }
++
++    static void apply_write(State::Entry &entry, std::string_view bytes,
++                            bool append_after_partial, bool append_initial,
++                            bool &wrote_any) {
++        if (append_after_partial || append_initial || wrote_any) {
++            entry.live_bytes.append(bytes);
++        } else {
++            entry.live_bytes.assign(bytes);
++        }
++        wrote_any = true;
++    }
++
++    static DurableFileResult
++    combine_results(const DurableFileResult &operation_result,
++                    const DurableFileResult &close_result) {
++        if (operation_result.status ==
++                DurableFileStatus::EffectMayHaveOccurred ||
++            close_result.status == DurableFileStatus::EffectMayHaveOccurred) {
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        }
++        if (!is_succeeded(operation_result)) {
++            return operation_result;
++        }
++        return close_result;
++    }
++
++    DurableFileResult replace_fixed(
++        std::string_view stage_name, std::string_view target_name,
++        std::string_view bytes, FaultOperation create_operation,
++        FaultOperation write_operation, FaultOperation flush_operation,
++        FaultOperation close_operation, FaultOperation replace_operation,
++        FaultOperation namespace_operation) {
++        std::uint64_t stage_identity = 0;
++        {
++            std::unique_lock lock(state_->mutex);
++            const auto created = run_step(lock, create_operation, true, [&] {
++                auto &entry = state_->entries[std::string(stage_name)];
++                entry = State::Entry{};
++                entry.live_exists = true;
++                entry.identity = next_entry_identity.fetch_add(1);
++                stage_identity = entry.identity;
++                state_->open_entries.insert(std::string(stage_name));
++            });
++            if (!is_succeeded(created)) {
++                if (state_->open_entries.count(std::string(stage_name)) == 0 ||
++                    state_->simulated_crash) {
++                    return created;
++                }
++                const auto closed = run_step(lock, close_operation, false, [&] {
++                    state_->open_entries.erase(std::string(stage_name));
++                });
++                state_->open_entries.erase(std::string(stage_name));
++                return combine_results(created, closed);
++            }
++        }
++        Channel channel(*this, stage_name, false, write_operation,
++                        flush_operation, write_operation, close_operation);
++        auto call_result = detail::write_flush_close(channel, bytes);
++        if (!is_succeeded(call_result)) {
++            return promote_after_persistent_effect(std::move(call_result));
++        }
++        {
++            std::unique_lock lock(state_->mutex);
++            const auto replaced = run_step(lock, replace_operation, true, [&] {
++                const auto *stage = state_->live_entry(stage_name);
++                auto &target = state_->entries[std::string(target_name)];
++                target.kind = State::EntryKind::Regular;
++                target.live_exists = true;
++                target.live_bytes =
++                    stage == nullptr ? std::string{} : stage->live_bytes;
++                target.identity = stage == nullptr ? 0 : stage->identity;
++                erase_live(stage_name);
++            });
++            if (!is_succeeded(replaced)) {
++                return promote_after_persistent_effect(replaced);
++            }
++        }
++        class NamespaceCall final : public DurableInterruptibleCall {
++        public:
++            NamespaceCall(Adapter &adapter, FaultOperation operation,
++                          std::string_view stage_name,
++                          std::string_view target_name)
++                : adapter_(adapter), operation_(operation),
++                  stage_name_(stage_name), target_name_(target_name) {}
++
++            DurableFileResult attempt() override {
++                std::unique_lock lock(adapter_.state_->mutex);
++                return adapter_.run_step(lock, operation_, true, [&] {
++                    adapter_.commit_replacement(stage_name_, target_name_);
++                });
++            }
++
++        private:
++            Adapter &adapter_;
++            FaultOperation operation_;
++            std::string stage_name_;
++            std::string target_name_;
++        } namespace_call(*this, namespace_operation, stage_name, target_name);
++        const auto namespace_result = promote_after_persistent_effect(
++            detail::retry_interrupted(namespace_call));
++        if (!is_succeeded(namespace_result)) {
++            return namespace_result;
++        }
++        std::unique_lock lock(state_->mutex);
++        const auto *target = state_->live_entry(target_name);
++        if (target == nullptr || target->kind != State::EntryKind::Regular ||
++            target->identity != stage_identity || target->live_bytes != bytes ||
++            !target->durable_exists || !target->durable_content_available ||
++            target->durable_bytes != bytes) {
++            return result(DurableFileStatus::EffectMayHaveOccurred);
++        }
++        return namespace_result;
++    }
++
++    bool fixed_entries_are_safe() const {
++        if (!state_->authority_directory_exists) {
++            return false;
++        }
++        for (const auto name : {journal_name, root_name, lock_name,
++                                journal_stage_name, root_stage_name}) {
++            const auto *entry = state_->live_entry(name);
++            if (entry != nullptr && entry->kind != State::EntryKind::Regular) {
++                return false;
++            }
++        }
++        return true;
++    }
++
++    static bool is_preflight_close(FaultOperation operation) {
++        return operation == FaultOperation::PreflightFlushClose ||
++               operation == FaultOperation::PreflightTruncateClose ||
++               operation == FaultOperation::PreflightReplaceStageClose;
++    }
++
++    void close_preflight_handle(FaultOperation operation) {
++        if (operation == FaultOperation::PreflightReplaceStageClose) {
++            state_->open_entries.erase(std::string(preflight_stage_name));
++        } else {
++            state_->open_entries.erase(std::string(preflight_probe_name));
++        }
++    }
++
++    DurableFileResult
++    finish_preflight_failure(FaultOperation operation,
++                             const DurableFileResult &operation_result) {
++        std::unique_lock lock(state_->mutex);
++        if (state_->simulated_crash) {
++            return operation_result;
++        }
++        auto combined = operation_result;
++        if (is_preflight_close(operation)) {
++            close_preflight_handle(operation);
++        } else {
++            std::optional<FaultOperation> close_operation;
++            const auto ordinal = static_cast<int>(operation);
++            if (state_->open_entries.count(std::string(preflight_stage_name)) !=
++                0) {
++                close_operation = FaultOperation::PreflightReplaceStageClose;
++            } else if (state_->open_entries.count(
++                           std::string(preflight_probe_name)) != 0) {
++                close_operation =
++                    ordinal <= static_cast<int>(
++                                   FaultOperation::PreflightFlushClose)
++                        ? FaultOperation::PreflightFlushClose
++                        : FaultOperation::PreflightTruncateClose;
++            }
++            if (close_operation.has_value()) {
++                const auto closed =
++                    run_step(lock, *close_operation, false,
++                             [&] { close_preflight_handle(*close_operation); });
++                close_preflight_handle(*close_operation);
++                combined = combine_results(combined, closed);
++            }
++        }
++        if (operation == FaultOperation::PreflightCleanup) {
++            return combined;
++        }
++        const auto cleaned =
++            run_step(lock, FaultOperation::PreflightCleanup, false, [&] {
++                state_->open_entries.erase(std::string(preflight_probe_name));
++                state_->open_entries.erase(std::string(preflight_stage_name));
++                erase_live(preflight_probe_name);
++                erase_durable(preflight_probe_name);
++                erase_live(preflight_stage_name);
++                erase_durable(preflight_stage_name);
++            });
++        return combine_results(combined, cleaned);
++    }
++
++    void commit_replacement(std::string_view stage_name,
++                            std::string_view target_name) {
++        auto &stage = state_->entries[std::string(stage_name)];
++        auto &target = state_->entries[std::string(target_name)];
++        if (stage.durable_content_available) {
++            target.durable_bytes = stage.durable_bytes;
++            target.durable_content_available = true;
++        }
++        for (auto &[name, entry] : state_->entries) {
++            static_cast<void>(name);
++            entry.durable_exists = entry.live_exists;
++        }
++        stage.durable_exists = false;
++        stage.durable_bytes.clear();
++        stage.durable_content_available = false;
++    }
++
++    void apply_preflight_operation(FaultOperation operation) {
++        switch (operation) {
++        case FaultOperation::PreflightProbe:
++            erase_live(preflight_probe_name);
++            erase_durable(preflight_probe_name);
++            erase_live(preflight_stage_name);
++            erase_durable(preflight_stage_name);
++            break;
++        case FaultOperation::PreflightFlushCreate: {
++            auto &entry = state_->entries[std::string(preflight_probe_name)];
++            entry = State::Entry{};
++            entry.live_exists = true;
++            entry.identity = next_entry_identity.fetch_add(1);
++            state_->open_entries.insert(std::string(preflight_probe_name));
++            break;
++        }
++        case FaultOperation::PreflightFlushWrite:
++            state_->entries[std::string(preflight_probe_name)].live_bytes =
++                "flush-probe";
++            break;
++        case FaultOperation::PreflightFlushFileFlush:
++        case FaultOperation::PreflightTruncateFlush:
++            state_->entries[std::string(preflight_probe_name)].durable_bytes =
++                state_->entries[std::string(preflight_probe_name)].live_bytes;
++            state_->entries[std::string(preflight_probe_name)].durable_exists =
++                true;
++            state_->entries[std::string(preflight_probe_name)]
++                .durable_content_available = true;
++            break;
++        case FaultOperation::PreflightFlushClose:
++            state_->open_entries.erase(std::string(preflight_probe_name));
++            break;
++        case FaultOperation::PreflightTruncateClose:
++            state_->open_entries.erase(std::string(preflight_probe_name));
++            break;
++        case FaultOperation::PreflightReplaceStageClose:
++            state_->open_entries.erase(std::string(preflight_stage_name));
++            break;
++        case FaultOperation::PreflightTruncate:
++            state_->open_entries.insert(std::string(preflight_probe_name));
++            state_->entries[std::string(preflight_probe_name)]
++                .live_bytes.clear();
++            break;
++        case FaultOperation::PreflightReplaceStageCreate: {
++            auto &entry = state_->entries[std::string(preflight_stage_name)];
++            entry = State::Entry{};
++            entry.live_exists = true;
++            entry.identity = next_entry_identity.fetch_add(1);
++            state_->open_entries.insert(std::string(preflight_stage_name));
++            break;
++        }
++        case FaultOperation::PreflightReplaceStageWrite:
++            state_->entries[std::string(preflight_stage_name)].live_bytes =
++                "replace-probe";
++            break;
++        case FaultOperation::PreflightReplaceStageFlush:
++            state_->entries[std::string(preflight_stage_name)].durable_bytes =
++                state_->entries[std::string(preflight_stage_name)].live_bytes;
++            state_->entries[std::string(preflight_stage_name)].durable_exists =
++                true;
++            state_->entries[std::string(preflight_stage_name)]
++                .durable_content_available = true;
++            break;
++        case FaultOperation::PreflightReplace:
++            state_->entries[std::string(preflight_probe_name)].live_bytes =
++                state_->entries[std::string(preflight_stage_name)].live_bytes;
++            erase_live(preflight_stage_name);
++            break;
++        case FaultOperation::PreflightNamespaceDurability: {
++            auto &probe = state_->entries[std::string(preflight_probe_name)];
++            auto &stage = state_->entries[std::string(preflight_stage_name)];
++            if (stage.durable_content_available) {
++                probe.durable_bytes = stage.durable_bytes;
++                probe.durable_content_available = true;
++            }
++            probe.durable_exists = probe.live_exists;
++            stage.durable_exists = false;
++            stage.durable_bytes.clear();
++            stage.durable_content_available = false;
++        } break;
++        case FaultOperation::PreflightCleanup:
++            state_->open_entries.erase(std::string(preflight_probe_name));
++            state_->open_entries.erase(std::string(preflight_stage_name));
++            erase_live(preflight_probe_name);
++            erase_durable(preflight_probe_name);
++            erase_live(preflight_stage_name);
++            erase_durable(preflight_stage_name);
++            break;
++        default:
++            break;
++        }
++    }
++
++    void erase_live(std::string_view name) {
++        auto found = state_->entries.find(std::string(name));
++        if (found != state_->entries.end()) {
++            found->second.live_exists = false;
++            found->second.live_bytes.clear();
++        }
++    }
++
++    void erase_durable(std::string_view name) {
++        auto found = state_->entries.find(std::string(name));
++        if (found != state_->entries.end()) {
++            found->second.durable_exists = false;
++            found->second.durable_bytes.clear();
++            found->second.durable_content_available = false;
++        }
++    }
++
++    bool owns_lock() const {
++        return owned_lock_identity_ != 0 &&
++               state_->held_lock_identities.count(owned_lock_identity_) != 0;
++    }
++
++    bool lock_handle_is_open() const {
++        return state_->open_lock_handles.count(lock_handle_identity_) != 0;
++    }
++
++    void close_open_lock_handle() {
++        if (lock_handle_is_open()) {
++            state_->open_lock_handles.erase(lock_handle_identity_);
++        }
++        opened_lock_identity_ = 0;
++    }
++
++    void release_owned_lock() {
++        if (owned_lock_identity_ == 0) {
++            return;
++        }
++        state_->held_lock_identities.erase(owned_lock_identity_);
++        owned_lock_identity_ = 0;
++        state_->condition.notify_all();
++    }
++
++    std::shared_ptr<State> state_;
++    const std::uint64_t lock_handle_identity_;
++    std::uint64_t opened_lock_identity_ = 0;
++    std::uint64_t owned_lock_identity_ = 0;
++};
++
++JournalTestStorage::JournalTestStorage(std::shared_ptr<State> state)
++    : state_(std::move(state)) {}
++
++JournalTestStorage JournalTestStorage::fresh() {
++#ifdef _WIN32
++    return fresh(PlatformContract::Windows);
++#elif defined(__APPLE__)
++    return fresh(PlatformContract::MacOS);
++#else
++    return fresh(PlatformContract::Linux);
++#endif
++}
++
++JournalTestStorage JournalTestStorage::fresh(PlatformContract platform) {
++    return JournalTestStorage(std::make_shared<State>(platform, true));
++}
++
++JournalTestStorage
++JournalTestStorage::seeded(std::string journal_bytes,
++                           std::optional<std::string> authority_root_bytes) {
++    auto storage = fresh();
++    {
++        std::lock_guard lock(storage.state_->mutex);
++        storage.state_->add_durable_regular(journal_name,
++                                            std::move(journal_bytes));
++        storage.state_->add_durable_regular(lock_name, {});
++        if (authority_root_bytes.has_value()) {
++            storage.state_->add_durable_regular(
++                root_name, std::move(*authority_root_bytes));
++        }
++    }
++    return storage;
++}
++
++JournalTestStorage
++JournalTestStorage::seeded(std::string journal_bytes,
++                           std::string authority_root_bytes) {
++    return seeded(std::move(journal_bytes),
++                  std::optional<std::string>(std::move(authority_root_bytes)));
++}
++
++JournalTestStorage JournalTestStorage::seeded(std::string journal_bytes,
++                                              std::string authority_root_bytes,
++                                              PlatformContract platform) {
++    auto storage = fresh(platform);
++    {
++        std::lock_guard lock(storage.state_->mutex);
++        storage.state_->add_durable_regular(journal_name,
++                                            std::move(journal_bytes));
++        storage.state_->add_durable_regular(lock_name, {});
++        storage.state_->add_durable_regular(root_name,
++                                            std::move(authority_root_bytes));
++    }
++    return storage;
++}
++
++JournalTestStorage
++JournalTestStorage::missing_authority_directory(PlatformContract platform) {
++    return JournalTestStorage(std::make_shared<State>(platform, false));
++}
++
++JournalTestStorage::JournalTestStorage(const JournalTestStorage &) = default;
++
++JournalTestStorage &
++JournalTestStorage::operator=(const JournalTestStorage &) = default;
++
++JournalTestStorage::JournalTestStorage(JournalTestStorage &&) noexcept =
++    default;
++
++JournalTestStorage &
++JournalTestStorage::operator=(JournalTestStorage &&) noexcept = default;
++
++JournalTestStorage::~JournalTestStorage() = default;
++
++JournalTestStorage JournalTestStorage::clone() const {
++    std::lock_guard lock(state_->mutex);
++    auto cloned = std::make_shared<State>(state_->platform,
++                                          state_->authority_directory_exists);
++    cloned->entries = state_->entries;
++    for (auto &[name, entry] : cloned->entries) {
++        static_cast<void>(name);
++        if (entry.live_exists || entry.durable_exists) {
++            entry.identity = next_entry_identity.fetch_add(1);
++        }
++    }
++    cloned->unavailable_capabilities = state_->unavailable_capabilities;
++    return JournalTestStorage(std::move(cloned));
++}
++
++DurableJournal JournalTestStorage::make_journal(JournalLimits limits) {
++    return detail::make_durable_journal_for_test(
++        std::make_unique<Adapter>(state_), limits);
++}
++
++NamespaceSnapshot JournalTestStorage::snapshot() const {
++    std::lock_guard lock(state_->mutex);
++    NamespaceSnapshot snapshot;
++    const auto *journal = state_->live_entry(journal_name);
++    if (journal != nullptr && journal->kind == State::EntryKind::Regular) {
++        snapshot.journal_bytes = journal->live_bytes;
++    }
++    const auto *root = state_->live_entry(root_name);
++    if (root != nullptr && root->kind == State::EntryKind::Regular) {
++        snapshot.authority_root_bytes = root->live_bytes;
++    }
++    for (const auto &[name, entry] : state_->entries) {
++        if (entry.live_exists || entry.durable_exists) {
++            switch (entry.kind) {
++            case State::EntryKind::Regular:
++                snapshot.entry_kinds.emplace(name, "regular");
++                break;
++            case State::EntryKind::Symlink:
++                snapshot.entry_kinds.emplace(name, "symlink");
++                break;
++            case State::EntryKind::NonRegular:
++                snapshot.entry_kinds.emplace(name, "nonregular");
++                break;
++            case State::EntryKind::ReparsePoint:
++                snapshot.entry_kinds.emplace(name, "reparse");
++                break;
++            }
++        }
++        if (entry.live_exists) {
++            snapshot.relative_paths.insert(name);
++            if (entry.kind == State::EntryKind::Regular) {
++                snapshot.live_file_bytes.emplace(name, entry.live_bytes);
++            }
++        }
++        if (entry.durable_exists) {
++            snapshot.durable_paths.insert(name);
++            if (entry.durable_content_available) {
++                snapshot.durable_content_available.insert(name);
++            }
++            if (entry.kind == State::EntryKind::Regular) {
++                snapshot.durable_file_bytes.emplace(name, entry.durable_bytes);
++            }
++        }
++    }
++    snapshot.observations = state_->observations;
++    snapshot.open_handles = state_->open_entries;
++    for (const auto handle : state_->open_lock_handles) {
++        snapshot.open_handles.insert("authority.lock#handle:" +
++                                     std::to_string(handle));
++    }
++    snapshot.namespace_durable = std::all_of(
++        state_->entries.begin(), state_->entries.end(), [](const auto &item) {
++            return item.second.live_exists == item.second.durable_exists;
++        });
++    snapshot.journal_durable =
++        journal == nullptr ||
++        (journal->durable_exists && journal->durable_content_available &&
++         journal->live_bytes == journal->durable_bytes);
++    snapshot.authority_root_durable =
++        root == nullptr ||
++        (root->durable_exists && root->durable_content_available &&
++         root->live_bytes == root->durable_bytes);
++    snapshot.journal_closed = snapshot.open_handles.empty();
++    snapshot.stage_files_absent =
++        state_->live_entry(journal_stage_name) == nullptr &&
++        state_->live_entry(root_stage_name) == nullptr;
++    const auto journal_stage =
++        state_->entries.find(std::string(journal_stage_name));
++    const auto root_stage = state_->entries.find(std::string(root_stage_name));
++    snapshot.durable_stage_files_absent =
++        (journal_stage == state_->entries.end() ||
++         !journal_stage->second.durable_exists) &&
++        (root_stage == state_->entries.end() ||
++         !root_stage->second.durable_exists);
++
++    const auto *lock_entry = state_->live_entry(lock_name);
++    snapshot.lock_file_present = lock_entry != nullptr;
++    snapshot.lock_file_stable =
++        lock_entry != nullptr && lock_entry->kind == State::EntryKind::Regular;
++
++    snapshot.all_authority_io_under_lock = true;
++    std::optional<std::size_t> first_root_read;
++    std::optional<std::size_t> first_journal_read;
++    snapshot.authority_mutation_attempted = false;
++    for (std::size_t index = 0; index < snapshot.observations.size(); ++index) {
++        const auto &observation = snapshot.observations[index];
++        if (observation.operation == FaultOperation::RootRead &&
++            !first_root_read.has_value()) {
++            first_root_read = index;
++        }
++        if (observation.operation == FaultOperation::JournalRead &&
++            !first_journal_read.has_value()) {
++            first_journal_read = index;
++        }
++        snapshot.authority_mutation_attempted |= observation.mutation_attempted;
++        if ((is_authority_operation(observation.operation) ||
++             observation.mutation_attempted) &&
++            !observation.lock_held) {
++            snapshot.all_authority_io_under_lock = false;
++        }
++    }
++    snapshot.root_read_before_journal_read =
++        !first_journal_read.has_value() ||
++        (first_root_read.has_value() && *first_root_read < *first_journal_read);
++    return snapshot;
++}
++
++void JournalTestStorage::seed_untrusted_file(std::string name,
++                                             std::string bytes) {
++    std::lock_guard lock(state_->mutex);
++    state_->add_durable_regular(name, std::move(bytes));
++}
++
++void JournalTestStorage::overwrite_fixed_child_bytes(FixedAuthorityChild child,
++                                                     std::string bytes) {
++    const std::map<FixedAuthorityChild, std::string_view> names{
++        {FixedAuthorityChild::Journal, journal_name},
++        {FixedAuthorityChild::Root, root_name},
++        {FixedAuthorityChild::Lock, lock_name},
++        {FixedAuthorityChild::JournalStage, journal_stage_name},
++        {FixedAuthorityChild::RootStage, root_stage_name},
++    };
++    std::lock_guard lock(state_->mutex);
++    state_->add_durable_regular(names.at(child), std::move(bytes));
++}
++
++void JournalTestStorage::replace_fixed_child_file(FixedAuthorityChild child,
++                                                  std::string bytes) {
++    const std::map<FixedAuthorityChild, std::string_view> names{
++        {FixedAuthorityChild::Journal, journal_name},
++        {FixedAuthorityChild::Root, root_name},
++        {FixedAuthorityChild::Lock, lock_name},
++        {FixedAuthorityChild::JournalStage, journal_stage_name},
++        {FixedAuthorityChild::RootStage, root_stage_name},
++    };
++    std::lock_guard lock(state_->mutex);
++    auto &entry = state_->entries[std::string(names.at(child))];
++    entry = State::Entry{};
++    entry.live_bytes = bytes;
++    entry.durable_bytes = std::move(bytes);
++    entry.live_exists = true;
++    entry.durable_exists = true;
++    entry.durable_content_available = true;
++    entry.identity = next_entry_identity.fetch_add(1);
++}
++
++void JournalTestStorage::remove_fixed_child_file(FixedAuthorityChild child) {
++    const std::map<FixedAuthorityChild, std::string_view> names{
++        {FixedAuthorityChild::Journal, journal_name},
++        {FixedAuthorityChild::Root, root_name},
++        {FixedAuthorityChild::Lock, lock_name},
++        {FixedAuthorityChild::JournalStage, journal_stage_name},
++        {FixedAuthorityChild::RootStage, root_stage_name},
++    };
++    std::lock_guard lock(state_->mutex);
++    state_->entries.erase(std::string(names.at(child)));
++}
++
++void JournalTestStorage::arm_fault(FaultOperation operation,
++                                   FaultPosition position, FaultAction action) {
++    arm_fault_sequence(operation, position, {action});
++}
++
++void JournalTestStorage::arm_fault_sequence(FaultOperation operation,
++                                            FaultPosition position,
++                                            std::vector<FaultAction> actions) {
++    std::lock_guard lock(state_->mutex);
++    state_->fault = State::FaultScript{
++        operation, position,
++        std::deque<FaultAction>(actions.begin(), actions.end())};
++    state_->simulated_crash = false;
++}
++
++void JournalTestStorage::restart() {
++    std::lock_guard lock(state_->mutex);
++    state_->restart();
++}
++
++void JournalTestStorage::reset_observations() {
++    std::lock_guard lock(state_->mutex);
++    state_->observations.clear();
++}
++
++std::size_t JournalTestStorage::attempt_count(FaultOperation operation) const {
++    std::lock_guard lock(state_->mutex);
++    return static_cast<std::size_t>(
++        std::count_if(state_->observations.begin(), state_->observations.end(),
++                      [&](const OperationObservation &observation) {
++                          return observation.operation == operation;
++                      }));
++}
++
++void JournalTestStorage::make_capability_unavailable(
++    DurabilityCapability capability) {
++    std::lock_guard lock(state_->mutex);
++    state_->unavailable_capabilities.insert(capability);
++}
++
++void JournalTestStorage::poison_fixed_child(FixedAuthorityChild child,
++                                            UnsupportedEntryKind kind) {
++    const std::map<FixedAuthorityChild, std::string_view> names{
++        {FixedAuthorityChild::Journal, journal_name},
++        {FixedAuthorityChild::Root, root_name},
++        {FixedAuthorityChild::Lock, lock_name},
++        {FixedAuthorityChild::JournalStage, journal_stage_name},
++        {FixedAuthorityChild::RootStage, root_stage_name},
++    };
++    std::lock_guard lock(state_->mutex);
++    auto &entry = state_->entries[std::string(names.at(child))];
++    entry.live_exists = true;
++    entry.durable_exists = true;
++    entry.identity = next_entry_identity.fetch_add(1);
++    switch (kind) {
++    case UnsupportedEntryKind::Symlink:
++        entry.kind = State::EntryKind::Symlink;
++        break;
++    case UnsupportedEntryKind::NonRegular:
++        entry.kind = State::EntryKind::NonRegular;
++        break;
++    case UnsupportedEntryKind::ReparsePoint:
++        entry.kind = State::EntryKind::ReparsePoint;
++        break;
++    }
++}
++
++void JournalTestStorage::pause_after(FaultOperation operation) {
++    pause_after_nth(operation, 1);
++}
++
++void JournalTestStorage::pause_after_nth(FaultOperation operation,
++                                         std::size_t occurrence) {
++    std::lock_guard lock(state_->mutex);
++    state_->pause_operation = operation;
++    state_->pause_occurrence = occurrence;
++    state_->pause_consumed = false;
++    state_->pause_released = false;
++    state_->paused = false;
++}
++
++bool JournalTestStorage::destroy_adapter_with_open_lock(bool simulated_crash) {
++    auto adapter = std::make_unique<Adapter>(state_);
++    const auto locked = adapter->lock_authority();
++    {
++        std::lock_guard lock(state_->mutex);
++        state_->simulated_crash = simulated_crash;
++    }
++    return locked.succeeded();
++}
++
++bool JournalTestStorage::wait_until_paused(std::uint64_t timeout_milliseconds) {
++    std::unique_lock lock(state_->mutex);
++    return state_->condition.wait_for(
++        lock, std::chrono::milliseconds(timeout_milliseconds),
++        [&] { return state_->paused; });
++}
++
++bool JournalTestStorage::wait_until_lock_waiter(
++    std::uint64_t timeout_milliseconds) const {
++    std::unique_lock lock(state_->mutex);
++    return state_->condition.wait_for(
++        lock, std::chrono::milliseconds(timeout_milliseconds),
++        [&] { return state_->blocked_lock_waiters != 0; });
++}
++
++void JournalTestStorage::release_pause() {
++    std::lock_guard lock(state_->mutex);
++    state_->pause_released = true;
++    state_->condition.notify_all();
++}
++
++bool JournalTestStorage::try_unlink_lock_file() {
++    std::lock_guard lock(state_->mutex);
++    if (state_->platform == PlatformContract::Windows &&
++        !state_->open_lock_handles.empty()) {
++        return false;
++    }
++    auto *entry = state_->live_entry(lock_name);
++    if (entry == nullptr) {
++        return false;
++    }
++    entry->live_exists = false;
++    entry->durable_exists = false;
++    return true;
++}
++
++bool JournalTestStorage::try_recreate_lock_file() {
++    std::lock_guard lock(state_->mutex);
++    if (state_->platform == PlatformContract::Windows &&
++        !state_->open_lock_handles.empty()) {
++        return false;
++    }
++    if (state_->live_entry(lock_name) != nullptr) {
++        return false;
++    }
++    state_->entries[std::string(lock_name)].identity = 0;
++    state_->add_durable_regular(lock_name, {});
++    return true;
++}
++
++bool JournalTestStorage::try_replace_lock_with_reparse_point() {
++    std::lock_guard lock(state_->mutex);
++    if (!state_->open_lock_handles.empty()) {
++        return false;
++    }
++    auto *entry = state_->live_entry(lock_name);
++    if (entry == nullptr) {
++        return false;
++    }
++    entry->kind = State::EntryKind::ReparsePoint;
++    return true;
++}
++
++void JournalTestStorage::alias_lock_identity_from(
++    const JournalTestStorage &other) {
++    if (state_.get() == other.state_.get()) {
++        return;
++    }
++    std::scoped_lock lock(state_->mutex, other.state_->mutex);
++    auto *target = state_->live_entry(lock_name);
++    const auto *source = other.state_->live_entry(lock_name);
++    if (target != nullptr && source != nullptr) {
++        target->identity = source->identity;
++    }
++}
++
++std::uint64_t JournalTestStorage::lock_identity() const {
++    std::lock_guard lock(state_->mutex);
++    const auto *entry = state_->live_entry(lock_name);
++    return entry == nullptr ? 0 : entry->identity;
++}
++
++bool operator==(const NamespaceSnapshot &left, const NamespaceSnapshot &right) {
++    const auto observations_equal =
++        left.observations.size() == right.observations.size() &&
++        std::equal(left.observations.begin(), left.observations.end(),
++                   right.observations.begin(),
++                   [](const OperationObservation &left_observation,
++                      const OperationObservation &right_observation) {
++                       return left_observation.operation ==
++                                  right_observation.operation &&
++                              left_observation.lock_held ==
++                                  right_observation.lock_held &&
++                              left_observation.mutation_attempted ==
++                                  right_observation.mutation_attempted &&
++                              left_observation.lock_identity ==
++                                  right_observation.lock_identity &&
++                              left_observation.requested_bytes ==
++                                  right_observation.requested_bytes &&
++                              left_observation.transferred_bytes ==
++                                  right_observation.transferred_bytes;
++                   });
++    return left.journal_bytes == right.journal_bytes &&
++           left.authority_root_bytes == right.authority_root_bytes &&
++           left.relative_paths == right.relative_paths &&
++           left.durable_paths == right.durable_paths &&
++           left.durable_content_available == right.durable_content_available &&
++           left.entry_kinds == right.entry_kinds &&
++           left.live_file_bytes == right.live_file_bytes &&
++           left.durable_file_bytes == right.durable_file_bytes &&
++           left.open_handles == right.open_handles && observations_equal &&
++           left.namespace_durable == right.namespace_durable &&
++           left.journal_durable == right.journal_durable &&
++           left.authority_root_durable == right.authority_root_durable &&
++           left.journal_closed == right.journal_closed &&
++           left.stage_files_absent == right.stage_files_absent &&
++           left.durable_stage_files_absent ==
++               right.durable_stage_files_absent &&
++           left.all_authority_io_under_lock ==
++               right.all_authority_io_under_lock &&
++           left.lock_file_present == right.lock_file_present &&
++           left.lock_file_stable == right.lock_file_stable &&
++           left.root_read_before_journal_read ==
++               right.root_read_before_journal_read &&
++           left.authority_mutation_attempted ==
++               right.authority_mutation_attempted;
++}
++
++bool same_persistent_state(const NamespaceSnapshot &left,
++                           const NamespaceSnapshot &right) {
++    return left.journal_bytes == right.journal_bytes &&
++           left.authority_root_bytes == right.authority_root_bytes &&
++           left.relative_paths == right.relative_paths &&
++           left.durable_paths == right.durable_paths &&
++           left.durable_content_available == right.durable_content_available &&
++           left.entry_kinds == right.entry_kinds &&
++           left.live_file_bytes == right.live_file_bytes &&
++           left.durable_file_bytes == right.durable_file_bytes &&
++           left.namespace_durable == right.namespace_durable &&
++           left.journal_durable == right.journal_durable &&
++           left.authority_root_durable == right.authority_root_durable &&
++           left.stage_files_absent == right.stage_files_absent &&
++           left.durable_stage_files_absent ==
++               right.durable_stage_files_absent &&
++           left.lock_file_present == right.lock_file_present &&
++           left.lock_file_stable == right.lock_file_stable;
++}
++
++} // namespace lemon::residency::testing
+diff --git c/test/residency/recovery/journal_persistence_test_support.h i/test/residency/recovery/journal_persistence_test_support.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..6e82848bb3228b9e4bdfb4a8da72a7322f4ec363
+--- /dev/null
++++ i/test/residency/recovery/journal_persistence_test_support.h
+@@ -0,0 +1,261 @@
++#pragma once
++
++#ifndef LEMONADE_RESIDENCY_DURABLE_TESTING
++#error "durable journal test support is confined to the test target"
++#endif
++
++#include "lemon/residency/durable_journal.h"
++
++#include <cstddef>
++#include <cstdint>
++#include <map>
++#include <memory>
++#include <optional>
++#include <set>
++#include <string>
++#include <vector>
++
++namespace lemon::residency::testing {
++
++enum class PlatformContract { Linux, Windows, MacOS };
++
++enum class FaultPosition { Before, After };
++
++enum class FaultAction {
++    Error,
++    Crash,
++    EffectThenError,
++    ShortWrite,
++    InterruptedOnce,
++    ZeroProgress,
++    OverreportedWrite,
++};
++
++enum class FaultOperation {
++    PreflightProbe,
++    PreflightFlushCreate,
++    PreflightFlushWrite,
++    PreflightFlushFileFlush,
++    PreflightFlushClose,
++    PreflightTruncate,
++    PreflightTruncateFlush,
++    PreflightTruncateClose,
++    PreflightReplaceStageCreate,
++    PreflightReplaceStageWrite,
++    PreflightReplaceStageFlush,
++    PreflightReplaceStageClose,
++    PreflightReplace,
++    PreflightNamespaceDurability,
++    PreflightCleanup,
++    FixedNamespaceInspect,
++    AuthorityLockOpen,
++    AuthorityLockAcquire,
++    AuthorityIdentityRead,
++    RootOpen,
++    RootRead,
++    RootClose,
++    JournalOpen,
++    JournalRead,
++    JournalReadClose,
++    JournalAppendOpen,
++    InitialJournalCreate,
++    JournalWrite,
++    JournalFlush,
++    JournalClose,
++    RootStageCreate,
++    RootStageWrite,
++    RootStageFlush,
++    RootStageClose,
++    RootReplace,
++    NamespaceDurability,
++    AuthorityUnlock,
++    AuthorityLockClose,
++    TailRepairOpen,
++    TailRepairTruncate,
++    TailRepairFlush,
++    TailRepairClose,
++    CompactionStageCreate,
++    CompactionWrite,
++    CompactionFlush,
++    CompactionClose,
++    CompactionReplace,
++    CompactionNamespaceDurability,
++};
++
++enum class DurabilityCapability {
++    RegularFileFlush,
++    TailTruncateAndFlush,
++    SameDirectoryReplace,
++    NamespaceDurability,
++};
++
++enum class FixedAuthorityChild { Journal, Root, Lock, JournalStage, RootStage };
++
++enum class UnsupportedEntryKind { Symlink, NonRegular, ReparsePoint };
++
++struct OperationObservation {
++    FaultOperation operation;
++    bool lock_held;
++    bool mutation_attempted;
++    std::uint64_t lock_identity;
++    std::size_t requested_bytes;
++    std::size_t transferred_bytes;
++};
++
++struct NamespaceSnapshot {
++    std::string journal_bytes;
++    std::string authority_root_bytes;
++    std::set<std::string> relative_paths;
++    std::set<std::string> durable_paths;
++    std::set<std::string> durable_content_available;
++    std::map<std::string, std::string> entry_kinds;
++    std::map<std::string, std::string> live_file_bytes;
++    std::map<std::string, std::string> durable_file_bytes;
++    std::set<std::string> open_handles;
++    std::vector<OperationObservation> observations;
++    bool namespace_durable;
++    bool journal_durable;
++    bool authority_root_durable;
++    bool journal_closed;
++    bool stage_files_absent;
++    bool durable_stage_files_absent;
++    bool all_authority_io_under_lock;
++    bool lock_file_present;
++    bool lock_file_stable;
++    bool root_read_before_journal_read;
++    bool authority_mutation_attempted;
++};
++
++enum class HelperResultKind {
++    Succeeded,
++    Interrupted,
++    FailedBeforeEffect,
++    EffectMayHaveOccurred,
++};
++
++struct HelperProbeResult {
++    HelperResultKind result;
++    std::string bytes;
++    std::size_t attempts;
++};
++
++struct HelperOrchestrationProbeResult {
++    HelperResultKind result;
++    std::string bytes;
++    std::size_t write_attempts;
++    std::size_t flush_attempts;
++    std::size_t truncate_attempts;
++    std::size_t close_attempts;
++};
++
++struct ReadHelperProbeResult {
++    HelperResultKind result;
++    std::string bytes;
++    bool truncated;
++    std::vector<std::size_t> requested_bytes;
++    std::vector<std::size_t> returned_bytes;
++    std::size_t read_attempts;
++    std::size_t close_attempts;
++};
++
++struct NativeLockPathProbeResult {
++    bool replacement_prevented_while_held;
++    bool stale_identity_rejected;
++    bool nonblocking_probe_rejected;
++    bool first_unlock_succeeded;
++    bool contender_succeeded;
++    bool contender_rebound;
++    bool replacement_after_release_rebound;
++};
++
++bool operator==(const NamespaceSnapshot &left, const NamespaceSnapshot &right);
++bool same_persistent_state(const NamespaceSnapshot &left,
++                           const NamespaceSnapshot &right);
++HelperProbeResult probe_write_all(std::string bytes,
++                                  std::vector<FaultAction> script);
++HelperProbeResult probe_flush_retry(std::vector<FaultAction> script);
++HelperProbeResult probe_truncate_retry(std::string bytes,
++                                       std::size_t truncate_to,
++                                       std::vector<FaultAction> script);
++HelperProbeResult probe_close_once(std::vector<FaultAction> script);
++HelperOrchestrationProbeResult
++probe_write_flush_close(std::string bytes,
++                        std::vector<FaultAction> write_script,
++                        std::vector<FaultAction> flush_script,
++                        std::vector<FaultAction> close_script);
++HelperOrchestrationProbeResult
++probe_truncate_flush_close(std::string bytes, std::size_t truncate_to,
++                           std::vector<FaultAction> truncate_script,
++                           std::vector<FaultAction> flush_script,
++                           std::vector<FaultAction> close_script);
++ReadHelperProbeResult
++probe_read_bounded_close(std::string bytes, std::size_t max_bytes,
++                         std::vector<FaultAction> read_script,
++                         std::vector<FaultAction> close_script);
++NativeLockPathProbeResult
++probe_native_lock_path_revalidation(std::string directory);
++
++class JournalTestStorage {
++public:
++    static JournalTestStorage fresh();
++    static JournalTestStorage fresh(PlatformContract platform);
++    static JournalTestStorage
++    seeded(std::string journal_bytes,
++           std::optional<std::string> authority_root_bytes);
++    static JournalTestStorage seeded(std::string journal_bytes,
++                                     std::string authority_root_bytes);
++    static JournalTestStorage seeded(std::string journal_bytes,
++                                     std::string authority_root_bytes,
++                                     PlatformContract platform);
++    static JournalTestStorage
++    missing_authority_directory(PlatformContract platform);
++
++    JournalTestStorage(const JournalTestStorage &);
++    JournalTestStorage &operator=(const JournalTestStorage &);
++    JournalTestStorage(JournalTestStorage &&) noexcept;
++    JournalTestStorage &operator=(JournalTestStorage &&) noexcept;
++    ~JournalTestStorage();
++
++    JournalTestStorage clone() const;
++    DurableJournal make_journal(JournalLimits limits);
++    NamespaceSnapshot snapshot() const;
++    void seed_untrusted_file(std::string name, std::string bytes);
++    void overwrite_fixed_child_bytes(FixedAuthorityChild child,
++                                     std::string bytes);
++    void replace_fixed_child_file(FixedAuthorityChild child,
++                                  std::string bytes);
++    void remove_fixed_child_file(FixedAuthorityChild child);
++
++    void arm_fault(FaultOperation operation, FaultPosition position,
++                   FaultAction action);
++    void arm_fault_sequence(FaultOperation operation, FaultPosition position,
++                            std::vector<FaultAction> actions);
++    void restart();
++    void reset_observations();
++    std::size_t attempt_count(FaultOperation operation) const;
++
++    void make_capability_unavailable(DurabilityCapability capability);
++    void poison_fixed_child(FixedAuthorityChild child,
++                            UnsupportedEntryKind kind);
++
++    void pause_after(FaultOperation operation);
++    void pause_after_nth(FaultOperation operation, std::size_t occurrence);
++    bool destroy_adapter_with_open_lock(bool simulated_crash);
++    bool wait_until_paused(std::uint64_t timeout_milliseconds);
++    bool wait_until_lock_waiter(std::uint64_t timeout_milliseconds) const;
++    void release_pause();
++    bool try_unlink_lock_file();
++    bool try_recreate_lock_file();
++    bool try_replace_lock_with_reparse_point();
++    void alias_lock_identity_from(const JournalTestStorage &other);
++    std::uint64_t lock_identity() const;
++
++private:
++    struct State;
++    class Adapter;
++    explicit JournalTestStorage(std::shared_ptr<State> state);
++
++    std::shared_ptr<State> state_;
++};
++
++} // namespace lemon::residency::testing
+diff --git c/test/residency/recovery/test_durable_journal_public_seam.py i/test/residency/recovery/test_durable_journal_public_seam.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..4d1461df1746643cb12f2f7211a93c8f7617406b
+--- /dev/null
++++ i/test/residency/recovery/test_durable_journal_public_seam.py
+@@ -0,0 +1,9164 @@
++import hashlib
++import os
++import re
++import shlex
++import shutil
++import subprocess
++import sys
++import tempfile
++import time
++from collections.abc import Mapping
++from pathlib import Path, PurePath, PureWindowsPath
++
++RUNNER = Path(__file__).resolve()
++REPO_ROOT = RUNNER.parents[3]
++PUBLIC_SEAM = REPO_ROOT / "test/residency/recovery/durable_journal_public_seam.cpp"
++PRIVATE_AUTHORITY_GATE = (
++    REPO_ROOT / "test/residency/recovery/durable_journal_private_authority_gate.cpp"
++)
++TEST_SUPPORT = (
++    REPO_ROOT / "test/residency/recovery/journal_persistence_test_support.cpp"
++)
++TEST_SUPPORT_HEADER = (
++    REPO_ROOT / "test/residency/recovery/journal_persistence_test_support.h"
++)
++INCLUDE_ROOT = REPO_ROOT / "src/cpp/include"
++INTERNAL_INCLUDE_ROOT = REPO_ROOT / "src/cpp/server/residency"
++TEST_INCLUDE_ROOT = REPO_ROOT / "test/residency/recovery"
++DURABLE_HEADER = INCLUDE_ROOT / "lemon/residency/durable_journal.h"
++DURABLE_SOURCE = REPO_ROOT / "src/cpp/server/residency/durable_journal.cpp"
++JOURNAL_SOURCE = REPO_ROOT / "src/cpp/server/residency/journal.cpp"
++JOURNAL_HEADER = INCLUDE_ROOT / "lemon/residency/journal.h"
++ADAPTER_HEADER = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter.h"
++ADAPTER_COMMON = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter.cpp"
++ADAPTER_POSIX = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter_posix.cpp"
++ADAPTER_WINDOWS = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter_windows.cpp"
++ADAPTER_MACOS = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter_macos.cpp"
++CMAKE = REPO_ROOT / "CMakeLists.txt"
++WORKFLOW = REPO_ROOT / ".github/workflows/cpp_server_build_test_release.yml"
++PROCESS_TIMEOUT_SECONDS = 240
++TESTING_DEFINITION = "LEMONADE_RESIDENCY_DURABLE_TESTING"
++UNAVAILABLE = "TASK-020 durable residency persistence contract is unavailable"
++COMPILER_UNAVAILABLE = "durable journal public-seam compiler is unavailable"
++COMPILATION_FAILED = "durable journal public-seam compilation failed"
++COMPILATION_TIMED_OUT = "durable journal public-seam compilation timed out"
++EXECUTABLE_UNAVAILABLE = "durable journal public-seam executable is unavailable"
++EXECUTION_TIMED_OUT = "durable journal public-seam execution timed out"
++CONTRACT_ASSERTION_FAILED = "durable journal public-seam contract assertion failed"
++TASK019_HASHES = {
++    JOURNAL_HEADER: "afc94955a9fa57dc0154d4fbb2e19ca416d2d33c770616c75c45f031c7b167f7",
++    JOURNAL_SOURCE: "de9ae2b8943e8a539f01809537590cacf8676b6b54256d2f6497094792fa6b73",
++}
++
++
++def cmake_relative_path(path: PurePath, root: PurePath) -> str:
++    return path.relative_to(root).as_posix()
++
++
++def split_compiler_command(value: str, *, windows: bool) -> list[str]:
++    try:
++        configured = shlex.split(value, posix=not windows)
++    except ValueError as error:
++        raise RuntimeError("C++ compiler command is invalid") from error
++    if windows:
++        configured = [
++            (
++                token[1:-1]
++                if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}
++                else token
++            )
++            for token in configured
++        ]
++    return configured
++
++
++def configured_compiler(
++    *,
++    environment: Mapping[str, str] | None = None,
++    which=shutil.which,
++) -> list[str]:
++    if environment is None:
++        environment = os.environ
++    windows = os.name == "nt"
++    default = "cl.exe" if windows else "c++"
++    configured = split_compiler_command(
++        environment.get("CXX", default), windows=windows
++    )
++    if not configured or which(configured[0]) is None:
++        raise RuntimeError(f"C++ compiler is unavailable: {configured!r}")
++    return configured
++
++
++def explicit_compiler(value: str) -> list[str]:
++    compiler = Path(value)
++    if not compiler.is_absolute() or not compiler.is_file():
++        raise RuntimeError("hosted C++ compiler is unavailable")
++    if os.name != "nt" and not os.access(compiler, os.X_OK):
++        raise RuntimeError("hosted C++ compiler is unavailable")
++    return [str(compiler)]
++
++
++def is_msvc_frontend(configured: list[str]) -> bool:
++    executable = configured[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
++    return executable in {"cl", "cl.exe", "clang-cl", "clang-cl.exe"}
++
++
++def native_adapter_source() -> Path:
++    if os.name == "nt":
++        return ADAPTER_WINDOWS
++    if sys.platform == "darwin":
++        return ADAPTER_MACOS
++    return ADAPTER_POSIX
++
++
++def compiler_command(
++    output: Path,
++    *,
++    configured: list[str] | None = None,
++    environment: Mapping[str, str] | None = None,
++) -> list[str]:
++    if configured is None:
++        configured = configured_compiler()
++    if environment is None:
++        environment = os.environ
++
++    executable = configured[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
++    nlohmann_include = environment.get("NLOHMANN_JSON_INCLUDE_DIR")
++    mbedtls_include = environment.get("MBEDTLS_INCLUDE_DIR")
++    mbedcrypto_library = environment.get("MBEDCRYPTO_LIBRARY")
++    sources = [
++        JOURNAL_SOURCE,
++        DURABLE_SOURCE,
++        ADAPTER_COMMON,
++        native_adapter_source(),
++        TEST_SUPPORT,
++        PUBLIC_SEAM,
++    ]
++
++    if executable in {"cl", "cl.exe", "clang-cl", "clang-cl.exe"}:
++        command = [
++            *configured,
++            "/nologo",
++            "/std:c++17",
++            "/W4",
++            "/WX",
++            "/EHsc",
++            f"/D{TESTING_DEFINITION}",
++            f"/I{INCLUDE_ROOT}",
++            f"/I{INTERNAL_INCLUDE_ROOT}",
++            f"/I{TEST_INCLUDE_ROOT}",
++        ]
++        if nlohmann_include:
++            command.append(f"/I{nlohmann_include}")
++        if mbedtls_include:
++            command.append(f"/I{mbedtls_include}")
++        if not mbedcrypto_library:
++            raise RuntimeError(
++                "MBEDCRYPTO_LIBRARY is required for the MSVC public seam"
++            )
++        command.extend(
++            [
++                f"/Fo{output.parent}{os.sep}",
++                f"/Fd{output.with_suffix('.pdb')}",
++                *(str(source) for source in sources),
++                mbedcrypto_library,
++                f"/Fe:{output}",
++            ]
++        )
++        return command
++
++    command = [
++        *configured,
++        "-std=c++17",
++        "-Wall",
++        "-Wextra",
++        "-Werror",
++        "-pedantic",
++        "-pthread",
++        f"-D{TESTING_DEFINITION}",
++        "-I",
++        str(INCLUDE_ROOT),
++        "-I",
++        str(INTERNAL_INCLUDE_ROOT),
++        "-I",
++        str(TEST_INCLUDE_ROOT),
++    ]
++    if nlohmann_include:
++        command.extend(["-I", nlohmann_include])
++    if mbedtls_include:
++        command.extend(["-I", mbedtls_include])
++    command.extend(
++        [
++            *(str(source) for source in sources),
++            mbedcrypto_library or "-lmbedcrypto",
++            "-o",
++            str(output),
++        ]
++    )
++    return command
++
++
++def compile_only_command(
++    source: Path,
++    output: Path,
++    *,
++    configured: list[str],
++    system_includes: tuple[str, ...] = (),
++) -> list[str]:
++    executable = configured[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
++    if executable in {"cl", "cl.exe", "clang-cl", "clang-cl.exe"}:
++        command = [
++            *configured,
++            "/nologo",
++            "/std:c++17",
++            "/EHsc",
++            f"/U{TESTING_DEFINITION}",
++            f"/I{INCLUDE_ROOT}",
++            "/c",
++            str(source),
++            f"/Fo{output}",
++        ]
++        command.extend(f"/I{include}" for include in system_includes)
++        return command
++    command = [
++        *configured,
++        "-std=c++17",
++        f"-U{TESTING_DEFINITION}",
++        "-I",
++        str(INCLUDE_ROOT),
++        "-c",
++        str(source),
++        "-o",
++        str(output),
++    ]
++    system_include_flags = [
++        token for include in system_includes for token in ("-isystem", include)
++    ]
++    command[2:2] = system_include_flags
++    return command
++
++
++def require_private_authority_construction(
++    directory: Path,
++    *,
++    configured: list[str],
++    system_includes: tuple[str, ...] = (),
++    runner=subprocess.run,
++) -> str | None:
++    positive_source = directory / "published_journal_positive_control.cpp"
++    positive_output = directory / "published_journal_positive_control.obj"
++    positive_source.write_text(
++        """
++#include "lemon/residency/durable_journal.h"
++#include "platform/durable_file_adapter.h"
++#include <type_traits>
++using lemon::residency::PublishedJournal;
++static_assert(std::is_move_constructible_v<PublishedJournal>);
++static_assert(!std::is_copy_constructible_v<PublishedJournal>);
++namespace lemon::residency::detail {
++enum class DurablePreflightTestFault { MacroOffNameCollision };
++class DurableJournalTestFactory {};
++inline constexpr int make_platform_durable_file_adapter_for_test = 0;
++inline constexpr int make_durable_journal_for_test = 0;
++}
++""",
++        encoding="utf-8",
++    )
++    try:
++        positive = runner(
++            compile_only_command(
++                positive_source,
++                positive_output,
++                configured=configured,
++                system_includes=(str(INTERNAL_INCLUDE_ROOT), *system_includes),
++            ),
++            cwd=directory,
++            check=False,
++            stdout=subprocess.PIPE,
++            stderr=subprocess.PIPE,
++            timeout=PROCESS_TIMEOUT_SECONDS,
++        )
++    except subprocess.TimeoutExpired:
++        return COMPILATION_TIMED_OUT
++    except (OSError, UnicodeError):
++        return COMPILER_UNAVAILABLE
++    if positive.returncode != 0:
++        return COMPILATION_FAILED
++
++    adversaries = {
++        "default": """
++#include "lemon/residency/durable_journal.h"
++using lemon::residency::PublishedJournal;
++PublishedJournal forged;
++""",
++        "root": """
++#include "lemon/residency/durable_journal.h"
++#include <string>
++using lemon::residency::PublishedJournal;
++PublishedJournal forged(std::string("root"));
++""",
++        "copy": """
++#include "lemon/residency/durable_journal.h"
++using lemon::residency::PublishedJournal;
++PublishedJournal copy(const PublishedJournal &value) { return value; }
++""",
++        "export": """
++#include "lemon/residency/durable_journal.h"
++#include <utility>
++using namespace lemon::residency;
++PublishedJournal forge(ExactSchemaExportCandidate value) {
++    return PublishedJournal(std::move(value));
++}
++""",
++        "record": """
++#include "lemon/residency/durable_journal.h"
++using namespace lemon::residency;
++PublishedJournal forge(const ParsedJournalRecord &value) {
++    return PublishedJournal(value);
++}
++""",
++        "history": """
++#include "lemon/residency/durable_journal.h"
++using namespace lemon::residency;
++PublishedJournal forge(JournalHistory &&value) {
++    return PublishedJournal(static_cast<JournalHistory &&>(value));
++}
++""",
++        "root_candidate": """
++#include "lemon/residency/durable_journal.h"
++using namespace lemon::residency;
++PublishedJournal forge(const AuthorityRootCandidate &value) {
++    return PublishedJournal(value);
++}
++""",
++        "adapter": """
++#include "lemon/residency/durable_journal.h"
++#include <memory>
++struct ForgedAdapter {};
++using lemon::residency::PublishedJournal;
++PublishedJournal forge(std::shared_ptr<ForgedAdapter> value) {
++    return PublishedJournal(value);
++}
++""",
++        "public_access": """
++#include "lemon/residency/durable_journal.h"
++namespace lemon::residency {
++class PublishedJournalAccess {
++public:
++    static PublishedJournal forge() { return PublishedJournal(); }
++};
++}
++""",
++        "public_test_access": """
++#include "lemon/residency/durable_journal.h"
++#include <memory>
++#include <utility>
++struct ForgedAdapter {};
++namespace lemon::residency {
++class DurableJournalTestAccess {
++public:
++    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
++        return DurableJournal(std::move(adapter), JournalLimits{});
++    }
++};
++}
++""",
++        "detail_access": """
++#include "lemon/residency/durable_journal.h"
++#include <memory>
++#include <utility>
++struct ForgedAdapter {};
++namespace lemon::residency::detail {
++class DurableJournalAccess {
++public:
++    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
++        return DurableJournal(std::move(adapter), JournalLimits{});
++    }
++};
++}
++""",
++        "detail_test_access": """
++#include "lemon/residency/durable_journal.h"
++#include <memory>
++#include <utility>
++struct ForgedAdapter {};
++namespace lemon::residency::detail {
++class DurableJournalTestAccess {
++public:
++    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
++        return DurableJournal(std::move(adapter), JournalLimits{});
++    }
++};
++}
++""",
++        "journal_default": """
++#include "lemon/residency/durable_journal.h"
++using lemon::residency::DurableJournal;
++DurableJournal forged;
++""",
++        "journal_copy": """
++#include "lemon/residency/durable_journal.h"
++using lemon::residency::DurableJournal;
++DurableJournal copy(const DurableJournal &value) { return value; }
++""",
++        "exact_test_factory": """
++#include "lemon/residency/durable_journal.h"
++#include <memory>
++#include <utility>
++struct ForgedAdapter {};
++namespace lemon::residency::detail {
++class DurableJournalTestFactory {
++public:
++    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
++        return DurableJournal(std::move(adapter), JournalLimits{});
++    }
++};
++}
++""",
++    }
++    for name, source_text in adversaries.items():
++        source = directory / f"forged_published_journal_{name}.cpp"
++        output = directory / f"forged_published_journal_{name}.obj"
++        source.write_text(source_text, encoding="utf-8")
++        try:
++            completed = runner(
++                compile_only_command(
++                    source,
++                    output,
++                    configured=configured,
++                    system_includes=system_includes,
++                ),
++                cwd=REPO_ROOT,
++                check=False,
++                stdout=subprocess.PIPE,
++                stderr=subprocess.PIPE,
++                timeout=PROCESS_TIMEOUT_SECONDS,
++            )
++        except subprocess.TimeoutExpired:
++            return COMPILATION_TIMED_OUT
++        except (OSError, UnicodeError):
++            return COMPILER_UNAVAILABLE
++        if completed.returncode == 0:
++            return CONTRACT_ASSERTION_FAILED
++    return None
++
++
++def require_platform_source_contract() -> None:
++    adapter_header = strip_cpp_comments_and_literals(
++        ADAPTER_HEADER.read_text(encoding="utf-8")
++    )
++    common = strip_cpp_comments_and_literals(ADAPTER_COMMON.read_text(encoding="utf-8"))
++    posix = strip_cpp_comments_and_literals(ADAPTER_POSIX.read_text(encoding="utf-8"))
++    windows = strip_cpp_comments_and_literals(
++        ADAPTER_WINDOWS.read_text(encoding="utf-8")
++    )
++    macos = strip_cpp_comments_and_literals(ADAPTER_MACOS.read_text(encoding="utf-8"))
++    durable = DURABLE_SOURCE.read_text(encoding="utf-8")
++    durable_header_raw = DURABLE_HEADER.read_text(encoding="utf-8")
++    durable_header = strip_cpp_comments_preserve_literals(durable_header_raw)
++    durable_header_code = strip_cpp_comments_and_literals(durable_header_raw)
++
++    require_exact_struct_shape(
++        adapter_header,
++        "DurableFixedNamespaceResult",
++        (
++            "DurableFileResult result;",
++            "bool journal_present;",
++            "bool root_present;",
++            "bool journal_stage_present;",
++            "bool root_stage_present;",
++            "bool lock_present;",
++        ),
++    )
++    require_exact_struct_shape(
++        adapter_header,
++        "DurableReadChunkResult",
++        (
++            "DurableFileResult result;",
++            "std::string bytes;",
++            "bool end_of_file = false;",
++        ),
++    )
++    if (
++        re.search(
++            r"\bclass\s+DurableReadChannel\s*\{(?P<body>.*?)\n\};",
++            adapter_header,
++            re.DOTALL,
++        )
++        is None
++        or re.search(
++            r"\bvirtual\s+DurableReadChunkResult\s+read_some\s*"
++            r"\(\s*std::size_t\s+max_bytes\s*\)\s*=\s*0\s*;",
++            adapter_header,
++        )
++        is None
++        or re.search(
++            r"\bvirtual\s+DurableFileResult\s+close\s*\(\s*\)\s*=\s*0\s*;",
++            adapter_header,
++        )
++        is None
++    ):
++        raise AssertionError("durable bounded-read channel shape drifted")
++    if (
++        re.search(
++            r"\bvirtual\s+DurableFixedNamespaceResult\s+"
++            r"inspect_fixed_namespace\s*\(\s*\)\s*=\s*0\s*;",
++            adapter_header,
++        )
++        is None
++    ):
++        raise AssertionError("durable adapter omits fixed-namespace inspection")
++
++    fixed_constants = {
++        "durable_journal_data_filename": "journal.jsonl",
++        "durable_journal_root_filename": "authority-root.json",
++        "durable_journal_lock_filename": "authority.lock",
++    }
++    for constant, value in fixed_constants.items():
++        declaration = re.compile(
++            rf"inline\s+constexpr\s+std::string_view\s+{constant}\s*=\s*\"{re.escape(value)}\"\s*;"
++        )
++        if declaration.search(durable_header) is None:
++            raise AssertionError(
++                f"missing fixed authority filename contract {constant}"
++            )
++        narrated = f'// inline constexpr std::string_view {constant} = "{value}";\n'
++        if declaration.search(strip_cpp_comments_preserve_literals(narrated)):
++            raise AssertionError("fixed-name scanner accepted a commented declaration")
++    published_match = re.search(
++        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
++        durable_header_code,
++        re.DOTALL,
++    )
++    if published_match is None:
++        raise AssertionError("PublishedJournal public declaration is unavailable")
++    require_published_journal_public_shape(durable_header_code)
++    require_durable_journal_public_shape(durable_header_code)
++    require_trusted_replay_floor_public_shape(durable_header_code)
++    if re.search(
++        r"\b(?:static\s+)?PublishedJournal\s+[A-Za-z_]\w*\s*\(",
++        durable_header_code,
++    ) or re.search(
++        r"\bstd\s*::\s*optional\s*<\s*PublishedJournal\s*>\s+" r"[A-Za-z_]\w*\s*\(",
++        durable_header_code,
++    ):
++        raise AssertionError("public header exposes an authority-minting factory")
++    friend_declarations = re.findall(r"\bfriend\b[^;]*;", published_match.group("body"))
++    if friend_declarations != ["friend class DurableJournal;"]:
++        raise AssertionError("PublishedJournal has a forgeable friend graph")
++    testing_friend = "friend class detail::DurableJournalTestFactory;"
++    if durable_header_code.count(testing_friend) != 1 or not exactly_macro_guarded(
++        durable_header_code,
++        testing_friend,
++        TESTING_DEFINITION,
++    ):
++        raise AssertionError("DurableJournal test factory is not macro-confined")
++    unguarded_factory_mutant = f"""
++#ifdef {TESTING_DEFINITION}
++#endif
++{testing_friend}
++#ifdef OTHER_GUARD
++#endif
++"""
++    if exactly_macro_guarded(
++        unguarded_factory_mutant,
++        testing_friend,
++        TESTING_DEFINITION,
++    ):
++        raise AssertionError("test-factory scanner crossed an early endif")
++    unguarded_declaration_mutant = f"""
++#ifdef {TESTING_DEFINITION}
++#endif
++namespace detail {{ class DurableJournalTestFactory; }}
++#ifdef OTHER_GUARD
++#endif
++"""
++    if exactly_macro_guarded_region(
++        unguarded_declaration_mutant,
++        TESTING_DEFINITION,
++        ("namespace detail", "class DurableJournalTestFactory;"),
++    ):
++        raise AssertionError("test-factory declaration scanner crossed endif")
++    for forbidden in (
++        "DurableFileAdapter",
++        "make_durable_journal_for_test",
++        "from_adapter",
++        "testing_adapter",
++    ):
++        if forbidden in durable_header_code:
++            raise AssertionError("public durable journal exposes adapter injection")
++    if not exactly_macro_guarded_region(
++        durable_header_code,
++        TESTING_DEFINITION,
++        ("class DurableJournalTestFactory;",),
++    ):
++        raise AssertionError("test-factory declaration is not macro-confined")
++    require_exact_enum_members(
++        durable_header_code,
++        "DurableJournalStatus",
++        (
++            "Published",
++            "ConflictBeforeWrite",
++            "UnsupportedStorage",
++            "CorruptOrRollback",
++            "LimitExceeded",
++            "RecoveryRequired",
++        ),
++    )
++    require_exact_enum_members(
++        durable_header_code,
++        "ExactSchemaExportStatus",
++        (
++            "ExportedCandidate",
++            "QuiescenceRequired",
++            "ConflictBeforeRead",
++            "RecoveryRequired",
++            "UnsupportedStorage",
++            "CorruptOrRollback",
++            "SchemaMismatch",
++            "LimitExceeded",
++        ),
++    )
++    require_exact_enum_members(
++        durable_header_code,
++        "JournalQuiescence",
++        ("Unconfirmed", "Confirmed"),
++    )
++    enum_mutant = """
++enum class DurableJournalStatus {
++    Published, ConflictBeforeWrite, UnsupportedStorage, CorruptOrRollback,
++    LimitExceeded, RecoveryRequired, ForgedSuccess
++};
++"""
++    try:
++        require_exact_enum_members(
++            enum_mutant,
++            "DurableJournalStatus",
++            (
++                "Published",
++                "ConflictBeforeWrite",
++                "UnsupportedStorage",
++                "CorruptOrRollback",
++                "LimitExceeded",
++                "RecoveryRequired",
++            ),
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("status scanner accepted an extra public outcome")
++    quiescence_mutant = """
++enum class JournalQuiescence { Unconfirmed, Confirmed, Assumed };
++"""
++    try:
++        require_exact_enum_members(
++            quiescence_mutant,
++            "JournalQuiescence",
++            ("Unconfirmed", "Confirmed"),
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("quiescence scanner accepted an extra public state")
++    require_exact_struct_shape(
++        durable_header_code,
++        "DurableJournalResult",
++        (
++            "DurableJournalStatus status;",
++            "std::optional<PublishedJournal> journal;",
++            "bool published() const noexcept;",
++        ),
++    )
++    require_exact_struct_shape(
++        durable_header_code,
++        "ExactSchemaExportCandidate",
++        (
++            "SchemaVersion schema;",
++            "std::string journal_bytes;",
++            "std::string authority_root_bytes;",
++        ),
++    )
++    require_exact_struct_shape(
++        durable_header_code,
++        "ExactSchemaExportResult",
++        (
++            "ExactSchemaExportStatus status;",
++            "std::optional<ExactSchemaExportCandidate> candidate;",
++            "bool exported() const noexcept;",
++        ),
++    )
++    diagnostic_mutant = durable_header_code.replace(
++        "DurableJournalStatus status;",
++        "DurableJournalStatus status; std::string diagnostic;",
++        1,
++    )
++    if diagnostic_mutant == durable_header_code:
++        raise AssertionError("public diagnostic mutant was unavailable")
++    try:
++        require_exact_struct_shape(
++            diagnostic_mutant,
++            "DurableJournalResult",
++            (
++                "DurableJournalStatus status;",
++                "std::optional<PublishedJournal> journal;",
++                "bool published() const noexcept;",
++            ),
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("public result scanner accepted diagnostics")
++    combined_code = f"{common}\n{posix}\n{windows}\n{macos}\n{strip_cpp_comments_and_literals(durable)}"
++    if "atomic_replace_file" in combined_code or "copy_file" in combined_code:
++        raise AssertionError("durable adapter uses a forbidden copy fallback")
++    durable_code = strip_cpp_comments_and_literals(durable)
++    if "parse_authority_root_candidate" not in durable_code:
++        raise AssertionError("persistence bypassed the TASK-019 root parser")
++    if "inspect_fixed_namespace" not in durable_code:
++        raise AssertionError("persistence bypassed fixed-namespace inspection")
++    if "nlohmann" in durable_code or "parse_json" in durable_code:
++        raise AssertionError("persistence duplicated TASK-019 JSON parsing")
++    require_task019_live_contract(durable_code)
++    require_compaction_prefix_binding(durable_code)
++    require_directory_lineage_fence_registry(durable_code)
++    require_final_authority_revalidation(durable_code)
++    for path, expected in TASK019_HASHES.items():
++        observed = hashlib.sha256(path.read_bytes()).hexdigest()
++        if observed != expected:
++            raise AssertionError("TASK-019 pure codec bytes changed during TASK-020")
++
++    require_tokens(
++        posix,
++        (
++            "openat",
++            "renameat",
++            "fsync",
++            "flock",
++            "O_APPEND",
++            "O_CLOEXEC",
++            "O_NOFOLLOW",
++            "AT_SYMLINK_NOFOLLOW",
++            "LOCK_EX",
++            "EINTR",
++            "S_ISREG",
++            "st_ino",
++            "st_dev",
++            "st_nlink",
++            "ftruncate",
++            "O_DIRECTORY",
++            "close",
++            "read",
++        ),
++        "POSIX durable adapter",
++    )
++    if "atomic_replace_file" in posix:
++        raise AssertionError("POSIX adapter reused generic replacement")
++
++    require_tokens(
++        windows,
++        (
++            "CreateFileW",
++            "WriteFile",
++            "ReadFile",
++            "FlushFileBuffers",
++            "CloseHandle",
++            "LockFileEx",
++            "UnlockFileEx",
++            "MoveFileExW",
++            "MOVEFILE_REPLACE_EXISTING",
++            "MOVEFILE_WRITE_THROUGH",
++            "SetFilePointerEx",
++            "SetEndOfFile",
++            "MAXDWORD",
++            "OPEN_ALWAYS",
++            "ERROR_ALREADY_EXISTS",
++            "OVERLAPPED",
++            "FILE_SHARE_READ",
++            "FILE_SHARE_WRITE",
++            "FILE_FLAG_OPEN_REPARSE_POINT",
++            "FILE_ATTRIBUTE_REPARSE_POINT",
++            "FILE_ATTRIBUTE_DIRECTORY",
++            "GetFileInformationByHandleEx",
++            "FileIdInfo",
++            "FileAttributeTagInfo",
++            "FILE_ID_INFO",
++            "FILE_ATTRIBUTE_TAG_INFO",
++        ),
++        "Windows durable adapter",
++    )
++    require_absent_tokens(
++        windows,
++        (
++            "MOVEFILE_COPY_ALLOWED",
++            "FILE_ATTRIBUTE_TEMPORARY",
++            "FILE_FLAG_DELETE_ON_CLOSE",
++            "FILE_FLAG_OVERLAPPED",
++            "FILE_SHARE_DELETE",
++        ),
++        "Windows durable adapter",
++    )
++
++    require_tokens(
++        macos,
++        (
++            "F_FULLFSYNC",
++            "fcntl",
++            "fsync",
++            "renameat",
++            "flock",
++            "openat",
++            "fstatat",
++            "O_NOFOLLOW",
++            "O_DIRECTORY",
++            "AT_SYMLINK_NOFOLLOW",
++            "LOCK_EX",
++            "EINTR",
++            "S_ISREG",
++            "st_ino",
++            "st_dev",
++            "st_nlink",
++            "close",
++            "O_APPEND",
++            "O_CLOEXEC",
++            "ftruncate",
++        ),
++        "macOS durable adapter",
++    )
++    if "F_BARRIERFSYNC" in macos:
++        raise AssertionError("macOS adapter substituted a barrier for persistence")
++    require_call_argument(macos, "fcntl", "F_FULLFSYNC", "macOS regular-file policy")
++    require_call_arguments(
++        windows,
++        "MoveFileExW",
++        ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
++        "Windows root replacement",
++    )
++    require_call_arguments(
++        windows,
++        "LockFileEx",
++        ("LOCKFILE_EXCLUSIVE_LOCK", "MAXDWORD", "MAXDWORD"),
++        "Windows whole-file lock",
++    )
++    require_call_argument(posix, "flock", "LOCK_EX", "POSIX authority lock")
++    require_call_argument(macos, "flock", "LOCK_EX", "macOS authority lock")
++    for platform_source, label in (
++        (posix, "POSIX durable adapter"),
++        (macos, "macOS durable adapter"),
++    ):
++        require_call_arguments_unordered(
++            platform_source,
++            "openat",
++            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
++            f"{label} journal append",
++        )
++        require_call_argument(
++            platform_source,
++            "open",
++            "O_DIRECTORY",
++            f"{label} authority directory",
++        )
++        require_call_argument(
++            platform_source,
++            "fstatat",
++            "AT_SYMLINK_NOFOLLOW",
++            f"{label} stable lock identity",
++        )
++        require_call_expression(platform_source, "renameat", label)
++    require_call_arguments_unordered(
++        windows,
++        "CreateFileW",
++        ("OPEN_ALWAYS", "FILE_SHARE_READ", "FILE_SHARE_WRITE"),
++        "Windows stable authority lock",
++    )
++    if re.search(r"\bOVERLAPPED\s+\w+\s*(?:\{\s*\}|=\s*\{\s*\})", windows) is None:
++        raise AssertionError("Windows authority lock OVERLAPPED is not zeroed")
++    require_call_argument(
++        windows,
++        "GetFileInformationByHandleEx",
++        "FileIdInfo",
++        "Windows composite authority identity",
++    )
++    all_adapter_sources = f"{common}\n{posix}\n{windows}\n{macos}"
++    helper_declarations = {
++        "retry_interrupted": (
++            "DurableFileResult retry_interrupted(DurableInterruptibleCall &call);"
++        ),
++        "write_all": (
++            "DurableFileResult write_all(DurableFileChannel &channel, "
++            "std::string_view bytes);"
++        ),
++        "flush_retrying_interrupts": (
++            "DurableFileResult flush_retrying_interrupts("
++            "DurableFileChannel &channel);"
++        ),
++        "truncate_retrying_interrupts": (
++            "DurableFileResult truncate_retrying_interrupts("
++            "DurableFileChannel &channel, std::size_t bytes);"
++        ),
++        "close_once": ("DurableFileResult close_once(DurableFileChannel &channel);"),
++        "write_flush_close": (
++            "DurableFileResult write_flush_close(DurableFileChannel &channel, "
++            "std::string_view bytes);"
++        ),
++        "truncate_flush_close": (
++            "DurableFileResult truncate_flush_close("
++            "DurableFileChannel &channel, std::size_t bytes);"
++        ),
++        "close_read_once": (
++            "DurableFileResult close_read_once(DurableReadChannel &channel);"
++        ),
++    }
++    for helper, declaration in helper_declarations.items():
++        require_unique_helper_definition(
++            adapter_header,
++            all_adapter_sources,
++            helper,
++            declaration,
++            "durable adapter",
++        )
++    require_unique_helper_definition(
++        adapter_header,
++        all_adapter_sources,
++        "read_bounded_close",
++        "DurableReadResult read_bounded_close(DurableReadChannel &channel, "
++        "std::size_t max_bytes);",
++        "durable adapter",
++        return_type="DurableReadResult",
++    )
++    for platform_source, label in (
++        (posix, "POSIX durable adapter"),
++        (windows, "Windows durable adapter"),
++        (macos, "macOS durable adapter"),
++    ):
++        combined_platform = f"{common}\n{platform_source}"
++        for required_call in (
++            "write_flush_close",
++            "truncate_flush_close",
++        ):
++            require_each_override_call(
++                combined_platform,
++                "DurableFileAdapter",
++                "preflight_capabilities",
++                required_call,
++                f"{label} capability probe",
++            )
++        for entry, required_calls in (
++            ("append_journal", ("write_flush_close",)),
++            ("truncate_journal", ("truncate_flush_close",)),
++            ("read_root", ("read_bounded_close",)),
++            ("read_journal", ("read_bounded_close",)),
++            ("create_journal", ("write_flush_close",)),
++            ("replace_journal", ("write_flush_close",)),
++            ("replace_root", ("write_flush_close",)),
++        ):
++            for required_call in required_calls:
++                require_each_override_call_exactly_once(
++                    combined_platform,
++                    "DurableFileAdapter",
++                    entry,
++                    required_call,
++                    label,
++                )
++        for entry in ("create_journal", "append_journal"):
++            require_each_override_call_result_propagated(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "write_flush_close",
++                label,
++            )
++        require_each_override_call_result_propagated(
++            combined_platform,
++            "DurableFileAdapter",
++            "truncate_journal",
++            "truncate_flush_close",
++            label,
++        )
++        for entry in ("replace_journal", "replace_root"):
++            require_each_override_call_result_propagated(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "write_flush_close",
++                label,
++            )
++        for entry in ("read_root", "read_journal"):
++            require_each_override_call_result_propagated(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "read_bounded_close",
++                label,
++            )
++        require_each_override_call_result_propagated(
++            combined_platform,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "write_flush_close",
++            f"{label} capability probe",
++            minimum_calls=2,
++        )
++        require_each_override_call_result_propagated(
++            combined_platform,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "truncate_flush_close",
++            f"{label} capability probe",
++        )
++    for platform_source, platform, label in (
++        (posix, "posix", "POSIX durable adapter"),
++        (macos, "posix", "macOS durable adapter"),
++        (windows, "windows", "Windows durable adapter"),
++    ):
++        require_post_replace_verification(platform_source, platform, label)
++        require_post_replace_verification_mutants(platform_source, platform, label)
++    require_windows_bound_directory_factory(windows)
++    require_windows_bound_directory_factory_mutants(windows)
++    require_transaction_helper_contract(all_adapter_sources)
++    require_bounded_read_helper_contract(f"{adapter_header}\n{all_adapter_sources}")
++    require_close_read_once_contract(all_adapter_sources)
++    for platform_source, label in (
++        (posix, "POSIX durable adapter"),
++        (macos, "macOS durable adapter"),
++    ):
++        combined_platform = f"{common}\n{platform_source}"
++        require_retrying_posix_flock(
++            platform_source,
++            "lock_file_retrying_interrupts",
++            "LOCK_EX",
++            f"{label} acquisition",
++        )
++        require_retrying_posix_flock(
++            platform_source,
++            "unlock_file_retrying_interrupts",
++            "LOCK_UN",
++            f"{label} release",
++        )
++        require_retrying_posix_flock(
++            platform_source,
++            "lock_directory_retrying_interrupts",
++            "LOCK_EX",
++            f"{label} directory acquisition",
++        )
++        require_retrying_posix_flock(
++            platform_source,
++            "unlock_directory_retrying_interrupts",
++            "LOCK_UN",
++            f"{label} directory release",
++        )
++        require_retrying_posix_flock_mutant(
++            platform_source,
++            "lock_directory_retrying_interrupts",
++            "LOCK_EX",
++            f"{label} directory acquisition",
++        )
++        require_retrying_posix_flock_mutant(
++            platform_source,
++            "unlock_directory_retrying_interrupts",
++            "LOCK_UN",
++            f"{label} directory release",
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            "lock_file_retrying_interrupts",
++            label,
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "unlock_authority",
++            "unlock_file_retrying_interrupts",
++            label,
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            "lock_directory_retrying_interrupts",
++            label,
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "unlock_authority",
++            "unlock_directory_retrying_interrupts",
++            label,
++        )
++        require_each_override_result_call_checked(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            "lock_file_retrying_interrupts",
++            label,
++        )
++        require_each_override_result_call_checked(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            "lock_directory_retrying_interrupts",
++            label,
++        )
++        require_each_override_result_call_checked(
++            combined_platform,
++            "DurableFileAdapter",
++            "unlock_authority",
++            "unlock_directory_retrying_interrupts",
++            label,
++        )
++        require_posix_unlock_result_mapping(combined_platform, label)
++        require_each_override_ordered_calls(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            (
++                "lock_directory_retrying_interrupts",
++                "openat",
++                "lock_file_retrying_interrupts",
++            ),
++            label,
++        )
++        require_each_override_ordered_calls(
++            combined_platform,
++            "DurableFileAdapter",
++            "unlock_authority",
++            (
++                "unlock_file_retrying_interrupts",
++                "close",
++                "unlock_directory_retrying_interrupts",
++            ),
++            label,
++        )
++        require_posix_live_lock_rebinding(combined_platform, label)
++        require_posix_lock_path_binding_mutants(combined_platform, label)
++        require_retrying_directory_sync(platform_source, label)
++        require_each_override_call_arguments(
++            combined_platform,
++            "DurableFileAdapter",
++            "append_journal",
++            "openat",
++            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
++            label,
++        )
++        require_each_override_call(
++            combined_platform,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "renameat",
++            f"{label} capability probe replacement",
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "renameat",
++            f"{label} capability probe replacement",
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "sync_directory_retrying_interrupts",
++            f"{label} capability probe namespace durability",
++        )
++        require_each_override_directory_sync_binding(
++            combined_platform,
++            "preflight_capabilities",
++            f"{label} capability probe namespace durability",
++        )
++        require_each_override_result_call_checked(
++            combined_platform,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "sync_directory_retrying_interrupts",
++            f"{label} capability probe namespace durability",
++        )
++        require_each_override_call_arguments(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            "fstatat",
++            ("AT_SYMLINK_NOFOLLOW",),
++            label,
++        )
++        require_unique_function_call_arguments(
++            combined_platform,
++            "make_platform_durable_file_adapter",
++            "open",
++            ("O_DIRECTORY",),
++            label,
++        )
++        require_each_override_fail_closed_checks(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            ("fstat", "fstatat", "S_ISREG", "st_nlink", "st_dev", "st_ino"),
++            f"{label} stable lock",
++        )
++        require_each_override_ordered_calls(
++            combined_platform,
++            "DurableFileAdapter",
++            "lock_authority",
++            ("lock_file_retrying_interrupts", "fstat", "fstatat"),
++            f"{label} stable lock",
++        )
++        for entry in (
++            "read_root",
++            "read_journal",
++            "create_journal",
++            "append_journal",
++            "truncate_journal",
++            "replace_journal",
++            "replace_root",
++        ):
++            require_each_override_call_arguments(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "openat",
++                ("O_CLOEXEC", "O_NOFOLLOW"),
++                f"{label} fixed-child open",
++            )
++            require_each_override_call(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "fstat",
++                f"{label} fixed-child open",
++            )
++            require_each_override_pattern(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                r"\bS_ISREG\s*\(",
++                f"{label} fixed-child open",
++            )
++            require_each_override_fail_closed_checks(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                ("fstat", "S_ISREG"),
++                f"{label} fixed-child open",
++            )
++        for entry in ("preflight_capabilities", "inspect_fixed_namespace"):
++            require_each_override_call_arguments(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "fstatat",
++                ("AT_SYMLINK_NOFOLLOW",),
++                f"{label} fixed-child preflight",
++            )
++            require_each_override_pattern(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                r"\bS_ISREG\s*\(",
++                f"{label} fixed-child preflight",
++            )
++            require_each_override_fail_closed_checks(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                ("fstatat", "S_ISREG"),
++                f"{label} fixed-child preflight",
++            )
++    require_each_override_call_arguments(
++        f"{common}\n{macos}",
++        "DurableFileChannel",
++        "flush",
++        "fcntl",
++        ("F_FULLFSYNC",),
++        "macOS durable adapter",
++    )
++    combined_windows = f"{common}\n{windows}"
++    require_windows_composite_identity(combined_windows)
++    require_each_override_call_arguments(
++        combined_windows,
++        "DurableFileAdapter",
++        "lock_authority",
++        "CreateFileW",
++        (
++            "FILE_SHARE_READ",
++            "FILE_SHARE_WRITE",
++            "OPEN_ALWAYS",
++            "FILE_FLAG_OPEN_REPARSE_POINT",
++        ),
++        "Windows durable adapter",
++    )
++    require_each_override_call_arguments(
++        combined_windows,
++        "DurableFileAdapter",
++        "preflight_capabilities",
++        "MoveFileExW",
++        ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
++        "Windows durable adapter capability probe",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableFileAdapter",
++        "preflight_capabilities",
++        "MoveFileExW",
++        "Windows durable adapter capability probe",
++    )
++    require_each_override_call_arguments(
++        combined_windows,
++        "DurableFileAdapter",
++        "lock_authority",
++        "LockFileEx",
++        ("LOCKFILE_EXCLUSIVE_LOCK", "MAXDWORD", "MAXDWORD"),
++        "Windows durable adapter",
++    )
++    require_each_override_pattern(
++        combined_windows,
++        "DurableFileAdapter",
++        "lock_authority",
++        r"\bOVERLAPPED\s+\w+\s*(?:\{\s*\}|=\s*\{\s*\})",
++        "Windows zeroed lock OVERLAPPED",
++    )
++    require_windows_lock_overlapped_binding(combined_windows)
++    require_each_override_minimum_call_argument(
++        combined_windows,
++        "DurableFileAdapter",
++        "lock_authority",
++        "GetFileInformationByHandleEx",
++        "FileIdInfo",
++        2,
++        "Windows stable lock identity",
++    )
++    require_each_override_fail_closed_checks(
++        combined_windows,
++        "DurableFileAdapter",
++        "lock_authority",
++        (
++            "LockFileEx",
++            "VolumeSerialNumber",
++            "FileId",
++            "NumberOfLinks",
++        ),
++        "Windows durable adapter lock",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableFileAdapter",
++        "lock_authority",
++        "LockFileEx",
++        "Windows durable adapter lock",
++    )
++    require_windows_unlock_result_mapping(combined_windows)
++    require_each_override_ordered_calls(
++        combined_windows,
++        "DurableFileAdapter",
++        "unlock_authority",
++        ("UnlockFileEx", "CloseHandle"),
++        "Windows durable adapter unlock",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableFileAdapter",
++        "unlock_authority",
++        "UnlockFileEx",
++        "Windows durable adapter unlock",
++    )
++    for entry in (
++        "lock_authority",
++        "preflight_capabilities",
++        "inspect_fixed_namespace",
++        "read_root",
++        "read_journal",
++        "create_journal",
++        "append_journal",
++        "truncate_journal",
++        "replace_journal",
++        "replace_root",
++    ):
++        require_each_override_call_arguments(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            "CreateFileW",
++            ("FILE_FLAG_OPEN_REPARSE_POINT",),
++            "Windows fixed-child open",
++        )
++        require_each_override_call_arguments(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            "GetFileInformationByHandleEx",
++            ("FileAttributeTagInfo",),
++            "Windows fixed-child open",
++        )
++        require_each_override_pattern(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            r"\bFILE_ATTRIBUTE_REPARSE_POINT\b",
++            "Windows fixed-child open",
++        )
++        require_each_override_fail_closed_checks(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            (
++                "GetFileInformationByHandleEx",
++                "FILE_ATTRIBUTE_REPARSE_POINT",
++                "FILE_ATTRIBUTE_DIRECTORY",
++            ),
++            "Windows fixed-child open",
++        )
++    for entry in ("replace_journal", "replace_root"):
++        require_each_override_call_arguments(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            "MoveFileExW",
++            ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
++            "Windows durable adapter",
++        )
++        require_each_override_ordered_calls(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            (
++                "write_flush_close",
++                "MoveFileExW",
++            ),
++            "Windows durable adapter",
++        )
++        require_each_override_call_exactly_once(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            "MoveFileExW",
++            "Windows durable adapter",
++        )
++    for entry, required_calls in (
++        ("lock_authority", ("openat", "fstat", "fstatat")),
++        ("authority_identity", ("fstat",)),
++        ("append_journal", ("openat",)),
++        ("replace_journal", ("renameat",)),
++        ("replace_root", ("renameat",)),
++    ):
++        for required_call in required_calls:
++            require_each_override_call(
++                f"{common}\n{posix}",
++                "DurableFileAdapter",
++                entry,
++                required_call,
++                "POSIX durable adapter",
++            )
++            require_each_override_call(
++                f"{common}\n{macos}",
++                "DurableFileAdapter",
++                entry,
++                required_call,
++                "macOS durable adapter",
++            )
++    for platform_source, label, flush_call in (
++        (posix, "POSIX durable adapter", "fsync"),
++        (macos, "macOS durable adapter", "fcntl"),
++    ):
++        combined_platform = f"{common}\n{platform_source}"
++        require_each_override_write_count_mapping(combined_platform, "posix", label)
++        require_each_override_read_count_mapping(combined_platform, "posix", label)
++        require_each_override_retryable_result_mapping(
++            combined_platform,
++            "DurableFileChannel",
++            "flush",
++            flush_call,
++            "EINTR",
++            label,
++        )
++        require_each_override_retryable_result_mapping(
++            combined_platform,
++            "DurableFileChannel",
++            "truncate",
++            "ftruncate",
++            "EINTR",
++            label,
++        )
++        require_each_override_close_result_mapping(combined_platform, "close", label)
++        require_each_override_close_result_mapping(
++            combined_platform, "close", label, base="DurableReadChannel"
++        )
++        for entry, required_call in (
++            ("write_some", "write"),
++            ("flush", flush_call),
++            ("truncate", "ftruncate"),
++        ):
++            require_each_override_call(
++                combined_platform,
++                "DurableFileChannel",
++                entry,
++                required_call,
++                label,
++            )
++            require_each_override_call_exactly_once(
++                combined_platform,
++                "DurableFileChannel",
++                entry,
++                required_call,
++                label,
++            )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileChannel",
++            "close",
++            "close",
++            label,
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableReadChannel",
++            "read_some",
++            "read",
++            label,
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableReadChannel",
++            "close",
++            "close",
++            label,
++        )
++        require_each_override_call_exactly_once(
++            combined_platform,
++            "DurableFileAdapter",
++            "unlock_authority",
++            "close",
++            label,
++        )
++        require_each_override_omits_calls(
++            combined_platform,
++            "DurableFileAdapter",
++            "replace_journal",
++            ("ftruncate", "truncate_retrying_interrupts"),
++            label,
++        )
++        require_each_override_omits_calls(
++            combined_platform,
++            "DurableFileAdapter",
++            "truncate_journal",
++            ("renameat",),
++            label,
++        )
++        for entry in ("replace_journal", "replace_root"):
++            require_each_override_directory_sync_binding(
++                combined_platform,
++                entry,
++                f"{label} parent namespace durability",
++            )
++            require_each_override_result_call_checked(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "sync_directory_retrying_interrupts",
++                f"{label} parent namespace durability",
++            )
++            require_each_override_fail_closed_checks(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                ("renameat",),
++                f"{label} replacement",
++            )
++            require_each_override_ordered_calls(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                (
++                    "write_flush_close",
++                    "renameat",
++                    "sync_directory_retrying_interrupts",
++                ),
++                f"{label} parent namespace durability",
++            )
++            require_each_override_call_exactly_once(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "renameat",
++                f"{label} parent namespace durability",
++            )
++            require_each_override_call_exactly_once(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                "sync_directory_retrying_interrupts",
++                f"{label} parent namespace durability",
++            )
++            require_each_override_omits_calls(
++                combined_platform,
++                "DurableFileAdapter",
++                entry,
++                ("fsync",),
++                f"{label} parent namespace durability",
++            )
++    for entry, required_calls in (
++        ("lock_authority", ("CreateFileW", "LockFileEx")),
++        ("authority_identity", ("GetFileInformationByHandleEx",)),
++        ("append_journal", ("CreateFileW",)),
++        ("replace_journal", ("MoveFileExW",)),
++        ("replace_root", ("MoveFileExW",)),
++        ("unlock_authority", ("UnlockFileEx",)),
++    ):
++        for required_call in required_calls:
++            require_each_override_call(
++                f"{common}\n{windows}",
++                "DurableFileAdapter",
++                entry,
++                required_call,
++                "Windows durable adapter",
++            )
++    for entry, required_call in (
++        ("write_some", "WriteFile"),
++        ("flush", "FlushFileBuffers"),
++        ("truncate", "SetEndOfFile"),
++    ):
++        require_each_override_call(
++            combined_windows,
++            "DurableFileChannel",
++            entry,
++            required_call,
++            "Windows durable adapter",
++        )
++        require_each_override_call_exactly_once(
++            combined_windows,
++            "DurableFileChannel",
++            entry,
++            required_call,
++            "Windows durable adapter",
++        )
++    require_each_override_write_count_mapping(
++        combined_windows, "windows", "Windows durable adapter"
++    )
++    require_windows_write_override_shape(combined_windows, "Windows durable adapter")
++    indirect_write_mutant = combined_windows.replace(
++        "DWORD written = 0;",
++        """const auto indirect_write = &::WriteFile;
++        DWORD ignored = 0;
++        indirect_write(handle_, bytes.data(), request, &ignored, nullptr);
++        DWORD written = 0;""",
++        1,
++    )
++    if indirect_write_mutant == combined_windows:
++        raise AssertionError("Windows write shape mutant was not materialized")
++    try:
++        require_windows_write_override_shape(indirect_write_mutant, "mutant")
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted an indirect Windows write")
++    namespace_marker = "namespace lemon::residency::detail {"
++    overload_prefix, overload_separator, overload_suffix = combined_windows.rpartition(
++        namespace_marker
++    )
++    if not overload_separator:
++        raise AssertionError("Windows namespace marker is unavailable")
++    overload_mutant = overload_prefix + """
++BOOL WriteFile(HANDLE, const char *, DWORD request,
++               DWORD *written, std::nullptr_t) {
++    *written = request;
++    return TRUE;
++}
++""" + overload_separator + overload_suffix
++    try:
++        require_each_override_write_count_mapping(overload_mutant, "windows", "mutant")
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted a redirected Windows write")
++    success_macro_mutant = combined_windows.replace(
++        "#define NOMINMAX",
++        "#define NOMINMAX\n#define Succeeded Interrupted",
++        1,
++    )
++    if success_macro_mutant == combined_windows:
++        raise AssertionError("Windows success macro mutant was not materialized")
++    try:
++        require_each_override_write_count_mapping(
++            success_macro_mutant, "windows", "mutant"
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted a shadowed Windows success")
++    require_each_override_read_count_mapping(
++        combined_windows, "windows", "Windows durable adapter"
++    )
++    require_each_override_retryable_result_mapping(
++        combined_windows,
++        "DurableFileChannel",
++        "flush",
++        "FlushFileBuffers",
++        "ERROR_OPERATION_ABORTED",
++        "Windows durable adapter",
++    )
++    for primitive in ("SetFilePointerEx", "SetEndOfFile"):
++        require_each_override_retryable_result_mapping(
++            combined_windows,
++            "DurableFileChannel",
++            "truncate",
++            primitive,
++            "ERROR_OPERATION_ABORTED",
++            "Windows durable adapter",
++        )
++    require_each_override_close_result_mapping(
++        combined_windows, "CloseHandle", "Windows durable adapter"
++    )
++    require_each_override_close_result_mapping(
++        combined_windows,
++        "CloseHandle",
++        "Windows durable adapter",
++        base="DurableReadChannel",
++    )
++    require_each_override_call(
++        combined_windows,
++        "DurableFileChannel",
++        "truncate",
++        "SetFilePointerEx",
++        "Windows durable adapter",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableFileChannel",
++        "truncate",
++        "SetFilePointerEx",
++        "Windows durable adapter",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableFileChannel",
++        "close",
++        "CloseHandle",
++        "Windows durable adapter",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableReadChannel",
++        "read_some",
++        "ReadFile",
++        "Windows durable adapter",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableReadChannel",
++        "close",
++        "CloseHandle",
++        "Windows durable adapter",
++    )
++    require_each_override_call_exactly_once(
++        combined_windows,
++        "DurableFileAdapter",
++        "unlock_authority",
++        "CloseHandle",
++        "Windows durable adapter",
++    )
++    require_each_override_omits_calls(
++        combined_windows,
++        "DurableFileAdapter",
++        "replace_journal",
++        (
++            "SetFilePointerEx",
++            "SetEndOfFile",
++            "truncate_retrying_interrupts",
++        ),
++        "Windows durable adapter",
++    )
++    for entry in ("replace_journal", "replace_root"):
++        require_each_override_fail_closed_checks(
++            combined_windows,
++            "DurableFileAdapter",
++            entry,
++            ("MoveFileExW",),
++            "Windows durable adapter replacement",
++        )
++    require_each_override_omits_calls(
++        combined_windows,
++        "DurableFileAdapter",
++        "truncate_journal",
++        ("MoveFileExW",),
++        "Windows durable adapter",
++    )
++
++    narration = """
++// fsync renameat flock F_FULLFSYNC MoveFileExW FlushFileBuffers
++const char *claims = "openat LockFileEx MOVEFILE_WRITE_THROUGH";
++"""
++    if any(
++        token in strip_cpp_comments_and_literals(narration)
++        for token in ("fsync", "MoveFileExW", "LockFileEx", "F_FULLFSYNC")
++    ):
++        raise AssertionError("source-shape scanner accepted narrated platform tokens")
++    spliced_narration = "// narrated fsync \\\nMoveFileExW LockFileEx F_FULLFSYNC\n"
++    if any(
++        token in strip_cpp_comments_and_literals(spliced_narration)
++        for token in ("fsync", "MoveFileExW", "LockFileEx", "F_FULLFSYNC")
++    ):
++        raise AssertionError("source scanner ignored C++ line splicing")
++    try:
++        require_call_expression(
++            "DurableFileResult write_all(Channel &, Bytes) { return {}; }",
++            "write_all",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("shared-loop scanner accepted a dead definition")
++    inactive_mutant = """
++#if 0
++write_all(channel, bytes);
++openat(directory, name, O_APPEND | O_CLOEXEC | O_NOFOLLOW);
++#endif
++"""
++    inactive_code = strip_cpp_comments_and_literals(inactive_mutant)
++    if "write_all" in inactive_code or "openat" in inactive_code:
++        raise AssertionError("source scanner accepted inactive preprocessor code")
++    wrong_posix_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void append_journal() override { openat(directory, name, O_RDONLY); }
++};
++void append_journal(int) {
++    openat(directory, name, O_APPEND | O_CLOEXEC | O_NOFOLLOW);
++}
++"""
++    try:
++        require_each_override_call_arguments(
++            wrong_posix_mutant,
++            "DurableFileAdapter",
++            "append_journal",
++            "openat",
++            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted dead POSIX flags")
++    unsafe_posix_child_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void read_root() override {
++        openat(directory, name, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
++    }
++};
++void dead_safety_check() {
++    fstat(file, &metadata);
++    if (!S_ISREG(metadata.st_mode)) { refuse(); }
++}
++"""
++    for probe in (
++        lambda: require_each_override_call(
++            unsafe_posix_child_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            "fstat",
++            "mutant",
++        ),
++        lambda: require_each_override_pattern(
++            unsafe_posix_child_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            r"\bS_ISREG\s*\(",
++            "mutant",
++        ),
++    ):
++        try:
++            probe()
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted a dead POSIX safety check")
++    ignored_posix_validation_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void read_root() override {
++        openat(directory, name, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
++        fstat(file, &metadata);
++        (void)S_ISREG(metadata.st_mode);
++    }
++};
++"""
++    try:
++        require_each_override_fail_closed_checks(
++            ignored_posix_validation_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            ("fstat", "S_ISREG"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted ignored POSIX validation")
++    inverted_posix_validation_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void read_root() override {
++        if (fstat(file, &metadata) == 0) { return Succeeded; }
++        if (S_ISREG(metadata.st_mode)) { return Succeeded; }
++        return FailedBeforeEffect;
++    }
++};
++"""
++    try:
++        require_each_override_fail_closed_checks(
++            inverted_posix_validation_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            ("fstat", "S_ISREG"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted inverted POSIX validation")
++    transitive_overload_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void append_journal() override { do_append(0); }
++};
++void do_append(int) { openat(directory, name, O_RDONLY); }
++void do_append() {
++    openat(directory, name, O_APPEND | O_CLOEXEC | O_NOFOLLOW);
++}
++"""
++    try:
++        require_each_override_call_arguments(
++            transitive_overload_mutant,
++            "DurableFileAdapter",
++            "append_journal",
++            "openat",
++            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner unioned transitive overloads")
++    retrying_lock_control = """
++class LockCall final : public DurableInterruptibleCall {
++public:
++    explicit LockCall(int lock_fd) : lock_fd_(lock_fd) {}
++    DurableFileResult attempt() override {
++        if (flock(lock_fd_, LOCK_EX) != 0) {
++            if (errno == EINTR) { return Interrupted; }
++            return FailedBeforeEffect;
++        }
++        return Succeeded;
++    }
++private:
++    int lock_fd_;
++};
++DurableFileResult lock_file_retrying_interrupts(int lock_fd) {
++    LockCall call(lock_fd);
++    return retry_interrupted(call);
++}
++"""
++    require_retrying_posix_flock(
++        retrying_lock_control,
++        "lock_file_retrying_interrupts",
++        "LOCK_EX",
++        "control",
++    )
++    unrelated_lock_retry_mutant = """
++class UnrelatedCall final : public DurableInterruptibleCall {
++public:
++    DurableFileResult attempt() override { return FailedBeforeEffect; }
++};
++DurableFileResult lock_file_retrying_interrupts(int lock_fd) {
++    flock(lock_fd, LOCK_EX);
++    UnrelatedCall call;
++    return retry_interrupted(call);
++}
++"""
++    try:
++        require_retrying_posix_flock(
++            unrelated_lock_retry_mutant,
++            "lock_file_retrying_interrupts",
++            "LOCK_EX",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted unrelated flock retry")
++    ignored_posix_lock_mutants = (
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult lock_authority() override {
++        lock_file_retrying_interrupts(lock_fd);
++        return Succeeded;
++    }
++};
++""",
++            "lock_authority",
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult unlock_authority() override {
++        unlock_file_retrying_interrupts(lock_fd);
++        close(lock_fd);
++        return Succeeded;
++    }
++};
++""",
++            "unlock_authority",
++        ),
++    )
++    for mutant, entry in ignored_posix_lock_mutants:
++        try:
++            if entry == "lock_authority":
++                require_each_override_result_call_checked(
++                    mutant,
++                    "DurableFileAdapter",
++                    entry,
++                    "lock_file_retrying_interrupts",
++                    "mutant",
++                )
++            else:
++                require_posix_unlock_result_mapping(mutant, "mutant")
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted ignored POSIX lock result")
++    lock_identity_mutants = (
++        """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult lock_authority() override {
++        lock_file_retrying_interrupts(lock_fd);
++        if (fstat(lock_fd, &opened) != 0) { return FailedBeforeEffect; }
++        if (fstatat(directory, lock_name, &current,
++                    AT_SYMLINK_NOFOLLOW) != 0) { return FailedBeforeEffect; }
++        if (!S_ISREG(current.st_mode)) { return FailedBeforeEffect; }
++        return Succeeded;
++    }
++};
++""",
++        """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult lock_authority() override {
++        lock_file_retrying_interrupts(lock_fd);
++        if (fstat(lock_fd, &opened) != 0) { return FailedBeforeEffect; }
++        if (fstatat(directory, lock_name, &current,
++                    AT_SYMLINK_NOFOLLOW) != 0) { return FailedBeforeEffect; }
++        if (!S_ISREG(current.st_mode)) { return FailedBeforeEffect; }
++        if (current.st_nlink == 0 || current.st_dev != opened.st_dev) {
++            return FailedBeforeEffect;
++        }
++        return Succeeded;
++    }
++};
++""",
++    )
++    for mutant in lock_identity_mutants:
++        try:
++            require_each_override_fail_closed_checks(
++                mutant,
++                "DurableFileAdapter",
++                "lock_authority",
++                ("fstat", "fstatat", "S_ISREG", "st_nlink", "st_dev", "st_ino"),
++                "mutant",
++            )
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted split stable lock")
++    wrong_windows_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void lock_authority() override {
++        OVERLAPPED live;
++        CreateFileW(path, GENERIC_WRITE, FILE_SHARE_DELETE, nullptr,
++                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
++        LockFileEx(handle, 0, 0, 1, 1, &live);
++    }
++};
++void lock_authority(int) {
++    OVERLAPPED unused{};
++    CreateFileW(path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
++                nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
++    LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
++               &unused);
++}
++"""
++    for probe in (
++        lambda: require_each_override_call_arguments(
++            wrong_windows_mutant,
++            "DurableFileAdapter",
++            "lock_authority",
++            "CreateFileW",
++            (
++                "FILE_SHARE_READ",
++                "FILE_SHARE_WRITE",
++                "OPEN_ALWAYS",
++                "FILE_FLAG_OPEN_REPARSE_POINT",
++            ),
++            "mutant",
++        ),
++        lambda: require_each_override_call_arguments(
++            wrong_windows_mutant,
++            "DurableFileAdapter",
++            "lock_authority",
++            "LockFileEx",
++            ("LOCKFILE_EXCLUSIVE_LOCK", "MAXDWORD", "MAXDWORD"),
++            "mutant",
++        ),
++        lambda: require_each_override_pattern(
++            wrong_windows_mutant,
++            "DurableFileAdapter",
++            "lock_authority",
++            r"\bOVERLAPPED\s+\w+\s*(?:\{\s*\}|=\s*\{\s*\})",
++            "mutant",
++        ),
++        lambda: require_windows_lock_overlapped_binding(wrong_windows_mutant),
++    ):
++        try:
++            probe()
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted dead Windows flags")
++    ignored_windows_lock_mutants = (
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult lock_authority() override {
++        OVERLAPPED lock_overlapped{};
++        LockFileEx(lock, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
++                   &lock_overlapped);
++        return Succeeded;
++    }
++};
++""",
++            "lock_authority",
++            ("LockFileEx",),
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult unlock_authority() override {
++        UnlockFileEx(lock, 0, MAXDWORD, MAXDWORD, &lock_overlapped);
++        CloseHandle(lock);
++        return Succeeded;
++    }
++};
++""",
++            "unlock_authority",
++            ("UnlockFileEx", "CloseHandle"),
++        ),
++    )
++    for mutant, entry, predicates in ignored_windows_lock_mutants:
++        try:
++            if entry == "unlock_authority":
++                require_windows_unlock_result_mapping(mutant)
++            else:
++                require_each_override_fail_closed_checks(
++                    mutant,
++                    "DurableFileAdapter",
++                    entry,
++                    predicates,
++                    "mutant",
++                )
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted ignored Windows lock result")
++    missing_windows_identity_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableIdentityResult authority_identity() override {
++        FILE_ID_INFO directory_identity{};
++        GetFileInformationByHandleEx(directory, FileIdInfo,
++                                     &directory_identity,
++                                     sizeof(directory_identity));
++        return make_identity(directory_identity);
++    }
++};
++"""
++    try:
++        require_windows_composite_identity(missing_windows_identity_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted incomplete Windows identity")
++    missing_windows_lock_comparison_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult lock_authority() override {
++        if (!LockFileEx(lock, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
++                        &lock_overlapped)) { return FailedBeforeEffect; }
++        if (!GetFileInformationByHandleEx(lock, FileIdInfo, &opened,
++                                          sizeof(opened))) {
++            return FailedBeforeEffect;
++        }
++        if (!GetFileInformationByHandleEx(current, FileIdInfo, &current_info,
++                                          sizeof(current_info))) {
++            return FailedBeforeEffect;
++        }
++        return Succeeded;
++    }
++};
++"""
++    try:
++        require_each_override_fail_closed_checks(
++            missing_windows_lock_comparison_mutant,
++            "DurableFileAdapter",
++            "lock_authority",
++            ("VolumeSerialNumber", "FileId", "NumberOfLinks"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted stale Windows lock identity")
++    unsafe_windows_child_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void read_root() override {
++        CreateFileW(path, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
++                    FILE_ATTRIBUTE_NORMAL, nullptr);
++    }
++};
++void dead_safety_check() {
++    CreateFileW(path, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
++                FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
++    FILE_ATTRIBUTE_TAG_INFO info{};
++    GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info,
++                                 sizeof(info));
++    if (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) { refuse(); }
++}
++"""
++    for probe in (
++        lambda: require_each_override_call_arguments(
++            unsafe_windows_child_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            "CreateFileW",
++            ("FILE_FLAG_OPEN_REPARSE_POINT",),
++            "mutant",
++        ),
++        lambda: require_each_override_call_arguments(
++            unsafe_windows_child_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            "GetFileInformationByHandleEx",
++            ("FileAttributeTagInfo",),
++            "mutant",
++        ),
++        lambda: require_each_override_pattern(
++            unsafe_windows_child_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            r"\bFILE_ATTRIBUTE_REPARSE_POINT\b",
++            "mutant",
++        ),
++    ):
++        try:
++            probe()
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted a dead Windows safety check")
++    ignored_windows_validation_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void read_root() override {
++        CreateFileW(path, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
++                    FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
++        FILE_ATTRIBUTE_TAG_INFO info{};
++        GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info,
++                                     sizeof(info));
++        (void)(info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT);
++        (void)(info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY);
++    }
++};
++"""
++    try:
++        require_each_override_fail_closed_checks(
++            ignored_windows_validation_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            (
++                "GetFileInformationByHandleEx",
++                "FILE_ATTRIBUTE_REPARSE_POINT",
++                "FILE_ATTRIBUTE_DIRECTORY",
++            ),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted ignored Windows validation")
++    inverted_windows_validation_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void read_root() override {
++        if (GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info,
++                                         sizeof(info))) {
++            return Succeeded;
++        }
++        if (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
++            return Succeeded;
++        }
++        if (info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
++            return Succeeded;
++        }
++        return FailedBeforeEffect;
++    }
++};
++"""
++    try:
++        require_each_override_fail_closed_checks(
++            inverted_windows_validation_mutant,
++            "DurableFileAdapter",
++            "read_root",
++            (
++                "GetFileInformationByHandleEx",
++                "FILE_ATTRIBUTE_REPARSE_POINT",
++                "FILE_ATTRIBUTE_DIRECTORY",
++            ),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted inverted Windows validation")
++    wrong_replace_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void replace_root() override {
++        MoveFileExW(stage, root, MOVEFILE_COPY_ALLOWED);
++    }
++};
++void replace_root(int) {
++    MoveFileExW(stage, root,
++                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
++}
++"""
++    try:
++        require_each_override_call_arguments(
++            wrong_replace_mutant,
++            "DurableFileAdapter",
++            "replace_root",
++            "MoveFileExW",
++            ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted dead replacement flags")
++    in_place_compaction_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void replace_journal() override {
++        ftruncate(journal, exact_size);
++        renameat(directory, harmless, directory, harmless);
++    }
++};
++"""
++    try:
++        require_each_override_omits_calls(
++            in_place_compaction_mutant,
++            "DurableFileAdapter",
++            "replace_journal",
++            ("ftruncate", "truncate_retrying_interrupts"),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted in-place compaction")
++    replacement_tail_repair_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void truncate_journal() override {
++        MoveFileExW(stage, journal,
++                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
++    }
++};
++"""
++    try:
++        require_each_override_omits_calls(
++            replacement_tail_repair_mutant,
++            "DurableFileAdapter",
++            "truncate_journal",
++            ("MoveFileExW",),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted replacement tail repair")
++    ordering_mutants = (
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void append_journal() override {
++        flush_retrying_interrupts(channel);
++        write_all(channel, bytes);
++        close_once(channel);
++    }
++};
++""",
++            "append_journal",
++            ("write_all", "flush_retrying_interrupts", "close_once"),
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void replace_root() override {
++        renameat(directory, stage, directory, root);
++        write_all(channel, bytes);
++        flush_retrying_interrupts(channel);
++        close_once(channel);
++        fsync(directory);
++    }
++};
++""",
++            "replace_root",
++            (
++                "write_all",
++                "flush_retrying_interrupts",
++                "close_once",
++                "renameat",
++                "sync_directory_retrying_interrupts",
++            ),
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void truncate_journal() override {
++        flush_retrying_interrupts(channel);
++        truncate_retrying_interrupts(channel, boundary);
++        close_once(channel);
++    }
++};
++""",
++            "truncate_journal",
++            (
++                "truncate_retrying_interrupts",
++                "flush_retrying_interrupts",
++                "close_once",
++            ),
++        ),
++    )
++    for mutant, entry, calls in ordering_mutants:
++        try:
++            require_each_override_ordered_calls(
++                mutant,
++                "DurableFileAdapter",
++                entry,
++                calls,
++                "mutant",
++            )
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted unsafe durability order")
++    duplicate_mutation_mutants = (
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void replace_root() override {
++        renameat(directory, stage, directory, root);
++        write_all(channel, bytes);
++        flush_retrying_interrupts(channel);
++        close_once(channel);
++        renameat(directory, stage, directory, root);
++        sync_directory_retrying_interrupts(directory);
++    }
++};
++""",
++            "replace_root",
++            "renameat",
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void truncate_journal() override {
++        truncate_retrying_interrupts(channel, boundary);
++        truncate_retrying_interrupts(channel, boundary);
++        flush_retrying_interrupts(channel);
++        close_once(channel);
++    }
++};
++""",
++            "truncate_journal",
++            "truncate_retrying_interrupts",
++        ),
++    )
++    for mutant, entry, call in duplicate_mutation_mutants:
++        try:
++            require_each_override_call_exactly_once(
++                mutant,
++                "DurableFileAdapter",
++                entry,
++                call,
++                "mutant",
++            )
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted duplicate mutation")
++    wrong_macos_mutant = """
++class LiveChannel final : public DurableFileChannel {
++public:
++    void flush() override { fsync(file); }
++};
++void flush(int) { fcntl(file, F_FULLFSYNC); }
++"""
++    try:
++        require_each_override_call_arguments(
++            wrong_macos_mutant,
++            "DurableFileChannel",
++            "flush",
++            "fcntl",
++            ("F_FULLFSYNC",),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted dead macOS persistence")
++    missing_linux_flush_mutant = """
++class LiveChannel final : public DurableFileChannel {
++public:
++    void flush() override { return_success(); }
++};
++void unused_flush() { fsync(file); }
++"""
++    try:
++        require_each_override_call(
++            missing_linux_flush_mutant,
++            "DurableFileChannel",
++            "flush",
++            "fsync",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted a non-durable Linux flush")
++    native_read_controls = (
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(max_bytes, '\0');
++        const auto count = read(file, buffer.data(), max_bytes);
++        if (count < 0) {
++            if (errno == EINTR) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), count), count == 0};
++    }
++};
++""",
++            "posix",
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const auto request = std::min(max_bytes, std::size_t(MAXDWORD));
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0};
++    }
++};
++""",
++            "windows",
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const DWORD request = static_cast<DWORD>(
++            std::min(max_bytes, std::size_t(MAXDWORD)));
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0};
++    }
++};
++""",
++            "windows",
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const DWORD request = static_cast<DWORD>(
++            std::min(std::size_t(MAXDWORD), max_bytes));
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0};
++    }
++};
++""",
++            "windows",
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const std::uint32_t request = static_cast<std::uint32_t>(std::min(
++            max_bytes, std::numeric_limits<std::uint32_t>::max()));
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0};
++    }
++};
++""",
++            "windows",
++        ),
++    )
++    for control, platform in native_read_controls:
++        require_each_override_read_count_mapping(control, platform, "control")
++
++    unsafe_narrowed_read_requests = (
++        "static_cast<DWORD>(max_bytes)",
++        "std::min(static_cast<DWORD>(max_bytes), MAXDWORD)",
++        (
++            "static_cast<DWORD>(std::min("
++            "max_bytes, std::numeric_limits<std::size_t>::max()))"
++        ),
++        "static_cast<DWORD>(std::min(max_bytes, std::size_t(MAXDWORD) + 1))",
++        "static_cast<DWORD>(std::min(max_bytes, 0x100000000ULL))",
++    )
++    for request_expression in unsafe_narrowed_read_requests:
++        narrowed_read_mutant = f"""
++class LiveReadChannel final : public DurableReadChannel {{
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {{
++        const DWORD request = {request_expression};
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {{
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }}
++        return {{Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0}};
++    }}
++}};
++"""
++        try:
++            require_each_override_read_count_mapping(
++                narrowed_read_mutant, "windows", "mutant"
++            )
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted unsafe narrowed read")
++
++    native_result_mutants = (
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        write(file, bytes.data(), bytes.size());
++        return {Succeeded, bytes.size()};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        read(file, buffer, max_bytes);
++        return {Succeeded, std::string(buffer, max_bytes), false};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(max_bytes * 1000, '\0');
++        const auto count =
++            read(file, buffer.data(), std::min(max_bytes, sizeof(buffer)));
++        if (count < 0) {
++            if (errno == EINTR) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), count), count == 0};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(max_bytes * 1000, '\0');
++        const auto count = read(file, buffer.data(), max_bytes * 1000);
++        if (count < 0) {
++            if (errno == EINTR) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), count), count == 0};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(max_bytes, '\0');
++        const auto count = read(file, buffer.data(), max_bytes);
++        if (count < 0) {
++            if (errno == EINTR) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), count), count < max_bytes};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(max_bytes, '\0');
++        const auto count = read(file, buffer.data(), max_bytes);
++        if (count < 0) {
++            if (errno == EINTR) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), count), true};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(1073741824, '\0');
++        const auto count = read(file, buffer.data(), 1073741824);
++        if (count < 0) {
++            if (errno == EINTR) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), count), count == 0};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "posix", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const auto request = std::min(max_bytes, std::size_t(MAXDWORD));
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count), false};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const auto request = max_bytes * 1000;
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        const auto request = std::min(max_bytes, std::size_t(MAXDWORD));
++        std::string buffer(request, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count < request};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult flush() override { fsync(file); return Succeeded; }
++};
++""",
++            lambda source: require_each_override_retryable_result_mapping(
++                source,
++                "DurableFileChannel",
++                "flush",
++                "fsync",
++                "EINTR",
++                "mutant",
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        DWORD read_count = 0;
++        ReadFile(file, buffer, max_bytes, &read_count, nullptr);
++        return {Succeeded, std::string(buffer, max_bytes), false};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveReadChannel final : public DurableReadChannel {
++public:
++    DurableReadChunkResult read_some(std::size_t max_bytes) override {
++        std::string buffer(1073741824, '\0');
++        DWORD read_count = 0;
++        if (!ReadFile(file, buffer.data(), 1073741824,
++                      &read_count, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return FailedBeforeEffect;
++        }
++        return {Succeeded, std::string(buffer.data(), read_count),
++                read_count == 0};
++    }
++};
++""",
++            lambda source: require_each_override_read_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult truncate() override {
++        ftruncate(file, boundary);
++        return Succeeded;
++    }
++};
++""",
++            lambda source: require_each_override_retryable_result_mapping(
++                source,
++                "DurableFileChannel",
++                "truncate",
++                "ftruncate",
++                "EINTR",
++                "mutant",
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult close() override { close(file); return Succeeded; }
++};
++""",
++            lambda source: require_each_override_close_result_mapping(
++                source, "close", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult flush() override {
++        fcntl(file, F_FULLFSYNC);
++        return Succeeded;
++    }
++};
++""",
++            lambda source: require_each_override_retryable_result_mapping(
++                source,
++                "DurableFileChannel",
++                "flush",
++                "fcntl",
++                "EINTR",
++                "mutant",
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        ::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr);
++        return {Succeeded, bytes.size()};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        const auto WriteFile = [](auto &&...) { return FALSE; };
++        DWORD written = 0;
++        if (!WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = ::GetLastError();
++            return {::lemon::residency::detail::DurableFileResult{
++                        ::lemon::residency::detail::DurableFileStatus::
++                            EffectMayHaveOccurred,
++                        ::std::to_string(error)},
++                    0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++#define WriteFile(...) FALSE
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = ::GetLastError();
++            return {::lemon::residency::detail::DurableFileResult{
++                        ::lemon::residency::detail::DurableFileStatus::
++                            EffectMayHaveOccurred,
++                        ::std::to_string(error)},
++                    0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++%:define EffectMayHaveOccurred Interrupted
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = ::GetLastError();
++            return {::lemon::residency::detail::DurableFileResult{
++                        ::lemon::residency::detail::DurableFileStatus::
++                            EffectMayHaveOccurred,
++                        ::std::to_string(error)},
++                    0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++struct RetryStatus {
++    inline static constexpr auto EffectMayHaveOccurred =
++        ::lemon::residency::detail::DurableFileStatus::Interrupted;
++};
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        using DurableFileStatus = RetryStatus;
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = ::GetLastError();
++            return {DurableFileResult{
++                        DurableFileStatus::EffectMayHaveOccurred,
++                        std::to_string(error)},
++                    0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = GetLastError();
++            throw error;
++            return {make_windows_result(
++                        DurableFileStatus::EffectMayHaveOccurred, error),
++                    0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr) &&
++            should_report()) {
++            const auto error = GetLastError();
++            return {make_windows_result(EffectMayHaveOccurred, error), 0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = GetLastError();
++            return error == ERROR_OPERATION_ABORTED
++                       ? DurableWriteResult{Interrupted, 0}
++                       : DurableWriteResult{EffectMayHaveOccurred, 0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            const auto error = GetLastError();
++            return (EffectMayHaveOccurred, interrupted_write_failure(error));
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            if (GetLastError() == ERROR_DISK_FULL) {
++                return {EffectMayHaveOccurred, 0};
++            }
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            switch (GetLastError()) {
++            case ERROR_OPERATION_ABORTED:
++                return Interrupted;
++            default:
++                return {EffectMayHaveOccurred, 0};
++            }
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        const auto retry = Interrupted;
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            return retry;
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            return {EffectMayHaveOccurred, 0};
++        }
++        if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            return {FailedBeforeEffect, 0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableWriteResult write_some(std::string_view bytes) override {
++        DWORD written = 0;
++        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
++            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
++            return {EffectMayHaveOccurred, 0};
++        }
++        return {Succeeded, written};
++    }
++};
++""",
++            lambda source: require_each_override_write_count_mapping(
++                source, "windows", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult flush() override {
++        FlushFileBuffers(file);
++        return Succeeded;
++    }
++};
++""",
++            lambda source: require_each_override_retryable_result_mapping(
++                source,
++                "DurableFileChannel",
++                "flush",
++                "FlushFileBuffers",
++                "ERROR_OPERATION_ABORTED",
++                "mutant",
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult truncate() override {
++        SetFilePointerEx(file, boundary, nullptr, FILE_BEGIN);
++        SetEndOfFile(file);
++        return Succeeded;
++    }
++};
++""",
++            lambda source: require_each_override_retryable_result_mapping(
++                source,
++                "DurableFileChannel",
++                "truncate",
++                "SetEndOfFile",
++                "ERROR_OPERATION_ABORTED",
++                "mutant",
++            ),
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    DurableFileResult close() override { CloseHandle(file); return Succeeded; }
++};
++""",
++            lambda source: require_each_override_close_result_mapping(
++                source, "CloseHandle", "mutant"
++            ),
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult replace_root() override {
++        renameat(directory, stage, directory, root);
++        return Succeeded;
++    }
++};
++""",
++            lambda source: require_each_override_fail_closed_checks(
++                source,
++                "DurableFileAdapter",
++                "replace_root",
++                ("renameat",),
++                "mutant",
++            ),
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult replace_root() override {
++        MoveFileExW(stage, root,
++                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
++        return Succeeded;
++    }
++};
++""",
++            lambda source: require_each_override_fail_closed_checks(
++                source,
++                "DurableFileAdapter",
++                "replace_root",
++                ("MoveFileExW",),
++                "mutant",
++            ),
++        ),
++    )
++    for mutant, probe in native_result_mutants:
++        try:
++            probe(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted ignored native result")
++    transaction_helper_control = """
++DurableFileResult write_flush_close(DurableFileChannel &channel,
++                                    std::string_view bytes) {
++    const auto write_result = write_all(channel, bytes);
++    const auto flush_result = flush_retrying_interrupts(channel);
++    const auto close_result = close_once(channel);
++    if (write_result.effect_may_have_occurred()) {
++        return {DurableFileStatus::EffectMayHaveOccurred, {}};
++    }
++    return combine_results(write_result, flush_result, close_result);
++}
++DurableFileResult truncate_flush_close(DurableFileChannel &channel,
++                                       std::size_t bytes) {
++    const auto truncate_result = truncate_retrying_interrupts(channel, bytes);
++    const auto flush_result = flush_retrying_interrupts(channel);
++    const auto close_result = close_once(channel);
++    if (truncate_result.effect_may_have_occurred()) {
++        return {DurableFileStatus::EffectMayHaveOccurred, {}};
++    }
++    return combine_results(truncate_result, flush_result, close_result);
++}
++"""
++    require_transaction_helper_contract(transaction_helper_control)
++    bounded_read_control = """
++inline constexpr std::size_t durable_read_chunk_bytes = 64 * 1024;
++DurableReadResult read_bounded_close(DurableReadChannel &channel,
++                                     std::size_t max_bytes) {
++    std::string retained;
++    const auto requested = std::min(
++        max_bytes + 1 - retained.size(), durable_read_chunk_bytes);
++    const auto read_result = channel.read_some(requested);
++    const bool interrupted =
++        read_result.result.status == DurableFileStatus::Interrupted;
++    const bool truncated = !read_result.end_of_file;
++    const auto close_result = close_read_once(channel);
++    if (!close_result.succeeded()) {
++        return {close_result, {}, false};
++    }
++    return {read_result.result, read_result.bytes,
++            truncated && !interrupted};
++}
++"""
++    require_bounded_read_helper_contract(bounded_read_control)
++    unbounded_read_mutant = """
++inline constexpr std::size_t durable_read_chunk_bytes = 64 * 1024;
++DurableReadResult read_bounded_close(DurableReadChannel &channel,
++                                     std::size_t max_bytes) {
++    (void)max_bytes;
++    const auto read_result = channel.read_some(SIZE_MAX);
++    const bool interrupted =
++        read_result.result.status == DurableFileStatus::Interrupted;
++    const bool truncated = !read_result.end_of_file;
++    const auto close_result = close_read_once(channel);
++    if (!close_result.succeeded()) {
++        return {close_result, {}, false};
++    }
++    return {read_result.result, read_result.bytes,
++            truncated && !interrupted};
++}
++"""
++    try:
++        require_bounded_read_helper_contract(unbounded_read_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted an unbounded native read")
++    inflated_chunk_mutant = bounded_read_control.replace(
++        "durable_read_chunk_bytes);", "durable_read_chunk_bytes * 2);", 1
++    )
++    try:
++        require_bounded_read_helper_contract(inflated_chunk_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted an inflated read chunk")
++    aggregate_result_control = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult append_journal(std::string_view bytes) override {
++        return write_flush_close(channel, bytes);
++    }
++};
++"""
++    require_each_override_call_result_propagated(
++        aggregate_result_control,
++        "DurableFileAdapter",
++        "append_journal",
++        "write_flush_close",
++        "control",
++    )
++    ignored_transaction_helper_mutant = """
++DurableFileResult write_flush_close(DurableFileChannel &channel,
++                                    std::string_view bytes) {
++    const auto write_result = write_all(channel, bytes);
++    const auto flush_result = flush_retrying_interrupts(channel);
++    const auto close_result = close_once(channel);
++    return succeeded();
++}
++DurableFileResult truncate_flush_close(DurableFileChannel &channel,
++                                       std::size_t bytes) {
++    const auto truncate_result = truncate_retrying_interrupts(channel, bytes);
++    const auto flush_result = flush_retrying_interrupts(channel);
++    const auto close_result = close_once(channel);
++    return succeeded();
++}
++"""
++    try:
++        require_transaction_helper_contract(ignored_transaction_helper_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted ignored transaction results")
++    ignored_aggregate_result_mutants = (
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult append_journal(std::string_view bytes) override {
++        write_flush_close(channel, bytes);
++        return succeeded();
++    }
++};
++""",
++            "append_journal",
++            "write_flush_close",
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult truncate_journal(std::size_t bytes) override {
++        const auto ignored = truncate_flush_close(channel, bytes);
++        return succeeded();
++    }
++};
++""",
++            "truncate_journal",
++            "truncate_flush_close",
++        ),
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableReadResult read_root(std::size_t max_bytes) override {
++        const auto ignored = close_once(channel);
++        return {succeeded(), bytes, false};
++    }
++};
++""",
++            "read_root",
++            "close_once",
++        ),
++    )
++    for mutant, entry, call in ignored_aggregate_result_mutants:
++        try:
++            require_each_override_call_result_propagated(
++                mutant, "DurableFileAdapter", entry, call, "mutant"
++            )
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted ignored aggregate result")
++    missing_namespace_sync_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void replace_journal() override {
++        renameat(directory, stage, directory, journal);
++    }
++};
++void unused_namespace_sync() { fsync(directory); }
++"""
++    try:
++        require_each_override_call(
++            missing_namespace_sync_mutant,
++            "DurableFileAdapter",
++            "replace_journal",
++            "sync_directory_retrying_interrupts",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted an unsynced namespace")
++    retrying_namespace_control = """
++class DirectorySyncCall final : public DurableInterruptibleCall {
++public:
++    explicit DirectorySyncCall(int directory_fd)
++        : directory_fd_(directory_fd) {}
++    DurableFileResult attempt() override {
++        if (fsync(directory_fd_) != 0) {
++            if (errno == EINTR) { return Interrupted; }
++            return FailedBeforeEffect;
++        }
++        return Succeeded;
++    }
++private:
++    int directory_fd_;
++};
++DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
++    DirectorySyncCall call(directory_fd);
++    return retry_interrupted(call);
++}
++"""
++    require_retrying_directory_sync(retrying_namespace_control, "control")
++    invalid_namespace_helpers = (
++        """
++class UnrelatedCall final : public DurableInterruptibleCall {
++public:
++    DurableFileResult attempt() override { return FailedBeforeEffect; }
++};
++DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
++    UnrelatedCall call;
++    retry_interrupted(call);
++    return fsync(directory_fd);
++}
++""",
++        """
++class DirectorySyncCall final : public DurableInterruptibleCall {
++public:
++    explicit DirectorySyncCall(int directory_fd)
++        : directory_fd_(directory_fd) {}
++    DurableFileResult attempt() override {
++        fsync(directory_fd_);
++        return Succeeded;
++    }
++private:
++    int directory_fd_;
++};
++DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
++    DirectorySyncCall call(directory_fd);
++    return retry_interrupted(call);
++}
++""",
++    )
++    for mutant in invalid_namespace_helpers:
++        try:
++            require_retrying_directory_sync(mutant, "mutant")
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted unsafe directory fsync")
++    wrong_directory_sync_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult replace_root() override {
++        renameat(authority_fd, stage, authority_fd, root);
++        sync_directory_retrying_interrupts(unrelated_fd);
++        return Succeeded;
++    }
++};
++"""
++    try:
++        require_each_override_directory_sync_binding(
++            wrong_directory_sync_mutant, "replace_root", "mutant"
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted the wrong namespace fd")
++    ignored_directory_sync_result_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    DurableFileResult replace_root() override {
++        renameat(authority_fd, stage, authority_fd, root);
++        sync_directory_retrying_interrupts(authority_fd);
++        return Succeeded;
++    }
++};
++"""
++    try:
++        require_each_override_result_call_checked(
++            ignored_directory_sync_result_mutant,
++            "DurableFileAdapter",
++            "replace_root",
++            "sync_directory_retrying_interrupts",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted ignored namespace sync")
++    overlapped_lock_mutant = """
++CreateFileW(path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
++            OPEN_ALWAYS, FILE_FLAG_OVERLAPPED, nullptr);
++"""
++    try:
++        require_absent_tokens(
++            overlapped_lock_mutant,
++            ("FILE_FLAG_OVERLAPPED",),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted an overlapped lock handle")
++    lying_preflight_mutant = """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void preflight_capabilities() override { return_success(); }
++    void replace_root() override {
++        write_all(channel, bytes);
++        flush_retrying_interrupts(channel);
++        truncate_retrying_interrupts(channel, 0);
++        close_once(channel);
++        renameat(directory, stage, directory, root);
++        fsync(directory);
++    }
++};
++"""
++    try:
++        require_each_override_call(
++            lying_preflight_mutant,
++            "DurableFileAdapter",
++            "preflight_capabilities",
++            "write_all",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted a declarative preflight")
++    unrelated_channel_mutant = """
++class LiveChannel final : public DurableFileChannel {
++public:
++    void flush() override { fsync(file); }
++};
++class UnusedChannel final : public DurableFileChannel {
++public:
++    void flush() override { fcntl(file, F_FULLFSYNC); }
++};
++"""
++    try:
++        require_each_override_call_arguments(
++            unrelated_channel_mutant,
++            "DurableFileChannel",
++            "flush",
++            "fcntl",
++            ("F_FULLFSYNC",),
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner borrowed an unrelated channel policy")
++    helper_overload_mutant_header = """
++DurableFileResult write_all(DurableFileChannel &channel,
++                            std::string_view bytes);
++"""
++    helper_overload_mutant_source = """
++DurableFileResult write_all(DurableFileChannel &channel,
++                            std::string_view bytes) { return {}; }
++DurableFileResult write_all(DurableFileChannel &channel,
++                            const char *bytes) { return {}; }
++"""
++    try:
++        require_unique_helper_definition(
++            helper_overload_mutant_header,
++            helper_overload_mutant_source,
++            "write_all",
++            "DurableFileResult write_all(DurableFileChannel &channel, "
++            "std::string_view bytes);",
++            "mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("source scanner accepted an overloaded shared helper")
++    duplicate_close_mutants = (
++        (
++            """
++class LiveAdapter final : public DurableFileAdapter {
++public:
++    void append_journal() override {
++        close_once(channel);
++        close_once(channel);
++    }
++};
++""",
++            "DurableFileAdapter",
++            "append_journal",
++            "close_once",
++        ),
++        (
++            """
++class LiveChannel final : public DurableFileChannel {
++public:
++    void close() override {
++        close(fd);
++        close(fd);
++    }
++};
++""",
++            "DurableFileChannel",
++            "close",
++            "close",
++        ),
++    )
++    for mutant, base, entry, call in duplicate_close_mutants:
++        try:
++            require_each_override_call_exactly_once(mutant, base, entry, call, "mutant")
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted a duplicate close")
++
++
++def strip_cpp_comments_and_literals(source: str) -> str:
++    source = normalize_cpp_line_splices(source)
++    source = strip_inactive_cpp_blocks(source)
++    pattern = re.compile(
++        r"//[^\n]*|/\*.*?\*/|R\"(?P<tag>[^ ()\\\t\r\n]{0,16})\(.*?\)(?P=tag)\"|\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'",
++        re.DOTALL,
++    )
++    return pattern.sub(lambda match: "\n" * match.group(0).count("\n"), source)
++
++
++def normalize_cpp_declaration(declaration: str) -> str:
++    normalized = re.sub(r"\s+", " ", declaration.strip())
++    normalized = re.sub(r"\s*([(),;&=])\s*", r"\1", normalized)
++    return normalized
++
++
++def exactly_macro_guarded(source: str, token: str, macro: str) -> bool:
++    pattern = re.compile(
++        rf"(?m)^\s*#\s*ifdef\s+{re.escape(macro)}\s*$"
++        rf"(?:\s*\n)*\s*{re.escape(token)}\s*$"
++        r"(?:\s*\n)*\s*#\s*endif\s*$"
++    )
++    return pattern.search(source) is not None
++
++
++def exactly_macro_guarded_region(
++    source: str,
++    macro: str,
++    tokens: tuple[str, ...],
++) -> bool:
++    pattern = re.compile(
++        rf"(?ms)^\s*#\s*ifdef\s+{re.escape(macro)}\s*$"
++        r"(?P<body>.*?)"
++        r"^\s*#\s*endif\s*$"
++    )
++    matches = []
++    for match in pattern.finditer(source):
++        body = match.group("body")
++        if re.search(r"(?m)^\s*#\s*(?:if|ifdef|ifndef|else|elif|endif)\b", body):
++            continue
++        if all(token in body for token in tokens):
++            matches.append(match)
++    return len(matches) == 1
++
++
++def require_single_public_section(body: str, label: str) -> None:
++    if len(re.findall(r"\bpublic\s*:", body)) != 1:
++        raise AssertionError(f"{label} has multiple public surfaces")
++    if re.search(r"\bprotected\s*:", body):
++        raise AssertionError(f"{label} exposes a protected construction surface")
++
++
++def private_class_surface(body: str, label: str) -> str:
++    if len(re.findall(r"\bprivate\s*:", body)) != 1:
++        raise AssertionError(f"{label} private construction surface drifted")
++    private = re.search(r"\bprivate\s*:(?P<private>.*)\Z", body, re.DOTALL)
++    if private is None:
++        raise AssertionError(f"{label} private construction surface is unavailable")
++    return private.group("private")
++
++
++def require_private_construction_path(body: str, name: str) -> tuple[str, str]:
++    private = private_class_surface(body, name)
++    constructors = tuple(
++        re.finditer(
++            rf"\bexplicit\s+{re.escape(name)}\s*"
++            r"\((?P<parameters>[^;{}]*)\)\s*(?:noexcept\s*)?;",
++            private,
++        )
++    )
++    if len(constructors) != 1 or constructors[0].group("parameters").strip() in {
++        "",
++        "void",
++    }:
++        raise AssertionError(f"{name} private construction path drifted")
++    member = re.search(
++        r"(?m)^\s*(?!#|friend\b|class\b|struct\b|enum\b|using\b|explicit\b)"
++        r"[^;()]+\s+[A-Za-z_]\w*\s*(?:=[^;]+|\{[^;]*\})?;\s*$",
++        private,
++    )
++    if member is None:
++        raise AssertionError(f"{name} has no private construction state")
++    return private, constructors[0].group(0)
++
++
++def require_published_journal_public_shape(source: str) -> None:
++    match = re.search(
++        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
++        source,
++        re.DOTALL,
++    )
++    if match is None:
++        raise AssertionError("PublishedJournal public declaration is unavailable")
++    body = match.group("body")
++    require_single_public_section(body, "PublishedJournal")
++    public_match = re.search(
++        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
++        body,
++        re.DOTALL,
++    )
++    if public_match is None:
++        raise AssertionError("PublishedJournal public surface is unavailable")
++    declarations = tuple(
++        normalize_cpp_declaration(declaration + ";")
++        for declaration in public_match.group("public").split(";")
++        if declaration.strip()
++    )
++    expected = tuple(
++        normalize_cpp_declaration(declaration)
++        for declaration in (
++            "PublishedJournal() = delete;",
++            "PublishedJournal(const PublishedJournal &) = delete;",
++            "PublishedJournal &operator=(const PublishedJournal &) = delete;",
++            "PublishedJournal(PublishedJournal &&) noexcept;",
++            "PublishedJournal &operator=(PublishedJournal &&) noexcept;",
++            "~PublishedJournal();",
++            "bool available() const noexcept;",
++            "std::string_view root_bytes() const noexcept;",
++            "std::string_view journal_id() const noexcept;",
++            "std::uint64_t tip_sequence() const noexcept;",
++        )
++    )
++    if declarations != expected:
++        raise AssertionError("PublishedJournal public construction surface drifted")
++    _, private_constructor = require_private_construction_path(body, "PublishedJournal")
++    insertion = match.start("body") + public_match.end("public")
++    extra_constructor_mutant = (
++        source[:insertion] + " PublishedJournal(int); " + source[insertion:]
++    )
++    mutated = re.search(
++        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
++        extra_constructor_mutant,
++        re.DOTALL,
++    )
++    if mutated is None:
++        raise AssertionError("PublishedJournal mutant was unavailable")
++    mutated_public = re.search(
++        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
++        mutated.group("body"),
++        re.DOTALL,
++    )
++    if mutated_public is None:
++        raise AssertionError("PublishedJournal mutant public surface was unavailable")
++    mutated_declarations = tuple(
++        normalize_cpp_declaration(declaration + ";")
++        for declaration in mutated_public.group("public").split(";")
++        if declaration.strip()
++    )
++    if mutated_declarations == expected:
++        raise AssertionError("PublishedJournal audit accepted an extra constructor")
++    try:
++        require_single_public_section(
++            body + "\npublic:\nPublishedJournal(int);\n",
++            "PublishedJournal mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("PublishedJournal audit accepted a second public section")
++
++    missing_private_constructor = source.replace(private_constructor, "", 1)
++    missing_match = re.search(
++        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
++        missing_private_constructor,
++        re.DOTALL,
++    )
++    try:
++        require_private_construction_path(
++            missing_match.group("body"), "PublishedJournal"
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("PublishedJournal audit accepted no minting path")
++
++
++def require_durable_journal_public_shape(source: str) -> None:
++    match = re.search(
++        r"class\s+DurableJournal\s*\{(?P<body>.*?)\n\};",
++        source,
++        re.DOTALL,
++    )
++    if match is None:
++        raise AssertionError("DurableJournal public declaration is unavailable")
++    require_single_public_section(match.group("body"), "DurableJournal")
++    public_match = re.search(
++        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
++        match.group("body"),
++        re.DOTALL,
++    )
++    if public_match is None:
++        raise AssertionError("DurableJournal public surface is unavailable")
++    declarations = tuple(
++        normalize_cpp_declaration(declaration + ";")
++        for declaration in public_match.group("public").split(";")
++        if declaration.strip()
++    )
++    expected = tuple(
++        normalize_cpp_declaration(declaration)
++        for declaration in (
++            "DurableJournal() = delete;",
++            "DurableJournal(const DurableJournal &) = delete;",
++            "DurableJournal &operator=(const DurableJournal &) = delete;",
++            "DurableJournal(DurableJournal &&) noexcept;",
++            "DurableJournal &operator=(DurableJournal &&) noexcept;",
++            "~DurableJournal();",
++            "static DurableJournal native(std::filesystem::path directory, JournalLimits limits);",
++            "DurableJournalResult create_new(TrustedReplayFloor floor, const ParsedJournalRecord &genesis, const RecoveryOriginVerifier *verifier = nullptr);",
++            "DurableJournalResult recover_existing(TrustedReplayFloor floor, const RecoveryOriginVerifier *verifier = nullptr);",
++            "DurableJournalResult append_and_publish(PublishedJournal &&authority, const ParsedJournalRecord &candidate, const RecoveryOriginVerifier *verifier = nullptr);",
++            "DurableJournalResult compact_physical(PublishedJournal &&authority);",
++            "ExactSchemaExportResult export_exact_schema_candidate(const PublishedJournal &authority, SchemaVersion target, JournalQuiescence quiescence);",
++        )
++    )
++    if declarations != expected:
++        raise AssertionError("DurableJournal public authority surface drifted")
++    private, private_constructor = require_private_construction_path(
++        match.group("body"), "DurableJournal"
++    )
++    if re.findall(r"\bfriend\b[^;]*;", private) != [
++        "friend class detail::DurableJournalTestFactory;"
++    ]:
++        raise AssertionError("DurableJournal has a forgeable friend graph")
++    mint_declarations = tuple(
++        re.finditer(
++            r"\bDurableJournalResult\s+mint_published\s*"
++            r"\((?P<parameters>[^;{}]*)\)\s*;",
++            private,
++        )
++    )
++    if len(mint_declarations) != 1:
++        raise AssertionError("DurableJournal private mint sink drifted")
++    mint_parameters = split_cpp_arguments(mint_declarations[0].group("parameters"))
++    if (
++        len(mint_parameters) != 3
++        or re.search(r"\bJournalHistory\s*&&\s*[A-Za-z_]\w*\b", mint_parameters[0])
++        is None
++        or re.search(
++            r"\bAuthorityRootCandidate\s*(?:&&\s*)?[A-Za-z_]\w*\b",
++            mint_parameters[1],
++        )
++        is None
++        or re.search(r"\b(?:persistence|state)[A-Za-z_]*\b", mint_parameters[2]) is None
++    ):
++        raise AssertionError("DurableJournal private mint sink shape drifted")
++    minting_mutant = source.replace(
++        "~DurableJournal();",
++        "~DurableJournal(); static PublishedJournal from_record(const ParsedJournalRecord &);",
++        1,
++    )
++    if minting_mutant == source:
++        raise AssertionError("DurableJournal minting mutant was unavailable")
++    mutated_match = re.search(
++        r"class\s+DurableJournal\s*\{(?P<body>.*?)\n\};",
++        minting_mutant,
++        re.DOTALL,
++    )
++    mutated_public = re.search(
++        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
++        mutated_match.group("body"),
++        re.DOTALL,
++    )
++    mutated_declarations = tuple(
++        normalize_cpp_declaration(declaration + ";")
++        for declaration in mutated_public.group("public").split(";")
++        if declaration.strip()
++    )
++    if mutated_declarations == expected:
++        raise AssertionError("DurableJournal audit accepted a minting factory")
++    try:
++        require_single_public_section(
++            match.group("body")
++            + "\npublic:\nDurableJournalResult mint(const ParsedJournalRecord &);\n",
++            "DurableJournal mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("DurableJournal audit accepted a second public section")
++
++    missing_private_constructor = source.replace(private_constructor, "", 1)
++    missing_match = re.search(
++        r"class\s+DurableJournal\s*\{(?P<body>.*?)\n\};",
++        missing_private_constructor,
++        re.DOTALL,
++    )
++    try:
++        require_private_construction_path(missing_match.group("body"), "DurableJournal")
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("DurableJournal audit accepted no construction path")
++
++
++def require_trusted_replay_floor_public_shape(source: str) -> None:
++    match = re.search(
++        r"class\s+TrustedReplayFloor\s*\{(?P<body>.*?)\n\};",
++        source,
++        re.DOTALL,
++    )
++    if match is None:
++        raise AssertionError("TrustedReplayFloor public declaration is unavailable")
++    require_single_public_section(match.group("body"), "TrustedReplayFloor")
++    public_match = re.search(
++        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
++        match.group("body"),
++        re.DOTALL,
++    )
++    if public_match is None:
++        raise AssertionError("TrustedReplayFloor public surface is unavailable")
++    declarations = tuple(
++        normalize_cpp_declaration(declaration + ";")
++        for declaration in public_match.group("public").split(";")
++        if declaration.strip()
++    )
++    expected = tuple(
++        normalize_cpp_declaration(declaration)
++        for declaration in (
++            "TrustedReplayFloor() = delete;",
++            "static TrustedReplayFloor uninitialized();",
++            "static TrustedReplayFloor exact_root(std::string root);",
++        )
++    )
++    if declarations != expected:
++        raise AssertionError("TrustedReplayFloor public construction surface drifted")
++    private, private_constructor = require_private_construction_path(
++        match.group("body"), "TrustedReplayFloor"
++    )
++    friend_declarations = re.findall(r"\bfriend\b[^;]*;", private)
++    if friend_declarations != ["friend class DurableJournal;"]:
++        raise AssertionError("TrustedReplayFloor has a forgeable friend graph")
++    try:
++        require_single_public_section(
++            match.group("body") + "\npublic:\nTrustedReplayFloor(int);\n",
++            "TrustedReplayFloor mutant",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError(
++            "TrustedReplayFloor audit accepted a second public section"
++        )
++
++    missing_private_constructor = source.replace(private_constructor, "", 1)
++    missing_match = re.search(
++        r"class\s+TrustedReplayFloor\s*\{(?P<body>.*?)\n\};",
++        missing_private_constructor,
++        re.DOTALL,
++    )
++    try:
++        require_private_construction_path(
++            missing_match.group("body"), "TrustedReplayFloor"
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("TrustedReplayFloor audit accepted no state constructor")
++
++
++def require_exact_struct_shape(
++    source: str,
++    name: str,
++    expected: tuple[str, ...],
++) -> None:
++    match = re.search(
++        rf"struct\s+{re.escape(name)}\s*\{{(?P<body>.*?)\}}\s*;",
++        source,
++        re.DOTALL,
++    )
++    if match is None:
++        raise AssertionError(f"{name} public declaration is unavailable")
++    declarations = tuple(
++        normalize_cpp_declaration(declaration + ";")
++        for declaration in match.group("body").split(";")
++        if declaration.strip()
++    )
++    normalized_expected = tuple(
++        normalize_cpp_declaration(declaration) for declaration in expected
++    )
++    if declarations != normalized_expected:
++        raise AssertionError(f"{name} public result shape drifted")
++
++
++def require_exact_enum_members(
++    source: str,
++    name: str,
++    expected: tuple[str, ...],
++) -> None:
++    match = re.search(
++        rf"enum\s+class\s+{re.escape(name)}(?:\s*:\s*[^{{]+)?\s*\{{(?P<body>.*?)\}}\s*;",
++        source,
++        re.DOTALL,
++    )
++    if match is None:
++        raise AssertionError(f"{name} public enum is unavailable")
++    members = tuple(
++        re.match(r"\s*([A-Za-z_]\w*)", member).group(1)
++        for member in match.group("body").split(",")
++        if member.strip()
++    )
++    if members != expected:
++        raise AssertionError(f"{name} public outcomes drifted")
++
++
++def strip_cpp_comments_preserve_literals(source: str) -> str:
++    source = normalize_cpp_line_splices(source)
++    source = strip_inactive_cpp_blocks(source)
++    pattern = re.compile(r"//[^\n]*|/\*.*?\*/", re.DOTALL)
++    return pattern.sub(lambda match: "\n" * match.group(0).count("\n"), source)
++
++
++def normalize_cpp_line_splices(source: str) -> str:
++    return re.sub(r"\\\r?\n", "", source)
++
++
++def strip_inactive_cpp_blocks(source: str) -> str:
++    pattern = re.compile(r"(?ms)^\s*#\s*if\s+(?:0|false)\b.*?^\s*#\s*endif\b[^\n]*")
++    previous = None
++    while source != previous:
++        previous = source
++        source = pattern.sub(lambda match: "\n" * match.group(0).count("\n"), source)
++    return source
++
++
++def require_call_argument(source: str, call: str, argument: str, label: str) -> None:
++    pattern = re.compile(
++        rf"\b{re.escape(call)}\s*\([^;]*\b{re.escape(argument)}\b[^;]*\)"
++    )
++    if pattern.search(source) is None:
++        raise AssertionError(f"{label} omitted {call}(...{argument}...)")
++
++
++def require_call_arguments(
++    source: str,
++    call: str,
++    arguments: tuple[str, ...],
++    label: str,
++) -> None:
++    for match in re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", source):
++        call_arguments = match.group("args")
++        search_from = 0
++        for argument in arguments:
++            found_at = call_arguments.find(argument, search_from)
++            if found_at < 0:
++                break
++            search_from = found_at + len(argument)
++        else:
++            return
++    raise AssertionError(f"{label} omitted ordered arguments {arguments}")
++
++
++def require_call_arguments_unordered(
++    source: str,
++    call: str,
++    arguments: tuple[str, ...],
++    label: str,
++) -> None:
++    for match in re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", source):
++        call_arguments = match.group("args")
++        if all(argument in call_arguments for argument in arguments):
++            return
++    raise AssertionError(f"{label} omitted call arguments {arguments}")
++
++
++def require_call_expression(source: str, call: str, label: str) -> None:
++    pattern = re.compile(rf"\b{re.escape(call)}\s*\([^;{{}}]*\)\s*;")
++    if pattern.search(source) is None:
++        raise AssertionError(f"{label} does not call the shared {call} seam")
++
++
++def function_bodies(source: str, function: str) -> list[str]:
++    declaration = re.compile(
++        rf"\b{re.escape(function)}\s*\([^;{{}}]*\)\s*"
++        r"(?:const\s*)?(?:noexcept\s*)?(?:override\s*)?\{"
++    )
++    bodies: list[str] = []
++    for match in declaration.finditer(source):
++        opening = match.end() - 1
++        depth = 1
++        index = opening + 1
++        while index < len(source) and depth:
++            if source[index] == "{":
++                depth += 1
++            elif source[index] == "}":
++                depth -= 1
++            index += 1
++        if depth == 0:
++            bodies.append(source[opening + 1 : index - 1])
++    return bodies
++
++
++def class_blocks(source: str, base: str) -> list[tuple[str, str]]:
++    declaration = re.compile(
++        rf"\bclass\s+(?P<name>[A-Za-z_]\w*)\s*(?:final\s*)?:\s*"
++        rf"public\s+(?:detail\s*::\s*)?{re.escape(base)}\s*\{{"
++    )
++    blocks: list[tuple[str, str]] = []
++    for match in declaration.finditer(source):
++        opening = match.end() - 1
++        depth = 1
++        index = opening + 1
++        while index < len(source) and depth:
++            if source[index] == "{":
++                depth += 1
++            elif source[index] == "}":
++                depth -= 1
++            index += 1
++        if depth == 0:
++            blocks.append((match.group("name"), source[opening + 1 : index - 1]))
++    return blocks
++
++
++def qualified_function_bodies(
++    source: str,
++    class_name: str,
++    function: str,
++) -> list[str]:
++    declaration = re.compile(
++        rf"\b{re.escape(class_name)}\s*::\s*{re.escape(function)}\s*"
++        r"\([^;{}]*\)\s*(?:const\s*)?(?:noexcept\s*)?\{"
++    )
++    bodies: list[str] = []
++    for match in declaration.finditer(source):
++        opening = match.end() - 1
++        depth = 1
++        index = opening + 1
++        while index < len(source) and depth:
++            if source[index] == "{":
++                depth += 1
++            elif source[index] == "}":
++                depth -= 1
++            index += 1
++        if depth == 0:
++            bodies.append(source[opening + 1 : index - 1])
++    return bodies
++
++
++def overriding_method_bodies(source: str, base: str, function: str) -> list[str]:
++    bodies: list[str] = []
++    for class_name, class_body in class_blocks(source, base):
++        declaration = re.compile(
++            rf"\b{re.escape(function)}\s*\([^;{{}}]*\)\s*"
++            r"[^;{}]*\boverride\b[^;{}]*(?P<end>[;{])"
++        )
++        for match in declaration.finditer(class_body):
++            if match.group("end") == "{":
++                opening = match.end() - 1
++                depth = 1
++                index = opening + 1
++                while index < len(class_body) and depth:
++                    if class_body[index] == "{":
++                        depth += 1
++                    elif class_body[index] == "}":
++                        depth -= 1
++                    index += 1
++                if depth == 0:
++                    bodies.append(class_body[opening + 1 : index - 1])
++            else:
++                bodies.extend(qualified_function_bodies(source, class_name, function))
++    return bodies
++
++
++def require_unique_helper_definition(
++    header: str,
++    source: str,
++    function: str,
++    declaration: str,
++    label: str,
++    return_type: str = "DurableFileResult",
++) -> None:
++    header_matches = re.findall(
++        rf"[^;{{}}]*\b{re.escape(function)}\s*\([^;{{}}]*\)\s*;",
++        header,
++    )
++    expected = normalize_cpp_declaration(declaration)
++    if (
++        len(header_matches) != 1
++        or normalize_cpp_declaration(header_matches[0]) != expected
++    ):
++        raise AssertionError(f"{label} helper declaration drifted")
++    bodies = function_bodies(source, function)
++    if len(bodies) != 1:
++        raise AssertionError(f"{label} helper is overloaded or multiply defined")
++    definition = re.compile(
++        rf"\b{re.escape(return_type)}\s+{re.escape(function)}\s*"
++        r"\([^;{}]*\)\s*(?:noexcept\s*)?\{"
++    )
++    if len(definition.findall(source)) != 1:
++        raise AssertionError(f"{label} helper definition signature drifted")
++
++
++def require_transaction_helper_contract(source: str) -> None:
++    for helper, operation in (
++        ("write_flush_close", "write_all"),
++        ("truncate_flush_close", "truncate_retrying_interrupts"),
++    ):
++        bodies = function_bodies(source, helper)
++        if len(bodies) != 1:
++            raise AssertionError(f"durable adapter {helper} definition drifted")
++        body = bodies[0]
++        ordered_calls = (operation, "flush_retrying_interrupts", "close_once")
++        positions: list[int] = []
++        results: list[str] = []
++        for call in ordered_calls:
++            matches = list(
++                re.finditer(
++                    rf"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
++                    rf"(?P<result>[A-Za-z_]\w*)\s*=\s*"
++                    rf"{re.escape(call)}\s*\(",
++                    body,
++                )
++            )
++            if len(matches) != 1:
++                raise AssertionError(
++                    f"durable adapter {helper} does not capture {call} once"
++                )
++            positions.append(matches[0].start())
++            results.append(matches[0].group("result"))
++        if positions != sorted(positions):
++            raise AssertionError(f"durable adapter {helper} operation order drifted")
++        if re.search(r"\breturn\b", body[: positions[-1]]) is not None:
++            raise AssertionError(
++                f"durable adapter {helper} can bypass its checked close"
++            )
++        returned = re.findall(r"\breturn\b(?P<value>[^;]*);", body[positions[-1] :])
++        if not any(all(result in value for result in results) for value in returned):
++            raise AssertionError(
++                f"durable adapter {helper} does not combine every result"
++            )
++        if not any(
++            token in body
++            for token in ("effect_may_have_occurred", "EffectMayHaveOccurred")
++        ):
++            raise AssertionError(
++                f"durable adapter {helper} does not preserve indeterminate effects"
++            )
++
++
++def require_bounded_read_helper_contract(source: str) -> None:
++    if (
++        re.search(
++            r"\binline\s+constexpr\s+std::size_t\s+"
++            r"durable_read_chunk_bytes\s*=\s*64\s*\*\s*1024\s*;",
++            source,
++        )
++        is None
++    ):
++        raise AssertionError("durable bounded-read chunk cap drifted")
++    bodies = function_bodies(source, "read_bounded_close")
++    if len(bodies) != 1:
++        raise AssertionError("durable bounded-read helper definition drifted")
++    body = bodies[0]
++    read = re.search(
++        r"\b(?:const\s+)?(?:auto|DurableReadChunkResult)\s+"
++        r"(?P<result>[A-Za-z_]\w*)\s*=\s*"
++        r"(?:[A-Za-z_]\w*\s*\.\s*)?read_some\s*\(",
++        body,
++    )
++    close = re.search(
++        r"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
++        r"(?P<result>[A-Za-z_]\w*)\s*=\s*close_read_once\s*\(",
++        body,
++    )
++    if read is None or close is None or read.start() >= close.start():
++        raise AssertionError("durable bounded-read helper omits read then close")
++    if (
++        len(re.findall(r"\bread_some\s*\(", body)) != 1
++        or len(re.findall(r"\bclose_read_once\s*\(", body)) != 1
++    ):
++        raise AssertionError("durable bounded-read helper call count drifted")
++    read_arguments = call_argument_lists(body, "read_some")
++    if len(read_arguments) != 1 or len(read_arguments[0]) != 1:
++        raise AssertionError("durable bounded-read request shape drifted")
++    requested = read_arguments[0][0].strip()
++    if (
++        "max_bytes" not in requested
++        and re.search(
++            rf"\b(?:const\s+)?(?:auto|std::size_t)\s+{re.escape(requested)}\s*="
++            r"[^;]*\bmax_bytes\b",
++            body[: read.start()],
++        )
++        is None
++    ):
++        raise AssertionError("durable bounded read is not capped by max_bytes")
++    requested_assignment = re.search(
++        rf"\b(?:const\s+)?(?:auto|std::size_t)\s+{re.escape(requested)}\s*="
++        r"\s*(?P<value>[^;]+);",
++        body[: read.start()],
++        re.DOTALL,
++    )
++    if requested_assignment is None:
++        raise AssertionError("durable bounded-read request is not assigned")
++    minimums = call_argument_lists(requested_assignment.group("value"), "min")
++    if (
++        len(minimums) != 1
++        or len(minimums[0]) != 2
++        or normalized_cpp_expression(minimums[0][1]) != "durable_read_chunk_bytes"
++        or "max_bytes" not in minimums[0][0]
++        or "retained.size()" not in normalized_cpp_expression(minimums[0][0])
++    ):
++        raise AssertionError("durable bounded read omits its fixed chunk cap")
++    if re.search(r"\breturn\b", body[: close.start()]) is not None:
++        raise AssertionError("durable bounded-read helper can bypass close")
++    if not all(
++        token in body
++        for token in ("max_bytes", "end_of_file", "Interrupted", "truncated")
++    ):
++        raise AssertionError("durable bounded-read helper omits bounded EOF flow")
++    close_result = close.group("result")
++    if (
++        not any(
++            close_result in condition
++            and re.search(rf"\breturn\b[^;]*\b{re.escape(close_result)}\b", statement)
++            for condition, statement in fail_closed_if_branches(body[close.start() :])
++        )
++        and re.search(
++            rf"\breturn\b[^;]*\b{re.escape(close_result)}\b[^;]*;",
++            body[close.start() :],
++        )
++        is None
++    ):
++        raise AssertionError("durable bounded-read helper ignores close result")
++
++
++def require_close_read_once_contract(source: str) -> None:
++    bodies = function_bodies(source, "close_read_once")
++    if len(bodies) != 1:
++        raise AssertionError("durable read-close helper definition drifted")
++    body = bodies[0]
++    if (
++        len(re.findall(r"\bclose\s*\(", body)) != 1
++        or re.fullmatch(r"\s*return\s+\w+\s*\.\s*close\s*\(\s*\)\s*;\s*", body) is None
++        or "retry_interrupted" in body
++    ):
++        raise AssertionError("durable read-close helper does not close once")
++
++
++def require_unique_function_call_arguments(
++    source: str,
++    function: str,
++    call: str,
++    arguments: tuple[str, ...],
++    label: str,
++) -> None:
++    bodies = function_bodies(source, function)
++    if len(bodies) != 1:
++        raise AssertionError(f"{label} {function} is overloaded or multiply defined")
++    matches = re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", bodies[0])
++    if not any(
++        all(argument in match.group("args") for argument in arguments)
++        for match in matches
++    ):
++        raise AssertionError(f"{label} {function} omits {call}{arguments}")
++
++
++def require_each_override_call(
++    source: str,
++    base: str,
++    entry: str,
++    required_call: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies or any(
++        re.search(rf"\b{re.escape(required_call)}\s*\(", body) is None
++        for body in bodies
++    ):
++        raise AssertionError(
++            f"{label} {base}::{entry} does not directly call {required_call}"
++        )
++
++
++def require_each_override_call_exactly_once(
++    source: str,
++    base: str,
++    entry: str,
++    required_call: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        count = len(re.findall(rf"\b{re.escape(required_call)}\s*\(", body))
++        if count != 1:
++            raise AssertionError(
++                f"{label} {base}::{entry} calls {required_call} {count} times"
++            )
++
++
++def require_each_override_call_result_propagated(
++    source: str,
++    base: str,
++    entry: str,
++    call: str,
++    label: str,
++    minimum_calls: int = 1,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        calls = list(re.finditer(rf"\b{re.escape(call)}\s*\(", body))
++        if len(calls) < minimum_calls:
++            raise AssertionError(f"{label} {base}::{entry} omits {call}")
++        direct_returns = {
++            match.start("call")
++            for match in re.finditer(
++                rf"\breturn\s+(?P<call>{re.escape(call)})\s*\(", body
++            )
++        }
++        assignments = list(
++            re.finditer(
++                rf"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
++                rf"(?P<result>[A-Za-z_]\w*)\s*=\s*"
++                rf"(?P<call>{re.escape(call)})\s*\(",
++                body,
++            )
++        )
++        assigned_calls = {match.start("call") for match in assignments}
++        if any(
++            call_match.start() not in direct_returns | assigned_calls
++            for call_match in calls
++        ):
++            raise AssertionError(f"{label} {base}::{entry} discards {call}'s result")
++        for assignment in assignments:
++            result = assignment.group("result")
++            suffix = body[assignment.end() :]
++            if re.search(rf"\breturn\s+{re.escape(result)}\s*;", suffix):
++                continue
++            if not any(
++                result in condition
++                and re.search(rf"\breturn\s+{re.escape(result)}\s*;", statement)
++                for condition, statement in fail_closed_if_branches(suffix)
++            ):
++                raise AssertionError(
++                    f"{label} {base}::{entry} does not propagate {call}'s result"
++                )
++
++
++def require_each_override_omits_calls(
++    source: str,
++    base: str,
++    entry: str,
++    forbidden_calls: tuple[str, ...],
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        present = [
++            call
++            for call in forbidden_calls
++            if re.search(rf"\b{re.escape(call)}\s*\(", body)
++        ]
++        if present:
++            raise AssertionError(f"{label} {base}::{entry} uses {present}")
++
++
++def require_each_override_ordered_calls(
++    source: str,
++    base: str,
++    entry: str,
++    calls: tuple[str, ...],
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        search_from = 0
++        for call in calls:
++            match = re.search(rf"\b{re.escape(call)}\s*\(", body[search_from:])
++            if match is None:
++                raise AssertionError(f"{label} {base}::{entry} omits ordered {calls}")
++            search_from += match.end()
++
++
++def require_each_override_call_arguments(
++    source: str,
++    base: str,
++    entry: str,
++    call: str,
++    arguments: tuple[str, ...],
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        matches = re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", body)
++        if not any(
++            all(argument in match.group("args") for argument in arguments)
++            for match in matches
++        ):
++            raise AssertionError(f"{label} {base}::{entry} omits {call}{arguments}")
++
++
++def require_each_override_pattern(
++    source: str,
++    base: str,
++    entry: str,
++    pattern: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies or any(re.search(pattern, body) is None for body in bodies):
++        raise AssertionError(f"{label} {base}::{entry} omits required shape")
++
++
++def matching_delimiter(
++    source: str,
++    opening: int,
++    open_character: str,
++    close_character: str,
++) -> int:
++    depth = 1
++    index = opening + 1
++    while index < len(source) and depth:
++        if source[index] == open_character:
++            depth += 1
++        elif source[index] == close_character:
++            depth -= 1
++        index += 1
++    if depth:
++        raise AssertionError("C++ source has an unbalanced delimiter")
++    return index - 1
++
++
++def fail_closed_if_branches(body: str) -> tuple[tuple[str, str], ...]:
++    branches: list[tuple[str, str]] = []
++    for match in re.finditer(r"\bif\s*\(", body):
++        opening = body.find("(", match.start())
++        closing = matching_delimiter(body, opening, "(", ")")
++        statement_start = closing + 1
++        while statement_start < len(body) and body[statement_start].isspace():
++            statement_start += 1
++        if statement_start == len(body):
++            continue
++        if body[statement_start] == "{":
++            statement_end = matching_delimiter(body, statement_start, "{", "}")
++            statement = body[statement_start + 1 : statement_end]
++        else:
++            statement_end = body.find(";", statement_start)
++            if statement_end < 0:
++                continue
++            statement = body[statement_start : statement_end + 1]
++        if re.search(r"\breturn\b", statement):
++            branches.append((body[opening + 1 : closing], statement))
++    return tuple(branches)
++
++
++def branch_returns_non_success(statement: str) -> bool:
++    returns = re.findall(r"\breturn\b(?P<value>[^;]*);", statement)
++    return bool(returns) and all(
++        "succeeded" not in returned.lower() and "success" not in returned.lower()
++        for returned in returns
++    )
++
++
++def condition_rejects_predicate(condition: str, predicate: str) -> bool:
++    compact = re.sub(r"\s+", "", condition)
++    if predicate not in condition:
++        return False
++    if predicate in (
++        "fstat",
++        "fstatat",
++        "fsync",
++        "fcntl",
++        "ftruncate",
++        "close",
++        "renameat",
++        "flock",
++    ):
++        if re.search(rf"{predicate}\([^;]*\)==(?:0|true)", compact):
++            return False
++        return bool(
++            re.search(
++                rf"(?:!(?:::)?{predicate}\(|{predicate}\([^;]*\)(?:!=0|<0|==-1))",
++                compact,
++            )
++            or re.fullmatch(rf"(?:::)?{predicate}\([^;]*\)", compact)
++        )
++    if predicate == "S_ISREG":
++        return bool(
++            re.search(r"!S_ISREG\(", compact)
++            or re.search(r"S_ISREG\([^;]*\)==(?:0|false)", compact)
++        )
++    if predicate in (
++        "GetFileInformationByHandleEx",
++        "WriteFile",
++        "ReadFile",
++        "LockFileEx",
++        "UnlockFileEx",
++        "FlushFileBuffers",
++        "SetFilePointerEx",
++        "SetEndOfFile",
++        "CloseHandle",
++        "MoveFileExW",
++    ):
++        return bool(
++            re.search(rf"!(?:::)?{predicate}\(", compact)
++            or re.search(rf"{predicate}\([^;]*\)==(?:0|FALSE|false)", compact)
++        )
++    if predicate in ("FILE_ATTRIBUTE_REPARSE_POINT", "FILE_ATTRIBUTE_DIRECTORY"):
++        return not bool(
++            re.search(rf"{predicate}[^;]*(?:==0|==false|==FALSE)", compact)
++            or re.search(rf"!\([^;]*{predicate}", compact)
++        )
++    if predicate == "st_nlink":
++        return bool(re.search(r"st_nlink(?:==0|!=1|<1)", compact))
++    if predicate in ("st_dev", "st_ino"):
++        return "!=" in compact
++    if predicate in ("VolumeSerialNumber", "FileId"):
++        return "!=" in compact or "memcmp(" in compact
++    if predicate == "NumberOfLinks":
++        return bool(re.search(r"NumberOfLinks(?:==0|<1)", compact))
++    return False
++
++
++def require_each_override_fail_closed_checks(
++    source: str,
++    base: str,
++    entry: str,
++    predicates: tuple[str, ...],
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        branches = fail_closed_if_branches(body)
++        missing = [
++            predicate
++            for predicate in predicates
++            if not any(
++                condition_rejects_predicate(condition, predicate)
++                and branch_returns_non_success(statement)
++                for condition, statement in branches
++            )
++        ]
++        if missing:
++            raise AssertionError(
++                f"{label} {base}::{entry} does not fail closed on {missing}"
++            )
++
++
++def require_retrying_directory_sync(source: str, label: str) -> None:
++    helper = "sync_directory_retrying_interrupts"
++    signature = re.compile(
++        rf"\bDurableFileResult\s+{helper}\s*\(\s*int\s+directory_fd\s*\)\s*\{{"
++    )
++    helper_bodies = function_bodies(source, helper)
++    if len(signature.findall(source)) != 1 or len(helper_bodies) != 1:
++        raise AssertionError(f"{label} directory-sync helper shape drifted")
++    helper_body = helper_bodies[0]
++    if len(re.findall(r"\bretry_interrupted\s*\(", helper_body)) != 1:
++        raise AssertionError(f"{label} directory sync does not retry exactly once")
++
++    bindings = 0
++    for class_name, class_body in class_blocks(source, "DurableInterruptibleCall"):
++        attempts = function_bodies(class_body, "attempt")
++        if len(attempts) != 1:
++            continue
++        attempt = attempts[0]
++        if (
++            len(re.findall(r"\bfsync\s*\(\s*directory_fd_\s*\)", attempt)) != 1
++            or not any(
++                condition_rejects_predicate(condition, "fsync")
++                and branch_returns_non_success(statement)
++                for condition, statement in fail_closed_if_branches(attempt)
++            )
++            or not any(
++                "errno" in condition
++                and "EINTR" in condition
++                and "Interrupted" in statement
++                for condition, statement in fail_closed_if_branches(attempt)
++            )
++            or "Succeeded" not in attempt
++            or not any(
++                status in attempt
++                for status in (
++                    "FailedBeforeEffect",
++                    "EffectMayHaveOccurred",
++                    "Unsupported",
++                )
++            )
++        ):
++            continue
++        constructor = re.compile(
++            rf"\bexplicit\s+{re.escape(class_name)}\s*"
++            r"\(\s*int\s+directory_fd\s*\)\s*:\s*"
++            r"directory_fd_\s*\(\s*directory_fd\s*\)"
++        )
++        if constructor.search(class_body) is None:
++            continue
++        for instance in re.finditer(
++            rf"\b{re.escape(class_name)}\s+(?P<name>[A-Za-z_]\w*)\s*"
++            r"[({]\s*directory_fd\s*[)}]",
++            helper_body,
++        ):
++            variable = instance.group("name")
++            if re.search(
++                rf"\bretry_interrupted\s*\(\s*{re.escape(variable)}\s*\)",
++                helper_body,
++            ):
++                bindings += 1
++    if bindings != 1:
++        raise AssertionError(f"{label} directory fsync is not bound to its retry")
++
++
++def require_retrying_posix_flock(
++    source: str,
++    helper: str,
++    flag: str,
++    label: str,
++) -> None:
++    signature = re.compile(
++        rf"\bDurableFileResult\s+{re.escape(helper)}\s*"
++        r"\(\s*int\s+(?P<parameter>[A-Za-z_]\w*)\s*\)\s*\{"
++    )
++    signatures = tuple(signature.finditer(source))
++    helper_bodies = function_bodies(source, helper)
++    if len(signatures) != 1 or len(helper_bodies) != 1:
++        raise AssertionError(f"{label} flock helper shape drifted")
++    parameter = signatures[0].group("parameter")
++    member = f"{parameter}_"
++    helper_body = helper_bodies[0]
++    if len(re.findall(r"\bretry_interrupted\s*\(", helper_body)) != 1:
++        raise AssertionError(f"{label} flock does not retry exactly once")
++    bindings = 0
++    for class_name, class_body in class_blocks(source, "DurableInterruptibleCall"):
++        attempts = function_bodies(class_body, "attempt")
++        if len(attempts) != 1:
++            continue
++        attempt = attempts[0]
++        flock_pattern = (
++            rf"\bflock\s*\(\s*{re.escape(member)}\s*,\s*" rf"{re.escape(flag)}\s*\)"
++        )
++        attempt_branches = fail_closed_if_branches(attempt)
++        expected_failures = {
++            f"flock({member},{flag})!=0",
++            f"::flock({member},{flag})!=0",
++        }
++        failure_branches = tuple(
++            statement
++            for condition, statement in attempt_branches
++            if compact_cpp(condition) in expected_failures
++        )
++        returns = re.findall(r"\breturn\b(?P<value>[^;]*);", attempt)
++        final_return = normalized_cpp_expression(returns[-1]) if returns else ""
++        if (
++            len(re.findall(flock_pattern, attempt)) != 1
++            or len(failure_branches) != 1
++            or not branch_returns_non_success(failure_branches[0])
++            or not any(
++                compact_cpp(condition) == "errno==EINTR" and "Interrupted" in statement
++                for condition, statement in attempt_branches
++            )
++            or len(returns) < 3
++            or final_return
++            not in {"Succeeded", "make_result(DurableFileStatus::Succeeded)"}
++        ):
++            continue
++        constructor = re.compile(
++            rf"\bexplicit\s+{re.escape(class_name)}\s*"
++            rf"\(\s*int\s+{re.escape(parameter)}\s*\)\s*:\s*"
++            rf"{re.escape(member)}\s*\(\s*{re.escape(parameter)}\s*\)"
++        )
++        if constructor.search(class_body) is None:
++            continue
++        for instance in re.finditer(
++            rf"\b{re.escape(class_name)}\s+(?P<name>[A-Za-z_]\w*)\s*"
++            rf"[({{]\s*{re.escape(parameter)}\s*[)}})]",
++            helper_body,
++        ):
++            variable = instance.group("name")
++            if re.search(
++                rf"\bretry_interrupted\s*\(\s*{re.escape(variable)}\s*\)",
++                helper_body,
++            ):
++                bindings += 1
++    if bindings != 1:
++        raise AssertionError(f"{label} flock is not bound to its retry")
++
++
++def require_retrying_posix_flock_mutant(
++    source: str,
++    helper: str,
++    flag: str,
++    label: str,
++) -> None:
++    def disable_flock(body: str) -> str:
++        pattern = re.compile(
++            rf"if\s*\(\s*(?P<failure>::flock\s*\([^;]*?{re.escape(flag)}\s*\)"
++            r"\s*!=\s*0)\s*\)"
++        )
++        mutated, replacements = pattern.subn(
++            r"if (false && \g<failure>)", body, count=1
++        )
++        if replacements != 1:
++            raise AssertionError(f"{label} dead-flock mutant drifted")
++        return mutated
++
++    mutant = replace_unique_function_body(source, helper, disable_flock)
++    try:
++        require_retrying_posix_flock(mutant, helper, flag, label)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError(f"{label} accepted a dead flock predicate")
++
++
++def require_posix_live_lock_rebinding(source: str, label: str) -> None:
++    bodies = overriding_method_bodies(
++        source, "DurableFileAdapter", "authority_identity"
++    )
++    if len(bodies) != 1:
++        raise AssertionError(f"{label} authority identity override drifted")
++    body = bodies[0]
++    if (
++        len(call_argument_lists(body, "fstat")) != 2
++        or len(call_argument_lists(body, "fstatat")) != 1
++    ):
++        raise AssertionError(f"{label} does not re-read the live lock name")
++    fstatat_arguments = call_argument_lists(body, "fstatat")[0]
++    if (
++        len(fstatat_arguments) != 4
++        or "directory_fd_" not in fstatat_arguments[0]
++        or "lock_name" not in fstatat_arguments[1]
++        or "current_lock_information" not in fstatat_arguments[2]
++        or "AT_SYMLINK_NOFOLLOW" not in fstatat_arguments[3]
++    ):
++        raise AssertionError(f"{label} live lock lookup can follow another path")
++    required_predicates = (
++        r"!\s*S_ISREG\s*\(\s*lock_information\.st_mode\s*\)",
++        r"!\s*S_ISREG\s*\(\s*current_lock_information\.st_mode\s*\)",
++        r"lock_information\.st_nlink\s*==\s*0",
++        r"current_lock_information\.st_nlink\s*==\s*0",
++        r"lock_information\.st_dev\s*!=\s*current_lock_information\.st_dev",
++        r"lock_information\.st_ino\s*!=\s*current_lock_information\.st_ino",
++    )
++    branches = fail_closed_if_branches(body)
++    if any(
++        not any(
++            re.search(predicate, condition) and branch_returns_non_success(statement)
++            for condition, statement in branches
++        )
++        for predicate in required_predicates
++    ):
++        raise AssertionError(f"{label} does not reject a rebound live lock path")
++
++
++def require_posix_lock_path_binding_mutants(source: str, label: str) -> None:
++    def rejected(mutant: str, name: str) -> None:
++        try:
++            require_each_override_call_exactly_once(
++                mutant,
++                "DurableFileAdapter",
++                "lock_authority",
++                "lock_directory_retrying_interrupts",
++                label,
++            )
++            require_posix_live_lock_rebinding(mutant, label)
++        except AssertionError:
++            return
++        raise AssertionError(f"{label} accepted {name} lock-path mutant")
++
++    def lock_file_only(body: str) -> str:
++        return body.replace(
++            "lock_directory_retrying_interrupts(directory_fd_)",
++            "make_result(DurableFileStatus::Succeeded)",
++            1,
++        )
++
++    rejected(
++        replace_unique_override_body(source, "lock_authority", lock_file_only),
++        "lock-file-only",
++    )
++
++    def held_descriptor_only(body: str) -> str:
++        live_lookup = """struct stat current_lock_information {};
++        if (::fstatat(directory_fd_, lock_name.data(),
++                      &current_lock_information, AT_SYMLINK_NOFOLLOW) != 0) {
++            return {make_errno_result(DurableFileStatus::Unsupported, errno),
++                    {}};
++        }"""
++        mutated = body.replace(
++            live_lookup,
++            "const auto current_lock_information = lock_information;",
++            1,
++        )
++        if mutated == body or "::fstatat(" in mutated:
++            raise AssertionError(f"{label} held-descriptor mutant drifted")
++        return mutated
++
++    rejected(
++        replace_unique_override_body(
++            source, "authority_identity", held_descriptor_only
++        ),
++        "held-descriptor-only",
++    )
++
++    def inode_only(body: str) -> str:
++        return body.replace(
++            "lock_information.st_dev != current_lock_information.st_dev",
++            "false",
++            1,
++        )
++
++    rejected(
++        replace_unique_override_body(source, "authority_identity", inode_only),
++        "partial-identity",
++    )
++
++
++def require_windows_lock_overlapped_binding(source: str) -> None:
++    bodies = overriding_method_bodies(source, "DurableFileAdapter", "lock_authority")
++    if not bodies:
++        raise AssertionError("Windows lock override is unavailable")
++    for body in bodies:
++        calls = list(re.finditer(r"\bLockFileEx\s*\(", body))
++        if len(calls) != 1:
++            raise AssertionError("Windows lock does not call LockFileEx exactly once")
++        opening = body.find("(", calls[0].start())
++        closing = matching_delimiter(body, opening, "(", ")")
++        arguments = body[opening + 1 : closing]
++        variable_match = re.search(r"&\s*(?P<name>[A-Za-z_]\w*)\s*$", arguments)
++        if variable_match is None:
++            raise AssertionError("Windows lock omits its OVERLAPPED argument")
++        variable = variable_match.group("name")
++        if (
++            re.search(
++                rf"\bOVERLAPPED\s+{re.escape(variable)}\s*" r"(?:\{\s*\}|=\s*\{\s*\})",
++                body[: calls[0].start()],
++            )
++            is None
++        ):
++            raise AssertionError("Windows LockFileEx OVERLAPPED is not zeroed")
++
++
++def require_each_override_result_call_checked(
++    source: str,
++    base: str,
++    entry: str,
++    call: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        assignment = re.search(
++            rf"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
++            rf"(?P<result>[A-Za-z_]\w*)\s*=\s*{re.escape(call)}\s*\(",
++            body,
++        )
++        if assignment is None:
++            raise AssertionError(f"{label} does not capture {call}'s result")
++        result = assignment.group("result")
++        if not any(
++            result in condition
++            and (
++                re.search(
++                    rf"!\s*{re.escape(result)}\s*\.\s*succeeded\s*\(",
++                    condition,
++                )
++                or re.search(
++                    rf"{re.escape(result)}[^=]*(?:!=\s*DurableFileStatus::Succeeded|\.status\s*!=)",
++                    condition,
++                )
++            )
++            and branch_returns_non_success(statement)
++            for condition, statement in fail_closed_if_branches(
++                body[assignment.start() :]
++            )
++        ):
++            raise AssertionError(f"{label} ignores {call}'s result")
++
++
++def require_posix_unlock_result_mapping(source: str, label: str) -> None:
++    bodies = overriding_method_bodies(source, "DurableFileAdapter", "unlock_authority")
++    if not bodies:
++        raise AssertionError(f"{label} unlock override is unavailable")
++    for body in bodies:
++        unlock = re.search(
++            r"\b(?:const\s+)?auto\s+(?P<result>[A-Za-z_]\w*)\s*=\s*"
++            r"unlock_file_retrying_interrupts\s*\(",
++            body,
++        )
++        close = re.search(
++            r"\b(?:const\s+)?(?:auto|int)\s+(?P<result>[A-Za-z_]\w*)\s*=\s*"
++            r"(?:::)?close\s*\(",
++            body,
++        )
++        if unlock is None or close is None or not unlock.start() < close.start():
++            raise AssertionError(f"{label} does not capture unlock then close")
++        unlock_result = unlock.group("result")
++        close_result = close.group("result")
++        if not any(
++            unlock_result in condition
++            and close_result in condition
++            and (
++                f"!{unlock_result}.succeeded(" in re.sub(r"\s+", "", condition)
++                or f"{unlock_result}.status!=" in re.sub(r"\s+", "", condition)
++            )
++            and bool(
++                re.search(
++                    rf"\b{re.escape(close_result)}\s*(?:!=\s*0|<\s*0)",
++                    condition,
++                )
++            )
++            and branch_returns_non_success(statement)
++            for condition, statement in fail_closed_if_branches(body[unlock.start() :])
++        ):
++            raise AssertionError(f"{label} does not propagate unlock/close failure")
++
++
++def require_windows_unlock_result_mapping(source: str) -> None:
++    bodies = overriding_method_bodies(source, "DurableFileAdapter", "unlock_authority")
++    if not bodies:
++        raise AssertionError("Windows unlock override is unavailable")
++    for body in bodies:
++        unlock = re.search(
++            r"\b(?:const\s+)?(?:auto|BOOL|bool)\s+"
++            r"(?P<result>[A-Za-z_]\w*)\s*=\s*UnlockFileEx\s*\(",
++            body,
++        )
++        close = re.search(
++            r"\b(?:const\s+)?(?:auto|BOOL|bool)\s+"
++            r"(?P<result>[A-Za-z_]\w*)\s*=\s*CloseHandle\s*\(",
++            body,
++        )
++        if unlock is None or close is None or not unlock.start() < close.start():
++            raise AssertionError("Windows unlock does not capture unlock then close")
++        unlock_result = unlock.group("result")
++        close_result = close.group("result")
++        if not any(
++            bool(re.search(rf"!\s*{re.escape(unlock_result)}\b", condition))
++            and bool(re.search(rf"!\s*{re.escape(close_result)}\b", condition))
++            and branch_returns_non_success(statement)
++            for condition, statement in fail_closed_if_branches(body[unlock.start() :])
++        ):
++            raise AssertionError("Windows unlock/close failure is ignored")
++
++
++def split_cpp_arguments(arguments: str) -> tuple[str, ...]:
++    parts: list[str] = []
++    start = 0
++    depths = {"(": 0, "[": 0, "{": 0}
++    pairs = {")": "(", "]": "[", "}": "{"}
++    for index, character in enumerate(arguments):
++        if character in depths:
++            depths[character] += 1
++        elif character in pairs:
++            depths[pairs[character]] -= 1
++        elif character == "," and not any(depths.values()):
++            parts.append(arguments[start:index].strip())
++            start = index + 1
++    parts.append(arguments[start:].strip())
++    return tuple(parts)
++
++
++def call_argument_lists(body: str, call: str) -> tuple[tuple[str, ...], ...]:
++    arguments: list[tuple[str, ...]] = []
++    for match in re.finditer(rf"\b{re.escape(call)}\s*\(", body):
++        opening = body.find("(", match.start())
++        closing = matching_delimiter(body, opening, "(", ")")
++        arguments.append(split_cpp_arguments(body[opening + 1 : closing]))
++    return tuple(arguments)
++
++
++def replace_unique_function_body(
++    source: str,
++    function: str,
++    transform,
++) -> str:
++    declaration = re.compile(
++        rf"\b{re.escape(function)}\s*\([^;{{}}]*\)\s*"
++        r"(?:const\s*)?(?:noexcept\s*)?(?:override\s*)?\{"
++    )
++    matches = tuple(declaration.finditer(source))
++    if len(matches) != 1:
++        raise AssertionError(f"{function} mutation target is not unique")
++    opening = matches[0].end() - 1
++    closing = matching_delimiter(source, opening, "{", "}")
++    body = source[opening + 1 : closing]
++    transformed = transform(body)
++    if transformed == body:
++        raise AssertionError(f"{function} mutation did not change its body")
++    return source[: opening + 1] + transformed + source[closing:]
++
++
++def replace_unique_bool_function_body(
++    source: str,
++    function: str,
++    transform,
++) -> str:
++    declaration = re.compile(
++        rf"\bbool\s+{re.escape(function)}\s*\([^;{{}}]*\)\s*"
++        r"(?:const\s*)?(?:noexcept\s*)?\{"
++    )
++    matches = tuple(declaration.finditer(source))
++    if len(matches) != 1:
++        raise AssertionError(f"{function} bool mutation target is not unique")
++    opening = matches[0].end() - 1
++    closing = matching_delimiter(source, opening, "{", "}")
++    body = source[opening + 1 : closing]
++    transformed = transform(body)
++    if transformed == body:
++        raise AssertionError(f"{function} bool mutation did not change its body")
++    return source[: opening + 1] + transformed + source[closing:]
++
++
++def bool_function_bodies(source: str, function: str) -> tuple[str, ...]:
++    declaration = re.compile(
++        rf"\bbool\s+{re.escape(function)}\s*\([^;{{}}]*\)\s*"
++        r"(?:const\s*)?(?:noexcept\s*)?\{"
++    )
++    bodies: list[str] = []
++    for match in declaration.finditer(source):
++        opening = match.end() - 1
++        closing = matching_delimiter(source, opening, "{", "}")
++        bodies.append(source[opening + 1 : closing])
++    return tuple(bodies)
++
++
++def replace_unique_override_body(source: str, entry: str, transform) -> str:
++    declaration = re.compile(
++        rf"\b{re.escape(entry)}\s*\([^;{{}}]*\)\s*" r"[^;{}]*\boverride\b[^;{}]*\{"
++    )
++    matches = tuple(declaration.finditer(source))
++    if len(matches) != 1:
++        raise AssertionError(f"{entry} mutation target is not unique")
++    opening = matches[0].end() - 1
++    closing = matching_delimiter(source, opening, "{", "}")
++    body = source[opening + 1 : closing]
++    transformed = transform(body)
++    if transformed == body:
++        raise AssertionError(f"{entry} mutation did not change its body")
++    return source[: opening + 1] + transformed + source[closing:]
++
++
++def compact_cpp(expression: str) -> str:
++    return re.sub(r"\s+", "", expression)
++
++
++def cpp_object_expression(expression: str) -> str:
++    return re.sub(r"\.(?:data|c_str)\(\)$", "", compact_cpp(expression))
++
++
++def require_post_replace_verification(
++    source: str,
++    platform: str,
++    label: str,
++) -> None:
++    helper_bodies = function_bodies(source, "verify_replaced_target")
++    if len(helper_bodies) != 1:
++        raise AssertionError(f"{label} post-replace verifier is not unique")
++    helper = helper_bodies[0]
++    returns = re.findall(r"\breturn\b(?P<value>[^;]*);", helper, re.DOTALL)
++    if not returns or any(
++        "EffectMayHaveOccurred" not in value and "Succeeded" not in value
++        for value in returns
++    ):
++        raise AssertionError(f"{label} verifier does not fail effect-may")
++    if helper.count("DurableFileStatus::Succeeded") != 1:
++        raise AssertionError(f"{label} verifier maps a failure to success")
++    if any(
++        token in helper
++        for token in (
++            "DurableFileStatus::Unsupported",
++            "DurableFileStatus::FailedBeforeEffect",
++        )
++    ):
++        raise AssertionError(f"{label} verifier downgrades a replacement failure")
++    reads = call_argument_lists(helper, "read_bounded_close")
++    read_assignments = tuple(
++        re.finditer(
++            r"\b(?:const\s+)?(?:auto|DurableReadResult)\s+"
++            r"(?P<result>[A-Za-z_]\w*)\s*=\s*read_bounded_close\s*\(",
++            helper,
++        )
++    )
++    if (
++        len(reads) != 1
++        or len(read_assignments) != 1
++        or len(reads[0]) != 2
++        or compact_cpp(reads[0][1]) != "expected_bytes.size()"
++    ):
++        raise AssertionError(f"{label} verifier does not read exact bounded bytes")
++    read_result = read_assignments[0].group("result")
++    compared_views = tuple(
++        re.finditer(
++            r"\b(?:const\s+)?(?:auto|std::string_view)\s+"
++            r"(?P<view>[A-Za-z_]\w*)\s*=\s*std::string_view\s*\(\s*"
++            rf"{re.escape(read_result)}\s*\.\s*bytes\s*\.\s*data\s*\(\s*\)\s*,\s*"
++            rf"{re.escape(read_result)}\s*\.\s*bytes\s*\.\s*size\s*\(\s*\)\s*\)",
++            helper,
++        )
++    )
++    if len(compared_views) != 1:
++        raise AssertionError(f"{label} verifier does not compare observed bytes")
++    compared_view = compared_views[0].group("view")
++    if (
++        re.search(rf"\b{re.escape(read_result)}\s*\.\s*truncated\b", helper) is None
++        or re.search(rf"\b{re.escape(compared_view)}\s*!=\s*expected_bytes\b", helper)
++        is None
++    ):
++        raise AssertionError(f"{label} verifier ignores observed bounded bytes")
++
++    if platform == "posix":
++        opens = call_argument_lists(helper, "openat")
++        if len(opens) != 1 or not all(
++            token in "".join(opens[0])
++            for token in ("O_RDONLY", "O_CLOEXEC", "O_NOFOLLOW")
++        ):
++            raise AssertionError(f"{label} verifier follows an unsafe target")
++        if (
++            re.search(r"\bfstat\s*\(", helper) is None
++            or re.search(r"!\s*S_ISREG\s*\(", helper) is None
++            or re.search(r"\bst_nlink\s*!=\s*1\b", helper) is None
++            or re.search(
++                r"\bst_dev\s*!=\s*expected_identity\s*\.\s*device\b",
++                helper,
++            )
++            is None
++            or re.search(
++                r"\bst_ino\s*!=\s*expected_identity\s*\.\s*inode\b",
++                helper,
++            )
++            is None
++            or "close_open_descriptor" not in helper
++        ):
++            raise AssertionError(f"{label} verifier omits safe identity validation")
++    elif platform == "windows":
++        opens = call_argument_lists(helper, "CreateFileW")
++        if (
++            len(opens) != 1
++            or len(opens[0]) < 3
++            or not all(
++                token in "".join(opens[0])
++                for token in (
++                    "GENERIC_READ",
++                    "OPEN_EXISTING",
++                    "FILE_FLAG_OPEN_REPARSE_POINT",
++                )
++            )
++            or "FILE_SHARE_DELETE" in opens[0][2]
++        ):
++            raise AssertionError(f"{label} verifier follows an unsafe target")
++        for token in (
++            "FileAttributeTagInfo",
++            "FILE_ATTRIBUTE_REPARSE_POINT",
++            "FILE_ATTRIBUTE_DIRECTORY",
++            "FileStandardInfo",
++            "NumberOfLinks",
++            "FileIdInfo",
++            "same_file_identity",
++            "close_open_handle",
++        ):
++            if token not in helper:
++                raise AssertionError(f"{label} verifier omits safe identity validation")
++        if (
++            re.search(r"\bNumberOfLinks\s*!=\s*1\b", helper) is None
++            or re.search(
++                r"!\s*same_file_identity\s*\(\s*identity\s*,\s*"
++                r"expected_identity\s*\)",
++                helper,
++            )
++            is None
++        ):
++            raise AssertionError(f"{label} verifier ignores target identity")
++        identity_bodies = bool_function_bodies(source, "same_file_identity")
++        if len(identity_bodies) != 1:
++            raise AssertionError(f"{label} identity comparator is not unique")
++        identity_body = compact_cpp(identity_bodies[0])
++        expected_identity_return = (
++            "returnleft.VolumeSerialNumber==right.VolumeSerialNumber&&"
++            "std::memcmp(left.FileId.Identifier,right.FileId.Identifier,"
++            "sizeof(left.FileId.Identifier))==0;"
++        )
++        if expected_identity_return not in identity_body:
++            raise AssertionError(f"{label} compares an incomplete file identity")
++    else:
++        raise AssertionError(f"{label} verifier platform is unknown")
++
++    replacement_call = "renameat" if platform == "posix" else "MoveFileExW"
++    for entry in ("replace_journal", "replace_root"):
++        bodies = overriding_method_bodies(source, "DurableFileAdapter", entry)
++        if len(bodies) != 1:
++            raise AssertionError(f"{label} {entry} override is not unique")
++        body = bodies[0]
++        verifier_calls = call_argument_lists(body, "verify_replaced_target")
++        replacement_calls = call_argument_lists(body, replacement_call)
++        if len(verifier_calls) != 1 or len(replacement_calls) != 1:
++            raise AssertionError(f"{label} {entry} verifier call count drifted")
++        write_at = body.find("write_flush_close")
++        replace_at = body.find(replacement_call)
++        verify_at = body.find("verify_replaced_target")
++        if write_at < 0 or not write_at < replace_at < verify_at:
++            raise AssertionError(f"{label} {entry} verifies before replacement")
++        if (
++            re.search(r"\breturn\s+verify_replaced_target\s*\(", body[verify_at - 16 :])
++            is None
++        ):
++            raise AssertionError(f"{label} {entry} ignores verifier result")
++        verify = tuple(compact_cpp(value) for value in verifier_calls[0])
++        replacement = tuple(compact_cpp(value) for value in replacement_calls[0])
++        if platform == "posix":
++            sync_at = body.find("sync_directory_retrying_interrupts")
++            if not replace_at < sync_at < verify_at:
++                raise AssertionError(
++                    f"{label} {entry} verifies before namespace durability"
++                )
++            identity = re.search(
++                r"\bconst\s+[A-Za-z_]\w*FileIdentity\s+"
++                r"(?P<name>[A-Za-z_]\w*)\s*\{(?P<value>[^}]*)\}",
++                body,
++                re.DOTALL,
++            )
++            if (
++                identity is None
++                or identity.start() >= write_at
++                or "st_dev" not in identity.group("value")
++                or "st_ino" not in identity.group("value")
++                or len(verify) != 4
++                or len(replacement) != 4
++                or verify[0] != replacement[0]
++                or cpp_object_expression(verify[1])
++                != cpp_object_expression(replacement[3])
++                or verify[2] != identity.group("name")
++                or verify[3] != "bytes"
++            ):
++                raise AssertionError(
++                    f"{label} {entry} does not carry staged identity forward"
++                )
++        else:
++            identity = re.search(
++                r"\bFILE_ID_INFO\s+(?P<name>[A-Za-z_]\w*)\s*\{\s*\}",
++                body,
++            )
++            if identity is None or identity.start() >= write_at:
++                raise AssertionError(
++                    f"{label} {entry} does not capture staged identity"
++                )
++            identity_calls = [
++                arguments
++                for arguments in call_argument_lists(
++                    body[:write_at], "GetFileInformationByHandleEx"
++                )
++                if "FileIdInfo" in arguments
++                and any(
++                    compact_cpp(argument) == f"&{identity.group('name')}"
++                    for argument in arguments
++                )
++            ]
++            if (
++                len(identity_calls) != 1
++                or len(verify) != 3
++                or len(replacement) < 2
++                or cpp_object_expression(verify[0])
++                != cpp_object_expression(replacement[1])
++                or verify[1] != identity.group("name")
++                or verify[2] != "bytes"
++            ):
++                raise AssertionError(
++                    f"{label} {entry} does not carry staged identity forward"
++                )
++
++
++def require_post_replace_verification_mutants(
++    source: str,
++    platform: str,
++    label: str,
++) -> None:
++    def rejected(mutant: str, name: str) -> None:
++        try:
++            require_post_replace_verification(mutant, platform, f"{label} mutant")
++        except AssertionError:
++            return
++        raise AssertionError(f"{label} verifier accepted {name} mutant")
++
++    def missing(body: str) -> str:
++        return re.sub(
++            r"\breturn\s+verify_replaced_target\s*\([^;]*\)\s*;",
++            "return make_result(DurableFileStatus::Succeeded);",
++            body,
++            count=1,
++            flags=re.DOTALL,
++        )
++
++    rejected(
++        replace_unique_override_body(source, "replace_journal", missing),
++        "missing",
++    )
++
++    def early(body: str) -> str:
++        match = re.search(
++            r"\breturn\s+verify_replaced_target\s*\([^;]*\)\s*;",
++            body,
++            re.DOTALL,
++        )
++        if match is None:
++            return body
++        marker = "if (::renameat" if platform == "posix" else "if (!::MoveFileExW"
++        without = body[: match.start()] + body[match.end() :]
++        return without.replace(marker, match.group(0) + "\n" + marker, 1)
++
++    rejected(
++        replace_unique_override_body(source, "replace_journal", early),
++        "before-replace",
++    )
++
++    def identity_only(body: str) -> str:
++        if platform == "posix":
++            return re.sub(
++                r"information\s*\.\s*st_dev\s*!=\s*"
++                r"expected_identity\s*\.\s*device\s*\|\|\s*"
++                r"information\s*\.\s*st_ino\s*!=\s*"
++                r"expected_identity\s*\.\s*inode",
++                "false",
++                body,
++                count=1,
++            )
++        return re.sub(
++            r"!\s*same_file_identity\s*\(\s*identity\s*,\s*" r"expected_identity\s*\)",
++            "false",
++            body,
++            count=1,
++        )
++
++    rejected(
++        replace_unique_function_body(source, "verify_replaced_target", identity_only),
++        "content-only",
++    )
++
++    def content_only(body: str) -> str:
++        return re.sub(
++            r"observed_bytes\s*!=\s*expected_bytes",
++            "false",
++            body,
++            count=1,
++        )
++
++    rejected(
++        replace_unique_function_body(source, "verify_replaced_target", content_only),
++        "identity-only",
++    )
++
++    def unsafe(body: str) -> str:
++        token = "O_NOFOLLOW" if platform == "posix" else "FILE_FLAG_OPEN_REPARSE_POINT"
++        return body.replace(token, "0", 1)
++
++    rejected(
++        replace_unique_function_body(source, "verify_replaced_target", unsafe),
++        "unsafe-follow",
++    )
++
++    def unbounded(body: str) -> str:
++        return body.replace(
++            "expected_bytes.size()",
++            "std::numeric_limits<std::size_t>::max()",
++            1,
++        )
++
++    rejected(
++        replace_unique_function_body(source, "verify_replaced_target", unbounded),
++        "unbounded-read",
++    )
++
++    def downgraded(body: str) -> str:
++        return body.replace(
++            "DurableFileStatus::EffectMayHaveOccurred",
++            "DurableFileStatus::Succeeded",
++            1,
++        )
++
++    rejected(
++        replace_unique_function_body(source, "verify_replaced_target", downgraded),
++        "success-mapped-failure",
++    )
++
++    def rebound_observed_bytes(body: str) -> str:
++        return body.replace(
++            "std::string_view(observed.bytes.data(), observed.bytes.size())",
++            "std::string_view(expected_bytes.data(), expected_bytes.size())",
++            1,
++        )
++
++    rejected(
++        replace_unique_function_body(
++            source, "verify_replaced_target", rebound_observed_bytes
++        ),
++        "expected-bytes-rebind",
++    )
++
++    if platform == "windows":
++
++        def always_equal(_body: str) -> str:
++            return "\n    return true;\n"
++
++        rejected(
++            replace_unique_bool_function_body(
++                source, "same_file_identity", always_equal
++            ),
++            "always-equal-identity",
++        )
++
++        def volume_only(_body: str) -> str:
++            return (
++                "\n    return left.VolumeSerialNumber == " "right.VolumeSerialNumber;\n"
++            )
++
++        rejected(
++            replace_unique_bool_function_body(
++                source, "same_file_identity", volume_only
++            ),
++            "volume-only-identity",
++        )
++
++        def file_id_only(_body: str) -> str:
++            return (
++                "\n    return std::memcmp(left.FileId.Identifier, "
++                "right.FileId.Identifier, sizeof(left.FileId.Identifier)) == 0;\n"
++            )
++
++        rejected(
++            replace_unique_bool_function_body(
++                source, "same_file_identity", file_id_only
++            ),
++            "file-id-only-identity",
++        )
++
++        def delete_shared(body: str) -> str:
++            return body.replace(
++                "FILE_SHARE_READ | FILE_SHARE_WRITE",
++                "FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE",
++                1,
++            )
++
++        rejected(
++            replace_unique_function_body(
++                source, "verify_replaced_target", delete_shared
++            ),
++            "delete-shared-verifier",
++        )
++
++
++def require_windows_bound_directory_factory(source: str) -> None:
++    factory_bodies = function_bodies(source, "make_platform_durable_file_adapter")
++    if len(factory_bodies) != 1:
++        raise AssertionError("Windows adapter factory is not unique")
++    factory = factory_bodies[0]
++    opened_at = factory.find("CreateFileW")
++    attributes_at = factory.find("GetFileInformationByHandleEx")
++    final_at = factory.find("final_directory_path")
++    constructed_at = factory.rfind("make_unique<WindowsDurableFileAdapter>")
++    if not 0 <= opened_at < attributes_at < final_at < constructed_at:
++        raise AssertionError("Windows adapter binds its directory out of order")
++    opens = call_argument_lists(factory, "CreateFileW")
++    if len(opens) != 1 or not all(
++        token in "".join(opens[0])
++        for token in (
++            "directory.c_str()",
++            "OPEN_EXISTING",
++            "FILE_FLAG_BACKUP_SEMANTICS",
++            "FILE_FLAG_OPEN_REPARSE_POINT",
++        )
++    ):
++        raise AssertionError("Windows adapter does not open the caller directory")
++    if not all(
++        token in factory
++        for token in (
++            "FileAttributeTagInfo",
++            "FILE_ATTRIBUTE_REPARSE_POINT",
++            "FILE_ATTRIBUTE_DIRECTORY",
++            "std::move(*bound_directory)",
++            "INVALID_HANDLE_VALUE",
++        )
++    ):
++        raise AssertionError("Windows adapter does not validate its bound directory")
++    if len(re.findall(r"std::filesystem::path\s*\{\s*\}", factory)) < 2:
++        raise AssertionError("Windows adapter keeps an invalid caller path")
++    if re.search(
++        r"make_unique\s*<\s*WindowsDurableFileAdapter\s*>\s*" r"\(\s*directory\b",
++        factory,
++    ):
++        raise AssertionError("Windows adapter retains the caller-relative path")
++    final_bodies = function_bodies(source, "final_directory_path")
++    if len(final_bodies) != 1:
++        raise AssertionError("Windows final-directory resolver is not unique")
++    final_body = final_bodies[0]
++    if (
++        "FILE_NAME_NORMALIZED" not in final_body
++        or "VOLUME_NAME_DOS" not in final_body
++        or len(call_argument_lists(final_body, "GetFinalPathNameByHandleW")) < 2
++    ):
++        raise AssertionError("Windows adapter does not resolve a normalized path")
++    for arguments in call_argument_lists(final_body, "GetFinalPathNameByHandleW"):
++        if not any(compact_cpp(argument) == "flags" for argument in arguments):
++            raise AssertionError("Windows final-path call ignores normalized flags")
++
++
++def require_windows_bound_directory_factory_mutants(source: str) -> None:
++    def rejected(mutant: str, name: str) -> None:
++        try:
++            require_windows_bound_directory_factory(mutant)
++        except AssertionError:
++            return
++        raise AssertionError(f"Windows directory binding accepted {name} mutant")
++
++    def caller_path(body: str) -> str:
++        return body.replace(
++            "std::move(*bound_directory), directory_handle",
++            "directory, directory_handle",
++            1,
++        )
++
++    rejected(
++        replace_unique_function_body(
++            source, "make_platform_durable_file_adapter", caller_path
++        ),
++        "caller-path",
++    )
++
++    def unnormalized(body: str) -> str:
++        return body.replace("FILE_NAME_NORMALIZED", "0", 1)
++
++    rejected(
++        replace_unique_function_body(source, "final_directory_path", unnormalized),
++        "unnormalized-path",
++    )
++
++    def invalid_keeps_path(body: str) -> str:
++        return body.replace("std::filesystem::path{}", "directory", 1)
++
++    rejected(
++        replace_unique_function_body(
++            source, "make_platform_durable_file_adapter", invalid_keeps_path
++        ),
++        "invalid-caller-path",
++    )
++
++
++def require_each_override_directory_sync_binding(
++    source: str,
++    entry: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, "DurableFileAdapter", entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {entry} override")
++    for body in bodies:
++        renames = call_argument_lists(body, "renameat")
++        syncs = call_argument_lists(body, "sync_directory_retrying_interrupts")
++        if len(renames) != 1 or len(syncs) != 1:
++            raise AssertionError(f"{label} replacement/sync call count drifted")
++        rename = tuple(re.sub(r"\s+", "", argument) for argument in renames[0])
++        sync = tuple(re.sub(r"\s+", "", argument) for argument in syncs[0])
++        if (
++            len(rename) != 4
++            or len(sync) != 1
++            or rename[0] != rename[2]
++            or sync[0] != rename[0]
++        ):
++            raise AssertionError(f"{label} syncs a different authority directory")
++
++
++def require_each_override_minimum_call_argument(
++    source: str,
++    base: str,
++    entry: str,
++    call: str,
++    argument: str,
++    minimum: int,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        count = sum(
++            argument in arguments for arguments in call_argument_lists(body, call)
++        )
++        if count < minimum:
++            raise AssertionError(f"{label} omits repeated {call}({argument})")
++
++
++def require_windows_composite_identity(source: str) -> None:
++    bodies = overriding_method_bodies(
++        source, "DurableFileAdapter", "authority_identity"
++    )
++    if not bodies:
++        raise AssertionError("Windows authority identity override is unavailable")
++    for body in bodies:
++        declarations = re.findall(
++            r"\bFILE_ID_INFO\s+(?P<name>[A-Za-z_]\w*)\s*\{\s*\}", body
++        )
++        bound: list[str] = []
++        for arguments in call_argument_lists(body, "GetFileInformationByHandleEx"):
++            if "FileIdInfo" not in arguments or len(arguments) < 3:
++                continue
++            match = re.fullmatch(r"&\s*(?P<name>[A-Za-z_]\w*)", arguments[2])
++            if match is not None and match.group("name") in declarations:
++                bound.append(match.group("name"))
++        if len(set(bound)) < 2:
++            raise AssertionError("Windows identity omits directory or lock file ID")
++        returns = re.findall(r"\breturn\b(?P<value>[^;]*);", body)
++        if not any(all(name in value for name in set(bound)) for value in returns):
++            raise AssertionError("Windows identity does not bind both file IDs")
++
++
++def require_each_override_retryable_result_mapping(
++    source: str,
++    base: str,
++    entry: str,
++    primitive: str,
++    interruption_token: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, base, entry)
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
++    for body in bodies:
++        branches = fail_closed_if_branches(body)
++        if not any(
++            condition_rejects_predicate(condition, primitive)
++            and branch_returns_non_success(statement)
++            for condition, statement in branches
++        ):
++            raise AssertionError(f"{label} ignores {primitive} failure")
++        if not any(
++            interruption_token in condition and "Interrupted" in statement
++            for condition, statement in branches
++        ):
++            raise AssertionError(
++                f"{label} does not classify {interruption_token} for retry"
++            )
++        if "Succeeded" not in body:
++            raise AssertionError(f"{label} has no explicit success result")
++
++
++def require_each_override_close_result_mapping(
++    source: str,
++    primitive: str,
++    label: str,
++    base: str = "DurableFileChannel",
++) -> None:
++    require_each_override_fail_closed_checks(
++        source,
++        base,
++        "close",
++        (primitive,),
++        label,
++    )
++    require_each_override_omits_calls(
++        source,
++        base,
++        "close",
++        ("retry_interrupted",),
++        label,
++    )
++    for body in overriding_method_bodies(source, base, "close"):
++        if "Succeeded" not in body:
++            raise AssertionError(f"{label} close has no explicit success result")
++
++
++def require_each_override_write_count_mapping(
++    source: str,
++    platform: str,
++    label: str,
++) -> None:
++    bodies = overriding_method_bodies(source, "DurableFileChannel", "write_some")
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete write_some override")
++    for body in bodies:
++        if platform == "posix":
++            assignment = re.search(
++                r"\b(?:const\s+)?(?:auto|ssize_t)\s+(?P<count>[A-Za-z_]\w*)\s*"
++                r"=\s*(?:::)?write\s*\(",
++                body,
++            )
++            interruption_token = "EINTR"
++            primitive = "write"
++        else:
++            assignment = re.search(
++                r"\b(?:DWORD|std::uint32_t|auto)\s+(?P<count>[A-Za-z_]\w*)\s*"
++                r"(?:=\s*0)?\s*;[^{}]*\bWriteFile\s*\([^;]*&\s*"
++                r"(?P=count)\b",
++                body,
++                re.DOTALL,
++            )
++            interruption_token = "ERROR_OPERATION_ABORTED"
++            primitive = "WriteFile"
++        if assignment is None:
++            raise AssertionError(f"{label} does not capture the OS write count")
++        count = assignment.group("count")
++        branches = fail_closed_if_branches(body)
++        if platform == "posix":
++            failure_is_checked = any(
++                count in condition
++                and bool(
++                    re.search(rf"\b{re.escape(count)}\s*(?:<\s*0|==\s*-1)", condition)
++                )
++                and branch_returns_non_success(statement)
++                for condition, statement in branches
++            )
++            if not any(
++                interruption_token in condition and "Interrupted" in statement
++                for condition, statement in branches
++            ):
++                raise AssertionError(
++                    f"{label} does not classify {interruption_token} for retry"
++                )
++        else:
++            if len(re.findall(r"\bWriteFile\b", source)) != 1:
++                raise AssertionError(
++                    f"{label} has an indirect, duplicate, or redirected Windows write"
++                )
++            macro_source = source.replace("%:", "#")
++            defined_macros = re.findall(
++                r"(?m)^\s*#\s*define\s+([A-Za-z_]\w*)\b", macro_source
++            )
++            if any(name != "NOMINMAX" for name in defined_macros):
++                raise AssertionError(f"{label} shadows the Windows write contract")
++
++            def direct_write_failure(condition: str) -> bool:
++                compact = re.sub(r"\s+", "", condition)
++                call = re.match(r"!::WriteFile\(", compact)
++                if call is None:
++                    return False
++                opening = compact.find("(", call.start())
++                return (
++                    matching_delimiter(compact, opening, "(", ")") == len(compact) - 1
++                )
++
++            failure_statements = [
++                statement
++                for condition, statement in branches
++                if direct_write_failure(condition)
++            ]
++            if len(failure_statements) != 1:
++                raise AssertionError(
++                    f"{label} does not have one fail-closed {primitive} branch"
++                )
++            failure_statement = failure_statements[0]
++            canonical_failure = re.fullmatch(
++                r"\s*const\s+auto\s+(?P<error>[A-Za-z_]\w*)\s*=\s*"
++                r"(?:::)?GetLastError\(\)\s*;\s*"
++                r"return\s+\{\s*::lemon::residency::detail::"
++                r"DurableFileResult\s*\{\s*::lemon::residency::detail::"
++                r"DurableFileStatus::\s*EffectMayHaveOccurred\s*,\s*"
++                r"::std::to_string\(\s*(?P=error)\s*\)\s*\}\s*,\s*"
++                r"0\s*\}\s*;\s*",
++                failure_statement,
++                re.DOTALL,
++            )
++            if canonical_failure is None:
++                raise AssertionError(
++                    f"{label} does not unconditionally classify {primitive} "
++                    "failure as uncertain"
++                )
++            if re.search(r"\bInterrupted\b", body):
++                raise AssertionError(
++                    f"{label} retries an uncertain {primitive} failure"
++                )
++            failure_is_checked = branch_returns_non_success(failure_statement)
++        if not failure_is_checked:
++            raise AssertionError(f"{label} ignores {primitive} failure")
++        if re.search(rf"\breturn\b[^;]*\b{re.escape(count)}\b[^;]*;", body) is None:
++            raise AssertionError(f"{label} does not return the OS write count")
++
++
++def require_windows_write_override_shape(source: str, label: str) -> None:
++    bodies = overriding_method_bodies(source, "DurableFileChannel", "write_some")
++    if len(bodies) != 1:
++        raise AssertionError(f"{label} has an ambiguous Windows write override")
++    actual = re.sub(r"\s+", "", bodies[0])
++    expected = re.sub(
++        r"\s+",
++        "",
++        """
++        const auto request = static_cast<DWORD>(
++            std::min(bytes.size(), std::size_t(MAXDWORD)));
++        DWORD written = 0;
++        if (!::WriteFile(handle_, bytes.data(), request, &written, nullptr)) {
++            const auto error = ::GetLastError();
++            return {::lemon::residency::detail::DurableFileResult{
++                        ::lemon::residency::detail::DurableFileStatus::
++                            EffectMayHaveOccurred,
++                        ::std::to_string(error)},
++                    0};
++        }
++        return {::lemon::residency::detail::DurableFileResult{
++                    ::lemon::residency::detail::DurableFileStatus::Succeeded,
++                    {}},
++                written};
++        """,
++    )
++    if actual != expected:
++        raise AssertionError(f"{label} Windows write override shape drifted")
++
++
++def require_each_override_read_count_mapping(
++    source: str,
++    platform: str,
++    label: str,
++) -> None:
++    def fixed_read_cap(expression: str) -> bool:
++        return bool(
++            re.fullmatch(
++                r"(?:"
++                r"(?:0[xX][0-9A-Fa-f]+|[0-9]+)[uUlL]*|"
++                r"MAXDWORD|"
++                r"sizeof\([^()]+\)|"
++                r"(?:std::)?size_t\((?:MAXDWORD|[0-9]+[uUlL]*)\)|"
++                r"static_cast<(?:std::)?size_t>\((?:MAXDWORD|[0-9]+[uUlL]*)\)|"
++                r"std::numeric_limits<(?:DWORD|std::uint32_t|std::size_t)>::max\(\)"
++                r")",
++                expression,
++            )
++        )
++
++    def capped_read_request(expression: str) -> bool:
++        narrowed = re.fullmatch(
++            r"static_cast<(?:DWORD|std::uint32_t)>\((?P<value>.*)\)",
++            expression,
++        )
++        if narrowed is not None:
++            expression = narrowed.group("value")
++        if expression == "max_bytes":
++            return narrowed is None
++        minimum = re.fullmatch(r"(?:std::)?min\((?P<arguments>.*)\)", expression)
++        if minimum is None:
++            return False
++        arguments = tuple(
++            re.sub(r"\s+", "", argument)
++            for argument in split_cpp_arguments(minimum.group("arguments"))
++        )
++        if len(arguments) != 2:
++            return False
++        if arguments[0] == "max_bytes":
++            cap = arguments[1]
++        elif arguments[1] == "max_bytes":
++            cap = arguments[0]
++        else:
++            return False
++        if not fixed_read_cap(cap):
++            return False
++        if narrowed is None:
++            return True
++        if cap in {
++            "MAXDWORD",
++            "size_t(MAXDWORD)",
++            "std::size_t(MAXDWORD)",
++            "static_cast<size_t>(MAXDWORD)",
++            "static_cast<std::size_t>(MAXDWORD)",
++            "std::numeric_limits<DWORD>::max()",
++            "std::numeric_limits<std::uint32_t>::max()",
++        }:
++            return True
++        literal = re.fullmatch(r"(?P<value>0[xX][0-9A-Fa-f]+|[0-9]+)(?:[uUlL]*)", cap)
++        if literal is None:
++            return False
++        base = 16 if literal.group("value").lower().startswith("0x") else 10
++        return int(literal.group("value"), base) <= 0xFFFFFFFF
++
++    bodies = overriding_method_bodies(source, "DurableReadChannel", "read_some")
++    if not bodies:
++        raise AssertionError(f"{label} has no concrete read_some override")
++    for body in bodies:
++        if platform == "posix":
++            assignment = re.search(
++                r"\b(?:const\s+)?(?:auto|ssize_t)\s+"
++                r"(?P<count>[A-Za-z_]\w*)\s*=\s*(?:::)?read\s*\(",
++                body,
++            )
++            interruption_token = "EINTR"
++            primitive = "read"
++        else:
++            assignment = re.search(
++                r"\b(?:DWORD|std::uint32_t|auto)\s+"
++                r"(?P<count>[A-Za-z_]\w*)\s*(?:=\s*0)?\s*;"
++                r"[^{}]*\bReadFile\s*\([^;]*&\s*(?P=count)\b",
++                body,
++                re.DOTALL,
++            )
++            interruption_token = "ERROR_OPERATION_ABORTED"
++            primitive = "ReadFile"
++        if assignment is None:
++            raise AssertionError(f"{label} does not capture the OS read count")
++        count = assignment.group("count")
++        calls = call_argument_lists(body, primitive)
++        if len(calls) != 1:
++            raise AssertionError(f"{label} native read call count drifted")
++        arguments = calls[0]
++        if len(arguments) < 3:
++            raise AssertionError(f"{label} native read arguments drifted")
++        buffer_expression = re.sub(r"\s+", "", arguments[1])
++        request_expression = re.sub(r"\s+", "", arguments[2])
++        request_bound = capped_read_request(request_expression)
++        request_name = re.fullmatch(r"[A-Za-z_]\w*", request_expression)
++        request_initializer = ""
++        if request_name is not None:
++            declaration = re.search(
++                rf"\b(?:const\s+)?(?:auto|std::size_t|DWORD|std::uint32_t)\s+"
++                rf"{re.escape(request_name.group(0))}\s*=\s*(?P<value>[^;]+);",
++                body[: assignment.start()],
++            )
++            if declaration is not None:
++                request_initializer = re.sub(r"\s+", "", declaration.group("value"))
++                request_bound = capped_read_request(request_initializer)
++        if not request_bound:
++            raise AssertionError(f"{label} native read is not capped by max_bytes")
++        buffer_match = re.search(r"(?P<name>[A-Za-z_]\w*)", buffer_expression)
++        if buffer_match is None:
++            raise AssertionError(f"{label} native read buffer is unavailable")
++        buffer_name = buffer_match.group("name")
++        allocation_bound = False
++        allocation = re.search(
++            rf"\b(?:std::string|std::vector\s*<[^;>]+>)\s+"
++            rf"{re.escape(buffer_name)}\s*\(",
++            body[: assignment.start()],
++        )
++        if allocation is not None:
++            opening = body.find("(", allocation.start())
++            closing = matching_delimiter(body, opening, "(", ")")
++            allocation_arguments = split_cpp_arguments(body[opening + 1 : closing])
++            allocation_bound = bool(allocation_arguments) and (
++                re.sub(r"\s+", "", allocation_arguments[0])
++                in {request_expression, request_initializer or request_expression}
++            )
++        if allocation is not None and not allocation_bound:
++            raise AssertionError(f"{label} native read buffer is not request-bounded")
++        if allocation is None and (
++            f"sizeof({buffer_name})" not in request_expression
++            and f"sizeof({buffer_name})" not in request_initializer
++        ):
++            raise AssertionError(f"{label} native read buffer is not request-bounded")
++        branches = fail_closed_if_branches(body)
++        if platform == "posix":
++            failure_is_checked = any(
++                count in condition
++                and bool(
++                    re.search(
++                        rf"\b{re.escape(count)}\s*(?:<\s*0|==\s*-1)",
++                        condition,
++                    )
++                )
++                and branch_returns_non_success(statement)
++                for condition, statement in branches
++            )
++        else:
++            failure_is_checked = any(
++                condition_rejects_predicate(condition, primitive)
++                and branch_returns_non_success(statement)
++                for condition, statement in branches
++            )
++        if not failure_is_checked:
++            raise AssertionError(f"{label} ignores {primitive} failure")
++        if not any(
++            interruption_token in condition and "Interrupted" in statement
++            for condition, statement in branches
++        ):
++            raise AssertionError(
++                f"{label} does not classify {interruption_token} for retry"
++            )
++        returns = re.findall(r"\breturn\b(?P<value>[^;]*);", body)
++        if not any(count in value and buffer_name in value for value in returns):
++            raise AssertionError(f"{label} does not bind bytes to the OS read count")
++        normalized_returns = [re.sub(r"\s+", "", value) for value in returns]
++        eof_expression = rf"{re.escape(count)}==0"
++        eof_bound = any(
++            re.search(eof_expression, value) for value in normalized_returns
++        )
++        if not eof_bound:
++            eof_declarations = re.finditer(
++                r"\b(?:const\s+)?bool\s+(?P<name>[A-Za-z_]\w*)\s*="
++                rf"\s*{re.escape(count)}\s*==\s*0\s*;",
++                body,
++            )
++            eof_bound = any(
++                any(match.group("name") in value for value in normalized_returns)
++                for match in eof_declarations
++            )
++        if not eof_bound:
++            raise AssertionError(f"{label} does not bind EOF to the OS read count")
++
++
++def assigned_call(
++    body: str,
++    call: str,
++    label: str,
++) -> tuple[str, str, int]:
++    pattern = re.compile(
++        r"\b(?:const\s+)?(?:auto|ParsedJournalRecordResult|"
++        r"JournalHistoryResult|AuthorityRootCandidateResult)\s+"
++        rf"(?P<result>[A-Za-z_]\w*)\s*=\s*"
++        rf"(?:lemon::residency::)?{re.escape(call)}\s*\("
++    )
++    matches = list(pattern.finditer(body))
++    if len(matches) != 1:
++        raise AssertionError(f"{label} does not call {call} exactly once")
++    match = matches[0]
++    opening = body.find("(", match.start())
++    closing = matching_delimiter(body, opening, "(", ")")
++    return match.group("result"), body[opening + 1 : closing], match.start()
++
++
++def require_task019_result_binding(
++    body: str,
++    call: str,
++    member: str,
++    label: str,
++    required_argument: str | None = None,
++) -> tuple[int, str, tuple[str, ...]]:
++    result, arguments, position = assigned_call(body, call, label)
++    if required_argument is not None and required_argument not in arguments:
++        raise AssertionError(f"{label} omits {required_argument} from {call}")
++    rejected = any(
++        result in condition
++        and (
++            f"!{result}.accepted(" in re.sub(r"\s+", "", condition)
++            or f"!{result}.{member}" in re.sub(r"\s+", "", condition)
++        )
++        and branch_returns_non_success(statement)
++        for condition, statement in fail_closed_if_branches(body[position:])
++    )
++    if not rejected:
++        raise AssertionError(f"{label} does not reject the {call} result")
++    if (
++        re.search(
++            rf"\*\s*{re.escape(result)}\s*\.\s*{re.escape(member)}\b",
++            body[position:],
++        )
++        is None
++    ):
++        raise AssertionError(f"{label} does not carry {call}'s {member} forward")
++    return position, result, split_cpp_arguments(arguments)
++
++
++def normalized_cpp_expression(expression: str) -> str:
++    return re.sub(r"\s+", "", expression)
++
++
++def require_mint_published_definition(source: str) -> None:
++    definitions = tuple(
++        re.finditer(
++            r"\bDurableJournalResult\s+DurableJournal::mint_published\s*"
++            r"\((?P<parameters>[^;{}]*)\)\s*(?:noexcept\s*)?\{",
++            source,
++        )
++    )
++    if len(definitions) != 1:
++        raise AssertionError("DurableJournal private mint sink is not unique")
++    parameters = split_cpp_arguments(definitions[0].group("parameters"))
++    if (
++        len(parameters) != 3
++        or re.search(r"\bJournalHistory\s*&&\s*[A-Za-z_]\w*\b", parameters[0]) is None
++        or re.search(
++            r"\bAuthorityRootCandidate\s*(?:&&\s*)?[A-Za-z_]\w*\b",
++            parameters[1],
++        )
++        is None
++        or re.search(r"\b(?:persistence|state)[A-Za-z_]*\b", parameters[2]) is None
++    ):
++        raise AssertionError("DurableJournal private mint sink signature drifted")
++
++
++def require_mint_published_return(
++    body: str,
++    history_expression: str,
++    root_expression: str,
++    label: str,
++) -> int:
++    calls = tuple(re.finditer(r"\bmint_published\s*\(", body))
++    arguments = call_argument_lists(body, "mint_published")
++    if len(calls) != 1 or len(arguments) != 1 or len(arguments[0]) != 3:
++        raise AssertionError(f"{label} does not use one private mint sink")
++    start = calls[0].start()
++    statement_start = (
++        max(
++            body.rfind(";", 0, start),
++            body.rfind("{", 0, start),
++            body.rfind("}", 0, start),
++        )
++        + 1
++    )
++    prefix = body[statement_start:start]
++    if re.fullmatch(r"\s*return\s+", prefix) is None:
++        raise AssertionError(f"{label} does not return the private mint result")
++    observed = tuple(normalized_cpp_expression(item) for item in arguments[0])
++    expected_history = normalized_cpp_expression(f"std::move({history_expression})")
++    expected_root = normalized_cpp_expression(f"std::move({root_expression})")
++    if (
++        observed[0] != expected_history
++        or observed[1] != expected_root
++        or re.fullmatch(r"(?:[A-Za-z_]\w*|std::move\([A-Za-z_]\w*\))", observed[2])
++        is None
++    ):
++        raise AssertionError(f"{label} mints from nonauthoritative replay state")
++    return start
++
++
++def require_root_replacement_binding(
++    body: str,
++    root_result: str,
++    label: str,
++) -> int:
++    calls = tuple(re.finditer(r"\breplace_root\s*\(", body))
++    arguments = call_argument_lists(body, "replace_root")
++    if len(calls) != 1 or len(arguments) != 1 or len(arguments[0]) != 1:
++        raise AssertionError(f"{label} root replacement call count drifted")
++    observed = normalized_cpp_expression(arguments[0][0])
++    canonical = normalized_cpp_expression(f"{root_result}.candidate->canonical_bytes()")
++    if observed not in {
++        canonical,
++        f"std::string({canonical})",
++        f"std::string{{{canonical}}}",
++    }:
++        raise AssertionError(f"{label} replaces a nonauthoritative root")
++    return calls[0].start()
++
++
++def require_task019_live_contract(source: str) -> None:
++    require_task019_live_contract_without_mutants(source)
++
++    task019_control = """
++DurableJournalResult DurableJournal::recover_existing() {
++    auto bytes = read_root();
++    auto journal = read_journal();
++    const auto parsed = parse_authority_root_candidate(bytes, history);
++    if (!parsed.candidate) { return corrupt(); }
++    return mint_published(std::move(history), std::move(*parsed.candidate),
++                          persistence_state);
++}
++DurableJournalResult DurableJournal::append_and_publish() {
++    const auto advanced = advance_history(std::move(history), candidate, verifier);
++    if (!advanced.history) { return corrupt(); }
++    append_journal(frame);
++    const auto root = seal_authority_root_candidate(*advanced.history, previous);
++    if (!root.candidate) { return corrupt(); }
++    replace_root(root.candidate->canonical_bytes());
++    return mint_published(std::move(*advanced.history),
++                          std::move(*root.candidate), persistence_state);
++}
++DurableJournalResult DurableJournal::create_new() {
++    const auto history = begin_history(genesis, verifier);
++    if (!history.history) { return corrupt(); }
++    const auto root = seal_authority_root_candidate(*history.history);
++    if (!root.candidate) { return corrupt(); }
++    create_journal(frame);
++    replace_root(root.candidate->canonical_bytes());
++    return mint_published(std::move(*history.history),
++                          std::move(*root.candidate), persistence_state);
++}
++DurableJournalResult DurableJournal::mint_published(
++    JournalHistory &&history, AuthorityRootCandidate &&root,
++    PersistenceState persistence_state) { return DurableJournalResult{}; }
++"""
++    require_task019_live_contract_without_mutants(task019_control)
++    typed_result_control = (
++        task019_control.replace(
++            "const auto parsed = parse_authority_root_candidate",
++            "AuthorityRootCandidateResult parsed = parse_authority_root_candidate",
++        )
++        .replace(
++            "const auto advanced = advance_history",
++            "JournalHistoryResult advanced = advance_history",
++        )
++        .replace(
++            "const auto history = begin_history",
++            "JournalHistoryResult history = begin_history",
++        )
++        .replace(
++            "const auto root = seal_authority_root_candidate",
++            "AuthorityRootCandidateResult root = seal_authority_root_candidate",
++        )
++    )
++    require_task019_live_contract_without_mutants(typed_result_control)
++    delegated_control = """
++DurableJournalResult deep_recover() {
++    auto bytes = read_root();
++    auto journal = read_journal();
++    const auto parsed = parse_authority_root_candidate(bytes, history);
++    if (!parsed.candidate) { return corrupt(); }
++    return mint_published(std::move(history), std::move(*parsed.candidate),
++                          persistence_state);
++}
++DurableJournalResult deep_append() {
++    const auto advanced = advance_history(std::move(history), candidate, verifier);
++    if (!advanced.history) { return corrupt(); }
++    append_journal(frame);
++    const auto root = seal_authority_root_candidate(*advanced.history, previous);
++    if (!root.candidate) { return corrupt(); }
++    replace_root(root.candidate->canonical_bytes());
++    return mint_published(std::move(*advanced.history),
++                          std::move(*root.candidate), persistence_state);
++}
++DurableJournalResult deep_create() {
++    const auto history = begin_history(genesis, verifier);
++    if (!history.history) { return corrupt(); }
++    const auto root = seal_authority_root_candidate(*history.history);
++    if (!root.candidate) { return corrupt(); }
++    create_journal(frame);
++    replace_root(root.candidate->canonical_bytes());
++    return mint_published(std::move(*history.history),
++                          std::move(*root.candidate), persistence_state);
++}
++DurableJournalResult DurableJournal::recover_existing() { return deep_recover(); }
++DurableJournalResult DurableJournal::append_and_publish() { return deep_append(); }
++DurableJournalResult DurableJournal::create_new() { return deep_create(); }
++DurableJournalResult DurableJournal::mint_published(
++    JournalHistory &&history, AuthorityRootCandidate &&root,
++    PersistenceState persistence_state) { return DurableJournalResult{}; }
++"""
++    require_task019_live_contract_without_mutants(delegated_control)
++    dead_parser_mutant = task019_control.replace(
++        "const auto parsed = parse_authority_root_candidate(bytes, history);",
++        "const auto unused = parse_authority_root_candidate(bytes, history);\n"
++        "    const auto parsed = custom_decode_root(bytes, history);",
++    )
++    duplicate_transition_mutant = task019_control.replace(
++        "const auto advanced = advance_history(std::move(history), candidate, verifier);\n"
++        "    if (!advanced.history) { return corrupt(); }",
++        "const auto unused_advance = advance_history(std::move(history), candidate, verifier);\n"
++        "    const auto advanced = custom_advance(history, candidate);\n"
++        "    if (!advanced.history) { return corrupt(); }",
++    )
++    duplicate_sealer_mutant = task019_control.replace(
++        "const auto root = seal_authority_root_candidate(*advanced.history, previous);",
++        "const auto unused_root = seal_authority_root_candidate(*advanced.history, previous);\n"
++        "    const auto root = custom_seal(*advanced.history);",
++        1,
++    )
++    delegated_dead_parser = delegated_control.replace(
++        "const auto parsed = parse_authority_root_candidate(bytes, history);",
++        "const auto unused = parse_authority_root_candidate(bytes, history);\n"
++        "    const auto parsed = custom_decode_root(bytes, history);",
++    )
++    duplicate_helper = delegated_control + "\nDurableJournalResult deep_recover(int);\n"
++    duplicate_helper = duplicate_helper.replace(
++        "DurableJournalResult deep_recover(int);",
++        "DurableJournalResult deep_recover(int) { return corrupt(); }",
++    )
++    typed_dead_call = typed_result_control.replace(
++        "AuthorityRootCandidateResult parsed = "
++        "parse_authority_root_candidate(bytes, history);",
++        "AuthorityRootCandidateResult unused = "
++        "parse_authority_root_candidate(bytes, history);\n"
++        "    const auto parsed = custom_decode_root(bytes, history);",
++        1,
++    )
++    typed_duplicate_call = typed_result_control.replace(
++        "AuthorityRootCandidateResult parsed = "
++        "parse_authority_root_candidate(bytes, history);",
++        "AuthorityRootCandidateResult ignored = "
++        "parse_authority_root_candidate(bytes, history);\n"
++        "    AuthorityRootCandidateResult parsed = "
++        "parse_authority_root_candidate(bytes, history);",
++        1,
++    )
++    typed_unused_result = typed_result_control.replace(
++        "if (!parsed.candidate) { return corrupt(); }",
++        "if (false) { return corrupt(); }",
++        1,
++    )
++    checked_but_nonauthoritative = task019_control.replace(
++        "return mint_published(std::move(history), "
++        "std::move(*parsed.candidate),\n"
++        "                          persistence_state);",
++        "observe(*parsed.candidate);\n"
++        "    const auto custom = custom_decode_root(bytes, history);\n"
++        "    return mint_published(std::move(history), std::move(custom),\n"
++        "                          persistence_state);",
++        1,
++    ).replace(
++        "replace_root(root.candidate->canonical_bytes());",
++        "observe(*root.candidate);\n"
++        "    const auto custom = custom_seal(history);\n"
++        "    replace_root(custom.canonical_bytes());",
++        1,
++    )
++    for mutant in (
++        dead_parser_mutant,
++        duplicate_transition_mutant,
++        duplicate_sealer_mutant,
++        delegated_dead_parser,
++        duplicate_helper,
++        typed_dead_call,
++        typed_duplicate_call,
++        typed_unused_result,
++        checked_but_nonauthoritative,
++    ):
++        try:
++            require_task019_live_contract_without_mutants(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("source scanner accepted a dead TASK-019 call")
++
++
++def require_task019_recovery_flow(recover: str) -> None:
++    parsed_root, parsed, parse_arguments = require_task019_result_binding(
++        recover,
++        "parse_authority_root_candidate",
++        "candidate",
++        "DurableJournal recovery",
++    )
++    if len(parse_arguments) < 2:
++        raise AssertionError("DurableJournal recovery omits replay history")
++    minted = require_mint_published_return(
++        recover,
++        parse_arguments[1],
++        f"*{parsed}.candidate",
++        "DurableJournal recovery",
++    )
++    root_read = recover.find("read_root(")
++    journal_read = recover.find("read_journal(")
++    if (
++        min(root_read, journal_read) < 0
++        or not root_read < journal_read < parsed_root < minted
++    ):
++        raise AssertionError("DurableJournal recovery does not bind root-first replay")
++
++
++def require_task019_append_flow(append: str) -> None:
++    advanced, history_result, _ = require_task019_result_binding(
++        append,
++        "advance_history",
++        "history",
++        "DurableJournal append",
++        "verifier",
++    )
++    sealed, root_result, _ = require_task019_result_binding(
++        append,
++        "seal_authority_root_candidate",
++        "candidate",
++        "DurableJournal append",
++    )
++    journal_append = append.find("append_journal(")
++    root_replace = require_root_replacement_binding(
++        append, root_result, "DurableJournal append"
++    )
++    minted = require_mint_published_return(
++        append,
++        f"*{history_result}.history",
++        f"*{root_result}.candidate",
++        "DurableJournal append",
++    )
++    if (
++        min(journal_append, root_replace) < 0
++        or not advanced < journal_append < sealed < root_replace < minted
++    ):
++        raise AssertionError("DurableJournal append bypasses TASK-019 ordering")
++
++
++def require_task019_create_flow(create: str) -> None:
++    history, history_result, _ = require_task019_result_binding(
++        create,
++        "begin_history",
++        "history",
++        "DurableJournal create",
++        "verifier",
++    )
++    root, root_result, _ = require_task019_result_binding(
++        create,
++        "seal_authority_root_candidate",
++        "candidate",
++        "DurableJournal create",
++    )
++    journal_create = create.find("create_journal(")
++    root_replace = require_root_replacement_binding(
++        create, root_result, "DurableJournal create"
++    )
++    minted = require_mint_published_return(
++        create,
++        f"*{history_result}.history",
++        f"*{root_result}.candidate",
++        "DurableJournal create",
++    )
++    if (
++        min(journal_create, root_replace) < 0
++        or not history < root < journal_create < root_replace < minted
++    ):
++        raise AssertionError("DurableJournal create bypasses TASK-019 ordering")
++
++
++def require_direct_or_unique_helper(
++    source: str,
++    entry: str,
++    flow_validator,
++) -> None:
++    public_bodies = qualified_function_bodies(source, "DurableJournal", entry)
++    if len(public_bodies) != 1:
++        raise AssertionError("DurableJournal live TASK-019 entry shape drifted")
++    public_body = public_bodies[0]
++    try:
++        flow_validator(public_body)
++        return
++    except AssertionError:
++        pass
++
++    delegation = re.fullmatch(
++        r"\s*return\s+"
++        r"(?:(?:[A-Za-z_]\w*)\s*(?:::|->|\.)\s*)*"
++        r"(?P<helper>[A-Za-z_]\w*)\s*\([^;{}]*\)\s*;\s*",
++        public_body,
++    )
++    if delegation is None:
++        raise AssertionError("DurableJournal entry is not a thin private delegation")
++    helper = delegation.group("helper")
++    if helper in {"create_new", "recover_existing", "append_and_publish"}:
++        raise AssertionError("DurableJournal helper is not uniquely named")
++    helper_bodies = function_bodies(source, helper)
++    if len(helper_bodies) != 1:
++        raise AssertionError("DurableJournal private helper is not unique")
++    flow_validator(helper_bodies[0])
++
++
++def require_task019_live_contract_without_mutants(source: str) -> None:
++    require_mint_published_definition(source)
++    require_direct_or_unique_helper(
++        source, "recover_existing", require_task019_recovery_flow
++    )
++    require_direct_or_unique_helper(
++        source, "append_and_publish", require_task019_append_flow
++    )
++    require_direct_or_unique_helper(source, "create_new", require_task019_create_flow)
++
++
++def require_compaction_prefix_binding(source: str) -> None:
++    public_bodies = qualified_function_bodies(
++        source, "DurableJournal", "compact_physical"
++    )
++    if len(public_bodies) != 1:
++        raise AssertionError("DurableJournal compaction entry shape drifted")
++    public = public_bodies[0]
++    try:
++        require_owned_compaction_prefix_flow(public)
++    except AssertionError:
++        delegation = re.fullmatch(
++            r"\s*return\s+(?P<helper>[A-Za-z_]\w*)\s*"
++            r"\(\s*std::move\s*\(\s*(?P<authority>[A-Za-z_]\w*)\s*\)\s*\)"
++            r"\s*;\s*",
++            public,
++        )
++        if delegation is None:
++            raise AssertionError("DurableJournal compaction is not a thin delegation")
++        helper = delegation.group("helper")
++        helper_bodies = function_bodies(source, helper)
++        if len(helper_bodies) != 1:
++            raise AssertionError("DurableJournal compaction helper is not unique")
++        require_owned_compaction_prefix_flow(helper_bodies[0])
++
++    control = """
++DurableJournalResult DurableJournal::compact_physical(
++    PublishedJournal &&authority) {
++    return compact_owned_prefix(std::move(authority));
++}
++DurableJournalResult compact_owned_prefix(PublishedJournal &&authority) {
++    return replace_journal(authority.impl_->committed_prefix_bytes);
++}
++"""
++    if source != control:
++        require_compaction_prefix_binding(control)
++    mutant = """
++DurableJournalResult DurableJournal::compact_physical(
++    PublishedJournal &&authority) {
++    std::string committed_prefix_bytes;
++    for (const auto &record : authority.impl_->history.records()) {
++        committed_prefix_bytes += record.canonical_bytes();
++        committed_prefix_bytes.push_back('\n');
++    }
++    return replace_journal(committed_prefix_bytes);
++}
++"""
++    if source != mutant:
++        try:
++            require_compaction_prefix_binding(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("compaction scanner accepted record reserialization")
++    transformed_prefix_mutant = """
++DurableJournalResult DurableJournal::compact_physical(
++    PublishedJournal &&authority) {
++    return replace_journal(
++        rebuild_from_records(authority.impl_->committed_prefix_bytes));
++}
++"""
++    if source != transformed_prefix_mutant:
++        try:
++            require_compaction_prefix_binding(transformed_prefix_mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("compaction scanner accepted a transformed prefix")
++
++
++def require_directory_lineage_fence_registry_without_mutants(source: str) -> None:
++    if (
++        re.search(
++            r"\bstd::unordered_map\s*<\s*std::string\s*,\s*"
++            r"IdentityFenceToken\s*>\s*"
++            r"fenced_identities\s*;",
++            source,
++        )
++        is None
++    ):
++        raise AssertionError("process fence registry does not retain lineage state")
++
++    for function in ("fence_identity", "identity_fence", "clear_identity_fence"):
++        bodies = function_bodies(source, function)
++        if len(bodies) != 1:
++            raise AssertionError(f"process fence {function} definition drifted")
++        if "directory_identity(identity)" not in compact_cpp(bodies[0]):
++            raise AssertionError(f"process fence {function} is not lineage keyed")
++
++    fence_body = compact_cpp(function_bodies(source, "fence_identity")[0])
++    if (
++        "insert_or_assign(std::string(directory_identity(identity)),token)"
++        not in fence_body
++    ):
++        raise AssertionError("process fence does not retain the lineage epoch")
++
++
++def require_directory_lineage_fence_registry(source: str) -> None:
++    require_directory_lineage_fence_registry_without_mutants(source)
++    for function in ("fence_identity", "identity_fence", "clear_identity_fence"):
++        mutant = replace_unique_function_body(
++            source,
++            function,
++            lambda body: body.replace("directory_identity(identity)", "identity", 1),
++        )
++        try:
++            require_directory_lineage_fence_registry_without_mutants(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError(
++                f"process fence accepted full-identity {function} lookup"
++            )
++
++
++def require_final_authority_revalidation_without_mutants(source: str) -> None:
++    definitions = tuple(
++        re.finditer(
++            r"\bbool\s+revalidate_authority\s*" r"\((?P<parameters>[^;{}]*)\)\s*\{",
++            source,
++        )
++    )
++    bodies = bool_function_bodies(source, "revalidate_authority")
++    if len(definitions) != 1 or len(bodies) != 1:
++        raise AssertionError("final authority revalidation helper drifted")
++
++    parameters = split_cpp_arguments(definitions[0].group("parameters"))
++    if len(parameters) != 6:
++        raise AssertionError("final authority revalidation signature drifted")
++    parameter_patterns = (
++        r"std::string_view\s+(?P<name>[A-Za-z_]\w*)",
++        r"std::string_view\s+(?P<name>[A-Za-z_]\w*)",
++        r"std::string_view\s+(?P<name>[A-Za-z_]\w*)",
++        r"bool\s+(?P<name>[A-Za-z_]\w*)",
++        r"bool\s+(?P<name>[A-Za-z_]\w*)",
++        r"std::size_t\s+(?P<name>[A-Za-z_]\w*)",
++    )
++    parameter_names: list[str] = []
++    for parameter, pattern in zip(parameters, parameter_patterns, strict=True):
++        match = re.fullmatch(pattern, parameter.strip())
++        if match is None:
++            raise AssertionError("final authority revalidation signature drifted")
++        parameter_names.append(match.group("name"))
++    (
++        expected_identity,
++        expected_root,
++        expected_journal,
++        expected_journal_stage,
++        expected_root_stage,
++        journal_read_limit,
++    ) = parameter_names
++
++    body = bodies[0]
++    branches = fail_closed_if_branches(body)
++    if not any(
++        compact_cpp(condition) == "!lock_held"
++        and compact_cpp(statement) == "returnfalse;"
++        for condition, statement in branches
++    ):
++        raise AssertionError("final authority revalidation is not lock-bound")
++
++    def assigned_member_call(call: str) -> tuple[str, int]:
++        matches = tuple(
++            re.finditer(
++                r"\b(?:const\s+)?auto\s+(?P<result>[A-Za-z_]\w*)\s*=\s*"
++                rf"(?:[A-Za-z_]\w*\s*(?:->|\.)\s*)?{re.escape(call)}\s*\(",
++                body,
++            )
++        )
++        if len(matches) != 1:
++            raise AssertionError(
++                f"final authority revalidation does not call {call} exactly once"
++            )
++        return matches[0].group("result"), matches[0].start()
++
++    identity, identity_position = assigned_member_call("authority_identity")
++    fixed, fixed_position = assigned_member_call("inspect_fixed_namespace")
++    root, root_position = assigned_member_call("read_root")
++    journal, journal_position = assigned_member_call("read_journal")
++    if not identity_position < fixed_position < root_position < journal_position:
++        raise AssertionError("final authority revalidation order drifted")
++
++    root_arguments = call_argument_lists(body, "read_root")
++    journal_arguments = call_argument_lists(body, "read_journal")
++    if (
++        len(root_arguments) != 1
++        or len(root_arguments[0]) != 1
++        or normalized_cpp_expression(root_arguments[0][0]) != "max_journal_input_bytes"
++        or len(journal_arguments) != 1
++        or len(journal_arguments[0]) != 1
++        or normalized_cpp_expression(journal_arguments[0][0]) != journal_read_limit
++    ):
++        raise AssertionError("final authority revalidation read bounds drifted")
++
++    required_failure_predicates = (
++        (
++            identity_position,
++            (
++                f"!{identity}.result.succeeded()||"
++                f"{identity}.identity!={expected_identity}"
++            ),
++            "composite identity",
++        ),
++        (
++            fixed_position,
++            (
++                f"!{fixed}.result.succeeded()||"
++                f"!{fixed}.journal_present||"
++                f"!{fixed}.root_present||"
++                f"!{fixed}.lock_present||"
++                f"{fixed}.journal_stage_present!={expected_journal_stage}||"
++                f"{fixed}.root_stage_present!={expected_root_stage}"
++            ),
++            "fixed namespace",
++        ),
++        (
++            root_position,
++            (
++                f"!{root}.result.succeeded()||{root}.truncated||"
++                f"{root}.bytes!={expected_root}"
++            ),
++            "authority root",
++        ),
++    )
++    for position, expected_condition, label in required_failure_predicates:
++        if not any(
++            compact_cpp(condition) == expected_condition
++            and compact_cpp(statement) == "returnfalse;"
++            for condition, statement in fail_closed_if_branches(body[position:])
++        ):
++            raise AssertionError(f"final authority revalidation does not bind {label}")
++
++    final_returns = re.findall(
++        r"\breturn\b(?P<value>[^;]*);", body[journal_position:], re.DOTALL
++    )
++    expected_return = (
++        f"{journal}.result.succeeded()&&!{journal}.truncated&&"
++        f"{journal}.bytes=={expected_journal}"
++    )
++    if (
++        len(final_returns) != 1
++        or normalized_cpp_expression(final_returns[0]) != expected_return
++    ):
++        raise AssertionError("final authority revalidation does not bind journal bytes")
++
++    flow_contracts = {
++        "create_new": (
++            (
++                "identity",
++                "root_result.candidate->canonical_bytes()",
++                "framed",
++                "false",
++                "false",
++                "journal_read_limit",
++            ),
++            ("create_journal", "replace_root"),
++        ),
++        "recover_existing": (
++            (
++                "identity",
++                "parsed.candidate->canonical_bytes()",
++                "replay.persistence.committed_prefix_bytes",
++                "fixed.journal_stage_present",
++                "fixed.root_stage_present",
++                "journal_read_limit",
++            ),
++            ("read_root", "read_journal", "truncate_journal"),
++        ),
++        "append_and_publish": (
++            (
++                "identity",
++                "root_result.candidate->canonical_bytes()",
++                "expected_journal",
++                "authority_state->journal_stage_present",
++                "false",
++                "journal_read_limit",
++            ),
++            ("append_journal", "replace_root"),
++        ),
++        "compact_physical": (
++            (
++                "identity",
++                "authority_state->root.canonical_bytes()",
++                "authority_state->committed_prefix_bytes",
++                "false",
++                "authority_state->root_stage_present",
++                "journal_read_limit",
++            ),
++            ("replace_journal",),
++        ),
++    }
++    for entry, (expected_arguments, predecessors) in flow_contracts.items():
++        public_bodies = qualified_function_bodies(source, "DurableJournal", entry)
++        if len(public_bodies) != 1:
++            raise AssertionError(f"DurableJournal {entry} entry shape drifted")
++        flow = public_bodies[0]
++        revalidation_arguments = call_argument_lists(flow, "revalidate_authority")
++        if len(revalidation_arguments) != 1:
++            raise AssertionError(
++                f"DurableJournal {entry} omits final authority revalidation"
++            )
++        observed_arguments = tuple(
++            normalized_cpp_expression(argument)
++            for argument in revalidation_arguments[0]
++        )
++        if observed_arguments != expected_arguments:
++            raise AssertionError(
++                f"DurableJournal {entry} revalidates stale authority state"
++            )
++        revalidation_position = flow.find("revalidate_authority(")
++        mint_position = flow.find("mint_published(")
++        predecessor_positions = tuple(flow.find(f"{call}(") for call in predecessors)
++        if (
++            min(predecessor_positions) < 0
++            or mint_position < 0
++            or not max(predecessor_positions) < revalidation_position < mint_position
++        ):
++            raise AssertionError(
++                f"DurableJournal {entry} final revalidation order drifted"
++            )
++        if not any(
++            "!impl_->revalidate_authority(" in compact_cpp(condition)
++            and branch_returns_non_success(statement)
++            for condition, statement in fail_closed_if_branches(flow)
++        ):
++            raise AssertionError(
++                f"DurableJournal {entry} ignores final revalidation failure"
++            )
++
++
++def require_final_authority_revalidation(source: str) -> None:
++    require_final_authority_revalidation_without_mutants(source)
++    bypass_mutant = replace_unique_bool_function_body(
++        source, "revalidate_authority", lambda _body: " return true; "
++    )
++    try:
++        require_final_authority_revalidation_without_mutants(bypass_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError(
++            "final authority scanner accepted an unconditional success helper"
++        )
++    helper_mutations = (
++        (
++            "unlocked",
++            lambda body: body.replace("if (!lock_held)", "if (false)", 1),
++        ),
++        (
++            "identity-blind",
++            lambda body: body.replace(
++                "identity.identity != expected_identity", "false", 1
++            ),
++        ),
++        (
++            "stage-blind",
++            lambda body: body.replace(
++                "fixed.journal_stage_present != expected_journal_stage",
++                "false",
++                1,
++            ),
++        ),
++        (
++            "root-blind",
++            lambda body: body.replace("root.bytes != expected_root", "false", 1),
++        ),
++        (
++            "dead-root-check",
++            lambda body: body.replace(
++                "root.bytes != expected_root",
++                "(false && root.bytes != expected_root)",
++                1,
++            ),
++        ),
++        (
++            "journal-blind",
++            lambda body: body.replace("journal.bytes == expected_journal", "true", 1),
++        ),
++        (
++            "inflated-read",
++            lambda body: body.replace(
++                "read_journal(journal_read_limit)",
++                "read_journal(max_journal_input_bytes)",
++                1,
++            ),
++        ),
++    )
++    for label, transform in helper_mutations:
++        mutant = replace_unique_bool_function_body(
++            source, "revalidate_authority", transform
++        )
++        try:
++            require_final_authority_revalidation_without_mutants(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError(f"final authority scanner accepted its {label} mutant")
++    for entry in (
++        "create_new",
++        "recover_existing",
++        "append_and_publish",
++        "compact_physical",
++    ):
++        bypassed_flow = replace_unique_function_body(
++            source,
++            entry,
++            lambda body: body.replace(
++                "!impl_->revalidate_authority(",
++                "false && impl_->revalidate_authority(",
++                1,
++            ),
++        )
++        try:
++            require_final_authority_revalidation_without_mutants(bypassed_flow)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError(
++                f"final authority scanner accepted a bypassed {entry} check"
++            )
++
++
++def require_owned_compaction_prefix_flow(body: str) -> None:
++    calls = call_argument_lists(body, "replace_journal")
++    if len(calls) != 1 or len(calls[0]) != 1:
++        raise AssertionError("compaction does not replace the journal once")
++    argument = normalized_cpp_expression(calls[0][0])
++    string_copy = re.fullmatch(r"std::string\((?P<argument>.*)\)", argument)
++    if string_copy is not None:
++        argument = string_copy.group("argument")
++    owned_prefix = re.fullmatch(
++        r"(?:authority|published|token)[A-Za-z_0-9]*"
++        r"(?:(?:\.|->)[A-Za-z_]\w*)*"
++        r"(?:\.|->)(?:committed_prefix_bytes|authorized_prefix_bytes|"
++        r"committed_prefix|authorized_prefix)",
++        argument,
++    )
++    if owned_prefix is None:
++        raise AssertionError("compaction does not pass the exact owned prefix")
++
++
++def require_tokens(source: str, tokens: tuple[str, ...], label: str) -> None:
++    missing = [token for token in tokens if token not in source]
++    if missing:
++        raise AssertionError(f"{label} omitted {missing}")
++
++
++def require_absent_tokens(source: str, tokens: tuple[str, ...], label: str) -> None:
++    present = [token for token in tokens if token in source]
++    if present:
++        raise AssertionError(f"{label} uses forbidden {present}")
++
++
++def require_build_contract() -> None:
++    windows_root = PureWindowsPath("D:/a/lemonade/lemonade")
++    windows_runner = windows_root / (
++        "test/residency/recovery/test_durable_journal_public_seam.py"
++    )
++    expected_runner = "test/residency/recovery/test_durable_journal_public_seam.py"
++    if cmake_relative_path(windows_runner, windows_root) != expected_runner:
++        raise AssertionError("CMake runner path is host-dependent")
++    if str(windows_runner.relative_to(windows_root)) == expected_runner:
++        raise AssertionError("CMake Windows-path control is ineffective")
++
++    cmake = CMAKE.read_text(encoding="utf-8")
++    cmake_code = strip_cmake_comments(cmake)
++    require_tokens(
++        cmake_code,
++        (
++            "test_durable_residency_journal",
++            "ResidencyDurableJournal",
++            "add_cpp_ci_test",
++            "durable_file_adapter_posix.cpp",
++            "durable_file_adapter_windows.cpp",
++            "durable_file_adapter_macos.cpp",
++            TESTING_DEFINITION,
++        ),
++        "CMake durable-journal test contract",
++    )
++    block_start = cmake_code.find("test_durable_residency_journal")
++    block = cmake_code[max(0, block_start - 1500) : block_start + 5000]
++    if "BUILD_TESTING" not in block or "CI ON" not in block:
++        raise AssertionError("durable journal C++ seam is not an explicit CI test")
++    if not any(token in block for token in ("WIN32", "APPLE", "UNIX")):
++        raise AssertionError("durable journal adapters are not platform-selected")
++    testing_definition = re.compile(
++        rf"target_compile_definitions\s*\(\s*test_durable_residency_journal\s+PRIVATE\s+{TESTING_DEFINITION}\s*\)",
++        re.DOTALL,
++    )
++    if testing_definition.search(block) is None:
++        raise AssertionError("durable test injection is not target-confined")
++    if cmake_code.count(TESTING_DEFINITION) != 1:
++        raise AssertionError("durable test injection escaped its one test target")
++    quoted_hash_control = """
++if(TRUE)
++    set(version_pattern "^#define CLI11_VERSION ")
++endif()
++# if(FALSE)
++#     add_executable(test_durable_residency_journal narrated.cpp)
++# endif()
++"""
++    stripped_hash_control = strip_cmake_comments_preserve_arguments(quoted_hash_control)
++    if (
++        '"^#define CLI11_VERSION "' not in stripped_hash_control
++        or len(cmake_command_spans(stripped_hash_control, "if")) != 1
++        or len(cmake_command_spans(stripped_hash_control, "endif")) != 1
++        or cmake_command_spans(stripped_hash_control, "add_executable")
++    ):
++        raise AssertionError("CMake quoted hashes and comments are misclassified")
++    require_durable_target_sources(cmake)
++    require_private_authority_gate_contract(cmake)
++    require_durable_cmake_invocation(cmake)
++
++    private_gate_control = """
++if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/residency/recovery/durable_journal_public_seam.cpp")
++add_library(test_durable_residency_private_authority_gate OBJECT
++    test/residency/recovery/durable_journal_private_authority_gate.cpp
++)
++target_include_directories(test_durable_residency_private_authority_gate PRIVATE
++    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
++    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/residency
++)
++add_dependencies(test_durable_residency_journal
++        test_durable_residency_private_authority_gate
++)
++add_cpp_ci_test(
++        ResidencyDurableJournal
++)
++endif()
++"""
++    require_private_authority_gate_contract(private_gate_control)
++    private_gate_mutants = (
++        private_gate_control.replace(" OBJECT\n", " STATIC\n"),
++        private_gate_control.replace(
++            "test_durable_residency_private_authority_gate\n)\nadd_cpp_ci_test",
++            "unrelated_gate\n)\nadd_cpp_ci_test",
++        ),
++        private_gate_control.replace(
++            "add_dependencies(test_durable_residency_journal",
++            "target_compile_definitions("
++            "test_durable_residency_private_authority_gate PRIVATE "
++            f"{TESTING_DEFINITION})\n"
++            "add_dependencies(test_durable_residency_journal",
++        ),
++        private_gate_control.replace("BUILD_TESTING AND EXISTS", "FALSE AND EXISTS", 1),
++        private_gate_control.replace(
++            "BUILD_TESTING AND EXISTS",
++            "BUILD_TESTING AND TASK020_GATE_DISABLED AND EXISTS",
++        ),
++        "function(task020_disabled)\n" + private_gate_control + "\nendfunction()\n",
++        "return()\n" + private_gate_control,
++        "FUNCTION(task020_disabled)\n" + private_gate_control + "\nENDFUNCTION()\n",
++        "RETURN()\n" + private_gate_control,
++    )
++    for mutant in private_gate_mutants:
++        try:
++            require_private_authority_gate_contract(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("private-authority build-gate mutant was accepted")
++
++    workflow = WORKFLOW.read_text(encoding="utf-8")
++    windows_job_source = extract_yaml_job(
++        workflow,
++        "build-lemonade-server-installer",
++        "build-lemonade-desktop-installer",
++    )
++    build_command = re.compile(
++        r"(?m)^\s*cmake\s+--build\s+build\s+--config\s+Release\s+--target\s+test_durable_residency_journal\s*$"
++    )
++    test_command = re.compile(
++        r'(?m)^\s*ctest\s+--test-dir\s+build\s+-C\s+Release\s+--no-tests=error\s+--output-on-failure\s+-R\s+"\^ResidencyDurableJournal\$"\s*$'
++    )
++    require_live_windows_workflow_commands(
++        windows_job_source, build_command, test_command
++    )
++    failure_propagation_control = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Durable build
++        shell: pwsh
++        run: |
++          $ErrorActionPreference = "Stop"
++          if (-not (Test-Path build)) { throw "build directory missing" }
++          cmake --build build --config Release --target test_durable_residency_journal
++          if ($LASTEXITCODE -ne 0) {
++            exit $LASTEXITCODE
++          }
++      - name: Durable test
++        shell: PowerShell
++        run: |
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++          $testExitCode = $LASTEXITCODE
++          if ($testExitCode -ne 0) {
++            exit $testExitCode
++          }
++"""
++    require_live_windows_workflow_commands(
++        failure_propagation_control, build_command, test_command
++    )
++
++    cmake_narration = """
++# test_durable_residency_journal ResidencyDurableJournal add_cpp_ci_test CI ON LEMONADE_RESIDENCY_DURABLE_TESTING
++message("durable_file_adapter_windows.cpp durable_file_adapter_macos.cpp")
++#[[
++test_durable_residency_journal ResidencyDurableJournal add_cpp_ci_test CI ON
++durable_file_adapter_posix.cpp durable_file_adapter_windows.cpp durable_file_adapter_macos.cpp
++]]
++set(narrated [[
++test_durable_residency_journal ResidencyDurableJournal add_cpp_ci_test CI ON
++durable_file_adapter_posix.cpp durable_file_adapter_windows.cpp durable_file_adapter_macos.cpp
++]])
++"""
++    stripped_cmake_narration = strip_cmake_comments(cmake_narration)
++    if any(
++        token in stripped_cmake_narration
++        for token in (
++            "ResidencyDurableJournal",
++            "test_durable_residency_journal",
++            "durable_file_adapter_windows.cpp",
++        )
++    ):
++        raise AssertionError("CMake scanner accepted narrated test wiring")
++    yaml_narration = """
++# test_durable_residency_journal ctest \"^ResidencyDurableJournal$\"
++name: "test_durable_residency_journal ctest ^ResidencyDurableJournal$"
++run: echo "cmake --build build --config Release --target test_durable_residency_journal ctest --test-dir build -C Release --no-tests=error --output-on-failure -R ^ResidencyDurableJournal$"
++run: |
++  Write-Host 'cmake --build build --config Release --target test_durable_residency_journal'
++  Write-Host 'ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"'
++env:
++  NARRATION: |
++    cmake --build build --config Release --target test_durable_residency_journal
++    ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++run: |
++  $narration = @'
++  cmake --build build --config Release --target test_durable_residency_journal
++  ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++  '@
++  cat <<'TASK020'
++  cmake --build build --config Release --target test_durable_residency_journal
++  ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++  TASK020
++"""
++    stripped_narration = strip_shell_heredocs(extract_yaml_run_bodies(yaml_narration))
++    if build_command.search(stripped_narration) or test_command.search(
++        stripped_narration
++    ):
++        raise AssertionError("workflow scanner accepted narrated test wiring")
++    skipped_step_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Narrated durable test
++        if: ${{ false }}
++        continue-on-error: true
++        run: |
++          cmake --build build --config Release --target test_durable_residency_journal
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++"""
++    disabled_job_mutant = r"""
++  build-lemonade-server-installer:
++    if: ${{ false }}
++    continue-on-error: true
++    runs-on: windows-latest
++    steps:
++      - name: Durable test
++        run: |
++          cmake --build build --config Release --target test_durable_residency_journal
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++"""
++    guarded_commands_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Guarded durable test
++        run: |
++          if ($false) {
++            cmake --build build --config Release --target test_durable_residency_journal
++            ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++          }
++"""
++    early_control_transfer_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Bypassed durable build
++        run: |
++          exit 0
++          cmake --build build --config Release --target test_durable_residency_journal
++      - name: Bypassed durable test
++        run: |
++          return
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++"""
++    conditional_control_transfer_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Bypassed durable build
++        run: |
++          if ($true) { return; }
++          cmake --build build --config Release --target test_durable_residency_journal
++          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
++      - name: Bypassed durable test
++        run: |
++          if ($true) { return; }
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
++"""
++    linux_runner_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: ubuntu-latest
++    steps:
++      - name: Durable build
++        run: |
++          cmake --build build --config Release --target test_durable_residency_journal
++      - name: Durable test
++        run: |
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++"""
++    missing_no_tests_error_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Durable build
++        run: |
++          cmake --build build --config Release --target test_durable_residency_journal
++      - name: Durable test
++        run: |
++          ctest --test-dir build -C Release --output-on-failure -R "^ResidencyDurableJournal$"
++"""
++    missing_exit_propagation_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Durable build
++        shell: PowerShell
++        run: |
++          cmake --build build --config Release --target test_durable_residency_journal
++      - name: Durable test
++        shell: PowerShell
++        run: |
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++"""
++    dead_exit_propagation_mutant = r"""
++  build-lemonade-server-installer:
++    runs-on: windows-latest
++    steps:
++      - name: Durable build
++        shell: PowerShell
++        run: |
++          cmake --build build --config Release --target test_durable_residency_journal
++          if ($false) {
++            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
++          }
++      - name: Durable test
++        shell: PowerShell
++        run: |
++          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
++          if ($false) {
++            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
++          }
++"""
++    for mutant in (
++        skipped_step_mutant,
++        disabled_job_mutant,
++        guarded_commands_mutant,
++        early_control_transfer_mutant,
++        conditional_control_transfer_mutant,
++        linux_runner_mutant,
++        missing_no_tests_error_mutant,
++        missing_exit_propagation_mutant,
++        dead_exit_propagation_mutant,
++    ):
++        try:
++            require_live_windows_workflow_commands(mutant, build_command, test_command)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("workflow scanner accepted a disabled durable test")
++    commented_job_mutant = """
++#   build-lemonade-server-installer:
++#     run: cmake --build build --config Release --target test_durable_residency_journal
++  build-lemonade-desktop-installer:
++    runs-on: windows-latest
++"""
++    try:
++        extract_yaml_job(
++            commented_job_mutant,
++            "build-lemonade-server-installer",
++            "build-lemonade-desktop-installer",
++        )
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("workflow scanner accepted a commented job")
++
++    direct_binary_mutant = """
++if(BUILD_TESTING)
++    add_executable(test_durable_residency_journal fixture.cpp)
++    add_cpp_ci_test(
++        ResidencyDurableJournal
++        CI ON
++        COMMAND test_durable_residency_journal
++        DEPENDS test_durable_residency_journal)
++endif()
++"""
++    incomplete_wrapper_mutant = f"""
++if(BUILD_TESTING)
++    add_executable(test_durable_residency_journal fixture.cpp)
++    add_cpp_ci_test(
++        ResidencyDurableJournal
++        CI ON
++        COMMAND ${{Python3_EXECUTABLE}} {RUNNER}
++            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
++        DEPENDS test_durable_residency_journal)
++endif()
++"""
++    inert_command_prefix_mutant = f"""
++if(BUILD_TESTING)
++    add_executable(test_durable_residency_journal fixture.cpp)
++    add_cpp_ci_test(
++        ResidencyDurableJournal
++        CI ON
++        COMMAND ${{CMAKE_COMMAND}} -E echo
++            ${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)}
++            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
++            --compiler ${{CMAKE_CXX_COMPILER}}
++        DEPENDS test_durable_residency_journal)
++endif()
++"""
++    inactive_enclosure_mutant = f"""
++if(BUILD_TESTING AND FALSE)
++    add_executable(test_durable_residency_journal fixture.cpp)
++    add_cpp_ci_test(
++        ResidencyDurableJournal
++        CI ON
++        COMMAND ${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)}
++            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
++            --compiler ${{CMAKE_CXX_COMPILER}}
++        DEPENDS test_durable_residency_journal)
++endif()
++"""
++    masked_test_mutant = f"""
++if(BUILD_TESTING)
++    add_executable(test_durable_residency_journal fixture.cpp)
++    add_cpp_ci_test(
++        ResidencyDurableJournal
++        CI ON
++        COMMAND ${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)}
++            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
++            --compiler ${{CMAKE_CXX_COMPILER}}
++        DEPENDS test_durable_residency_journal)
++    set_tests_properties(ResidencyDurableJournal PROPERTIES DISABLED TRUE)
++endif()
++"""
++    for mutant in (
++        direct_binary_mutant,
++        incomplete_wrapper_mutant,
++        inert_command_prefix_mutant,
++        inactive_enclosure_mutant,
++        masked_test_mutant,
++    ):
++        try:
++            require_durable_cmake_invocation(mutant)
++        except AssertionError:
++            pass
++        else:
++            raise AssertionError("CTest can bypass the frozen Python race wrapper")
++    target_source_control = """
++if(WIN32)
++    set(_TASK020_PLATFORM_SOURCE
++        src/cpp/server/residency/durable_file_adapter_windows.cpp)
++elseif(APPLE)
++    set(_TASK020_PLATFORM_SOURCE
++        src/cpp/server/residency/durable_file_adapter_macos.cpp)
++else()
++    set(_TASK020_PLATFORM_SOURCE
++        src/cpp/server/residency/durable_file_adapter_posix.cpp)
++endif()
++add_executable(test_durable_residency_journal
++    test/residency/recovery/durable_journal_public_seam.cpp
++    test/residency/recovery/journal_persistence_test_support.cpp
++    src/cpp/server/residency/durable_journal.cpp
++    src/cpp/server/residency/durable_file_adapter_common.cpp
++    src/cpp/server/residency/journal.cpp
++    ${_TASK020_PLATFORM_SOURCE})
++target_include_directories(test_durable_residency_journal PRIVATE src/cpp/include)
++target_link_libraries(test_durable_residency_journal PRIVATE lemonade-digest-crypto)
++target_compile_definitions(test_durable_residency_journal PRIVATE
++    LEMONADE_RESIDENCY_DURABLE_TESTING)
++"""
++    require_durable_target_sources(target_source_control)
++    unconditional_platform_mutant = re.sub(
++        r"if\(WIN32\).*?endif\(\)",
++        """set(_TASK020_PLATFORM_SOURCE
++    src/cpp/server/residency/durable_file_adapter_windows.cpp)
++set(_TASK020_PLATFORM_SOURCE
++    src/cpp/server/residency/durable_file_adapter_macos.cpp)
++set(_TASK020_PLATFORM_SOURCE
++    src/cpp/server/residency/durable_file_adapter_posix.cpp)""",
++        target_source_control,
++        count=1,
++        flags=re.DOTALL,
++    )
++    try:
++        require_durable_target_sources(unconditional_platform_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("CMake platform sources are selected sequentially")
++    dummy_target_mutant = target_source_control.replace(
++        "test/residency/recovery/durable_journal_public_seam.cpp",
++        "test/residency/recovery/fixture.cpp",
++    )
++    try:
++        require_durable_target_sources(dummy_target_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("CMake target bypassed the frozen semantic fixture")
++    narrated_wrapper_mutant = f"""
++message("add_cpp_ci_test(ResidencyDurableJournal CI ON COMMAND "
++        "${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)} "
++        "--existing-executable $<TARGET_FILE:test_durable_residency_journal> "
++        "--compiler ${{CMAKE_CXX_COMPILER}} DEPENDS "
++        "test_durable_residency_journal)")
++add_cpp_ci_test(
++    ResidencyDurableJournal
++    CI ON
++    COMMAND test_durable_residency_journal
++    DEPENDS test_durable_residency_journal)
++"""
++    try:
++        require_durable_cmake_invocation(narrated_wrapper_mutant)
++    except AssertionError:
++        pass
++    else:
++        raise AssertionError("CTest scanner accepted a narrated wrapper call")
++
++
++def cmake_tokens(body: str) -> tuple[str, ...]:
++    return tuple(
++        token[1:-1] if token[:1] == token[-1:] and token[:1] in {'"', "'"} else token
++        for token in re.findall(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\S+', body)
++    )
++
++
++def require_durable_target_sources(source: str) -> None:
++    code = strip_cmake_comments_preserve_arguments(source)
++    target_calls = [
++        body
++        for body in cmake_command_arguments(code, "add_executable")
++        if cmake_tokens(body)[:1] == ("test_durable_residency_journal",)
++    ]
++    if len(target_calls) != 1:
++        raise AssertionError("durable semantic executable target is unavailable")
++    arguments = cmake_tokens(target_calls[0])
++    required = {
++        "test/residency/recovery/durable_journal_public_seam.cpp",
++        "test/residency/recovery/journal_persistence_test_support.cpp",
++        "src/cpp/server/residency/durable_journal.cpp",
++        "src/cpp/server/residency/durable_file_adapter_common.cpp",
++        "src/cpp/server/residency/journal.cpp",
++    }
++    set_calls = [cmake_tokens(body) for body in cmake_command_arguments(code, "set")]
++    variables = {
++        match.group("name")
++        for argument in arguments
++        if (match := re.fullmatch(r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\}", argument))
++    }
++    conditional_events = sorted(
++        (
++            start,
++            command,
++            cmake_tokens(body),
++        )
++        for command in ("if", "elseif", "else", "endif", "set")
++        for body, start, _end in cmake_command_spans(code, command)
++    )
++    conditional_stack: list[tuple[int, str]] = []
++    branch_sequences: dict[int, list[str]] = {}
++    positioned_sets: list[tuple[tuple[str, ...], tuple[int, str] | None]] = []
++    next_chain = 0
++    for _position, command, tokens in conditional_events:
++        if command == "if":
++            branch = "".join(tokens).upper()
++            branch_sequences[next_chain] = [branch]
++            conditional_stack.append((next_chain, branch))
++            next_chain += 1
++        elif command == "elseif":
++            if not conditional_stack:
++                raise AssertionError("CMake platform selection is unbalanced")
++            chain, _previous = conditional_stack[-1]
++            branch = "".join(tokens).upper()
++            branch_sequences[chain].append(branch)
++            conditional_stack[-1] = (chain, branch)
++        elif command == "else":
++            if not conditional_stack:
++                raise AssertionError("CMake platform selection is unbalanced")
++            chain, _previous = conditional_stack[-1]
++            branch_sequences[chain].append("ELSE")
++            conditional_stack[-1] = (chain, "ELSE")
++        elif command == "endif":
++            if not conditional_stack:
++                raise AssertionError("CMake platform selection is unbalanced")
++            conditional_stack.pop()
++        else:
++            positioned_sets.append(
++                (tokens, conditional_stack[-1] if conditional_stack else None)
++            )
++    if conditional_stack:
++        raise AssertionError("CMake platform selection is unbalanced")
++
++    def repo_relative(token: str) -> str:
++        return re.sub(r"^\$\{CMAKE_CURRENT_SOURCE_DIR\}/", "", token)
++
++    resolved_arguments = {repo_relative(token) for token in arguments}
++    for variable in variables:
++        resolved_arguments.update(
++            repo_relative(token)
++            for tokens in set_calls
++            if tokens[:1] == (variable,)
++            for token in tokens[1:]
++        )
++    if not required.issubset(resolved_arguments) or any(
++        token.endswith(("fixture.cpp", "dummy.cpp")) for token in resolved_arguments
++    ):
++        raise AssertionError("durable semantic executable omits frozen sources")
++    selected: list[str] = []
++    platform_files = {
++        "durable_file_adapter_posix.cpp",
++        "durable_file_adapter_windows.cpp",
++        "durable_file_adapter_macos.cpp",
++    }
++    for variable in variables:
++        assignments = [tokens for tokens in set_calls if tokens[:1] == (variable,)]
++        values = {Path(token).name for tokens in assignments for token in tokens[1:]}
++        guarded_assignments = [
++            (tokens, context)
++            for tokens, context in positioned_sets
++            if tokens[:1] == (variable,)
++        ]
++        if len(guarded_assignments) != 3 or any(
++            context is None or len(tokens) != 2
++            for tokens, context in guarded_assignments
++        ):
++            continue
++        chains = {context[0] for _tokens, context in guarded_assignments}
++        if len(chains) != 1:
++            continue
++        branch_files = {
++            context[1]: Path(tokens[1]).name for tokens, context in guarded_assignments
++        }
++        posix_branch = "ELSE" if "ELSE" in branch_files else "UNIX"
++        chain = next(iter(chains))
++        if (
++            platform_files.issubset(values)
++            and branch_sequences[chain] == ["WIN32", "APPLE", posix_branch]
++            and branch_files
++            == {
++                "WIN32": "durable_file_adapter_windows.cpp",
++                "APPLE": "durable_file_adapter_macos.cpp",
++                posix_branch: "durable_file_adapter_posix.cpp",
++            }
++        ):
++            selected.append(variable)
++    if len(selected) != 1 or any(
++        Path(argument).name in platform_files for argument in arguments
++    ):
++        raise AssertionError("durable semantic target does not select one platform")
++    for command in (
++        "target_include_directories",
++        "target_link_libraries",
++        "target_compile_definitions",
++    ):
++        calls = [
++            body
++            for body in cmake_command_arguments(code, command)
++            if cmake_tokens(body)[:1] == ("test_durable_residency_journal",)
++        ]
++        if len(calls) != 1:
++            raise AssertionError(f"durable semantic target {command} drifted")
++
++
++def require_private_authority_gate_contract(source: str) -> None:
++    code = strip_cmake_comments_preserve_arguments(source)
++    target = "test_durable_residency_private_authority_gate"
++    expected_calls = {
++        "add_library": (
++            target,
++            "OBJECT",
++            "test/residency/recovery/durable_journal_private_authority_gate.cpp",
++        ),
++        "add_dependencies": (
++            "test_durable_residency_journal",
++            target,
++        ),
++    }
++    positions: dict[str, int] = {}
++    for command, expected in expected_calls.items():
++        matching = [
++            (cmake_tokens(body), start)
++            for body, start, _end in cmake_command_spans(code, command)
++            if target in cmake_tokens(body)
++        ]
++        if len(matching) != 1 or matching[0][0] != expected:
++            raise AssertionError("private-authority build gate is incomplete")
++        positions[command] = matching[0][1]
++        require_live_cmake_test_enclosure(code, matching[0][1])
++
++    if any(
++        cmake_tokens(body)[:1] == (target,) and TESTING_DEFINITION in cmake_tokens(body)
++        for body in cmake_command_arguments(code, "target_compile_definitions")
++    ):
++        raise AssertionError("private-authority gate gained test-only access")
++
++    invocations = [
++        start
++        for body, start, _end in cmake_command_spans(code, "add_cpp_ci_test")
++        if cmake_tokens(body)[:1] == ("ResidencyDurableJournal",)
++    ]
++    if len(invocations) != 1 or positions["add_dependencies"] >= invocations[0]:
++        raise AssertionError("private-authority gate is not a build prerequisite")
++
++
++def require_durable_cmake_invocation(source: str) -> None:
++    code = strip_cmake_comments_preserve_arguments(source)
++    matching_calls = [
++        (body, start)
++        for body, start, _end in cmake_command_spans(code, "add_cpp_ci_test")
++        if re.match(r"\s*ResidencyDurableJournal\b", body)
++    ]
++    if len(matching_calls) != 1:
++        raise AssertionError("durable CTest wrapper call is unavailable")
++    body, call_start = matching_calls[0]
++    arguments = cmake_tokens(body)
++    expected = (
++        "ResidencyDurableJournal",
++        "CI",
++        "ON",
++        "COMMAND",
++        "${Python3_EXECUTABLE}",
++        cmake_relative_path(RUNNER, REPO_ROOT),
++        "--existing-executable",
++        "$<TARGET_FILE:test_durable_residency_journal>",
++        "--compiler",
++        "${CMAKE_CXX_COMPILER}",
++        "--private-authority-gate",
++        "$<TARGET_OBJECTS:test_durable_residency_private_authority_gate>",
++        "DEPENDS",
++        "test_durable_residency_journal",
++    )
++    if arguments != expected:
++        raise AssertionError("durable CTest wrapper/race argv is incomplete")
++    require_live_cmake_test_enclosure(code, call_start)
++    require_unmasked_cmake_test(code, "ResidencyDurableJournal")
++
++
++def require_live_cmake_test_enclosure(source: str, call_start: int) -> None:
++    commands: list[tuple[int, str, str]] = []
++    for command in ("if", "elseif", "else", "endif"):
++        commands.extend(
++            (start, command, body)
++            for body, start, _end in cmake_command_spans(source, command)
++            if start < call_start
++        )
++    stack: list[str] = []
++    for _start, command, body in sorted(commands):
++        if command == "if":
++            stack.append(body)
++        elif command in ("elseif", "else"):
++            if not stack:
++                raise AssertionError("CMake conditional structure is unbalanced")
++            stack[-1] = "CONDITIONAL_BRANCH"
++        else:
++            if not stack:
++                raise AssertionError("CMake conditional structure is unbalanced")
++            stack.pop()
++    expected = (
++        "BUILD_TESTING",
++        "AND",
++        "EXISTS",
++        "${CMAKE_CURRENT_SOURCE_DIR}/test/residency/recovery/durable_journal_public_seam.cpp",
++    )
++    if len(stack) != 1 or cmake_tokens(stack[0]) != expected:
++        raise AssertionError("durable CTest does not have its exact live enclosure")
++    scope_pairs = {
++        "endfunction": "function",
++        "endmacro": "macro",
++        "endforeach": "foreach",
++        "endwhile": "while",
++    }
++    scope_commands: list[tuple[int, str]] = []
++    for command in (*scope_pairs.values(), *scope_pairs):
++        scope_commands.extend(
++            (start, command)
++            for _body, start, _end in cmake_command_spans(source, command)
++            if start < call_start
++        )
++    scope_stack: list[str] = []
++    for _start, command in sorted(scope_commands):
++        if command in scope_pairs.values():
++            scope_stack.append(command)
++        else:
++            if not scope_stack or scope_stack[-1] != scope_pairs[command]:
++                raise AssertionError("CMake executable scope is unbalanced")
++            scope_stack.pop()
++    if scope_stack:
++        raise AssertionError("durable CTest is not at global executable scope")
++    if any(
++        start < call_start
++        for _body, start, _end in cmake_command_spans(source, "return")
++    ):
++        raise AssertionError("durable CTest is unreachable after CMake return")
++
++
++def require_unmasked_cmake_test(source: str, test: str) -> None:
++    forbidden = {
++        "DISABLED",
++        "WILL_FAIL",
++        "SKIP_RETURN_CODE",
++        "PASS_REGULAR_EXPRESSION",
++        "SKIP_REGULAR_EXPRESSION",
++    }
++    for command in ("set_tests_properties", "set_property"):
++        for body in cmake_command_arguments(source, command):
++            tokens = {
++                token.strip("\"'").upper()
++                for token in re.findall(
++                    r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\S+', body
++                )
++            }
++            if test.upper() in tokens and tokens & forbidden:
++                raise AssertionError("durable CTest outcome is masked")
++
++
++def strip_cmake_comments(source: str) -> str:
++    without_bracket_comments = re.sub(
++        r"#\[(?P<comment_equals>=*)\[.*?\](?P=comment_equals)\]",
++        "",
++        source,
++        flags=re.DOTALL,
++    )
++    without_bracket_arguments = re.sub(
++        r"(?<!#)\[(?P<argument_equals>=*)\[.*?\](?P=argument_equals)\]",
++        "",
++        without_bracket_comments,
++        flags=re.DOTALL,
++    )
++    without_comments = re.sub(r"(?m)#.*$", "", without_bracket_arguments)
++    return re.sub(r'"(?:\\.|[^"\\])*"', "", without_comments)
++
++
++def strip_cmake_comments_preserve_arguments(source: str) -> str:
++    without_bracket_comments = re.sub(
++        r"#\[(?P<comment_equals>=*)\[.*?\](?P=comment_equals)\]",
++        "",
++        source,
++        flags=re.DOTALL,
++    )
++    without_bracket_arguments = re.sub(
++        r"(?<!#)\[(?P<argument_equals>=*)\[.*?\](?P=argument_equals)\]",
++        "",
++        without_bracket_comments,
++        flags=re.DOTALL,
++    )
++    stripped: list[str] = []
++    index = 0
++    quoted = False
++    escaped = False
++    while index < len(without_bracket_arguments):
++        character = without_bracket_arguments[index]
++        if quoted:
++            stripped.append(character)
++            if escaped:
++                escaped = False
++            elif character == "\\":
++                escaped = True
++            elif character == '"':
++                quoted = False
++            index += 1
++            continue
++        if character == '"':
++            quoted = True
++            stripped.append(character)
++            index += 1
++            continue
++        if character == "#":
++            while (
++                index < len(without_bracket_arguments)
++                and without_bracket_arguments[index] not in "\r\n"
++            ):
++                index += 1
++            continue
++        stripped.append(character)
++        index += 1
++    return "".join(stripped)
++
++
++def cmake_command_spans(source: str, command: str) -> list[tuple[str, int, int]]:
++    calls: list[tuple[str, int, int]] = []
++    folded_source = source.casefold()
++    folded_command = command.casefold()
++    index = 0
++    quoted = False
++    escaped = False
++    while index < len(source):
++        character = source[index]
++        if quoted:
++            if escaped:
++                escaped = False
++            elif character == "\\":
++                escaped = True
++            elif character == '"':
++                quoted = False
++            index += 1
++            continue
++        if character == '"':
++            quoted = True
++            index += 1
++            continue
++        if folded_source.startswith(folded_command, index):
++            before = source[index - 1] if index else ""
++            after_index = index + len(command)
++            after = source[after_index] if after_index < len(source) else ""
++            if (before and (before.isalnum() or before == "_")) or (
++                after and (after.isalnum() or after == "_")
++            ):
++                index += 1
++                continue
++            opening = after_index
++            while opening < len(source) and source[opening].isspace():
++                opening += 1
++            if opening >= len(source) or source[opening] != "(":
++                index += 1
++                continue
++            depth = 1
++            cursor = opening + 1
++            inner_quoted = False
++            inner_escaped = False
++            while cursor < len(source) and depth:
++                current = source[cursor]
++                if inner_quoted:
++                    if inner_escaped:
++                        inner_escaped = False
++                    elif current == "\\":
++                        inner_escaped = True
++                    elif current == '"':
++                        inner_quoted = False
++                elif current == '"':
++                    inner_quoted = True
++                elif current == "(":
++                    depth += 1
++                elif current == ")":
++                    depth -= 1
++                cursor += 1
++            if depth != 0:
++                raise AssertionError("CMake command has unbalanced arguments")
++            calls.append((source[opening + 1 : cursor - 1], index, cursor))
++            index = cursor
++            continue
++        index += 1
++    return calls
++
++
++def cmake_command_arguments(source: str, command: str) -> list[str]:
++    return [body for body, _start, _end in cmake_command_spans(source, command)]
++
++
++def extract_yaml_job(source: str, job: str, following_job: str) -> str:
++    job_matches = list(re.finditer(rf"(?m)^  {re.escape(job)}\s*:\s*(?:#.*)?$", source))
++    following_matches = list(
++        re.finditer(rf"(?m)^  {re.escape(following_job)}\s*:\s*(?:#.*)?$", source)
++    )
++    if len(job_matches) != 1 or len(following_matches) != 1:
++        raise AssertionError("Windows installer job is unavailable")
++    start = job_matches[0].start()
++    end = following_matches[0].start()
++    if end <= start:
++        raise AssertionError("Windows installer job order drifted")
++    return source[start:end]
++
++
++def extract_yaml_run_bodies(source: str) -> str:
++    lines = source.splitlines(keepends=True)
++    bodies: list[str] = []
++    index = 0
++    run_line = re.compile(
++        r"^(?P<indent>\s*)(?:-\s+)?run\s*:\s*(?P<value>.*?)(?:\r?\n)?$"
++    )
++    while index < len(lines):
++        match = run_line.match(lines[index])
++        if match is None:
++            index += 1
++            continue
++        value = match.group("value").strip()
++        if re.fullmatch(r"[|>][+-]?\d?", value):
++            base_indent = len(match.group("indent"))
++            index += 1
++            block: list[str] = []
++            while index < len(lines):
++                line = lines[index]
++                if not line.strip():
++                    block.append(line)
++                    index += 1
++                    continue
++                indentation = len(line) - len(line.lstrip())
++                if indentation <= base_indent:
++                    break
++                block.append(line)
++                index += 1
++            bodies.extend(block)
++            continue
++        bodies.append(value + "\n")
++        index += 1
++    return "".join(bodies)
++
++
++def direct_yaml_metadata(
++    source: str,
++    indentation: int,
++    strip_sequence_marker: bool = False,
++) -> dict[str, str]:
++    metadata: dict[str, str] = {}
++    for line in source.splitlines():
++        leading = len(line) - len(line.lstrip())
++        if leading != indentation:
++            continue
++        content = line.lstrip()
++        if strip_sequence_marker and content.startswith("- "):
++            content = content[2:].lstrip()
++        match = re.match(r"(?P<key>[A-Za-z0-9_-]+)\s*:\s*(?P<value>.*)$", content)
++        if match is not None:
++            metadata[match.group("key")] = match.group("value").strip()
++    return metadata
++
++
++def extract_yaml_step_blocks(job_source: str) -> tuple[tuple[str, int], ...]:
++    lines = job_source.splitlines(keepends=True)
++    steps = [
++        (index, len(match.group("indent")))
++        for index, line in enumerate(lines)
++        if (match := re.match(r"^(?P<indent>\s*)steps\s*:\s*(?:#.*)?$", line))
++    ]
++    if len(steps) != 1:
++        raise AssertionError("Windows installer steps are unavailable")
++    steps_index, steps_indent = steps[0]
++    item_indent = steps_indent + 2
++    starts = [
++        index
++        for index in range(steps_index + 1, len(lines))
++        if re.match(rf"^\s{{{item_indent}}}-\s+", lines[index])
++    ]
++    if not starts:
++        raise AssertionError("Windows installer has no executable steps")
++    blocks: list[tuple[str, int]] = []
++    for offset, start in enumerate(starts):
++        end = starts[offset + 1] if offset + 1 < len(starts) else len(lines)
++        while end > start + 1 and not lines[end - 1].strip():
++            end -= 1
++        blocks.append(("".join(lines[start:end]), item_indent))
++    return tuple(blocks)
++
++
++def yaml_execution_metadata_is_live(metadata: dict[str, str]) -> bool:
++    if "if" in metadata:
++        return False
++    continue_on_error = metadata.get("continue-on-error")
++    return (
++        continue_on_error is None or continue_on_error.strip("'\"").lower() == "false"
++    )
++
++
++def direct_top_level_shell_statements(source: str) -> tuple[str, ...]:
++    lines = [line for line in source.splitlines() if line.strip()]
++    if not lines:
++        return ()
++    direct_indent = min(len(line) - len(line.lstrip()) for line in lines)
++    statements: list[str] = []
++    statement: list[str] = []
++    brace_depth = 0
++    for line in lines:
++        stripped = line.strip()
++        if stripped.startswith("#"):
++            continue
++        code = re.sub(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'', "", stripped)
++        indentation = len(line) - len(line.lstrip())
++        if not statement and indentation != direct_indent:
++            continue
++        statement.append(stripped)
++        brace_depth += code.count("{") - code.count("}")
++        if brace_depth <= 0:
++            statements.append("\n".join(statement))
++            statement = []
++            brace_depth = 0
++    if statement:
++        statements.append("\n".join(statement))
++    return tuple(statements)
++
++
++def is_powershell_exit_check(statement: str, variable: str) -> bool:
++    reference = re.escape(variable)
++    return (
++        re.fullmatch(
++            rf"(?is)^\s*if\s*\(\s*{reference}\s+-ne\s+0\s*\)"
++            rf"\s*\{{\s*exit\s+{reference}\s*\}}\s*$",
++            statement,
++        )
++        is not None
++    )
++
++
++def powershell_can_bypass_successfully(source: str) -> bool:
++    transfer_prefix = r"(?i)(?:^|[;{}\n])\s*"
++    if re.search(transfer_prefix + r"return(?=\s|[;}]|$)", source):
++        return True
++    for exit_statement in re.finditer(
++        transfer_prefix + r"exit(?:\s+(?P<status>[^;}\n]+))?", source
++    ):
++        status = (exit_statement.group("status") or "").strip()
++        if re.fullmatch(r"[+-]?\d+", status) is None or int(status) == 0:
++            return True
++    return False
++
++
++def has_immediate_powershell_exit_propagation(
++    source: str,
++    command: re.Pattern,
++) -> bool:
++    statements = direct_top_level_shell_statements(source)
++    for index, statement in enumerate(statements):
++        if command.fullmatch(statement) is None:
++            continue
++        prior_code = "\n".join(statements[:index])
++        prior_code = re.sub(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'', "", prior_code)
++        prior_code = "\n".join(
++            line.split("#", 1)[0] for line in prior_code.splitlines()
++        )
++        if powershell_can_bypass_successfully(prior_code):
++            continue
++        next_index = index + 1
++        if next_index >= len(statements):
++            continue
++        if is_powershell_exit_check(statements[next_index], "$LASTEXITCODE"):
++            return True
++        capture = re.fullmatch(
++            r"(?i)^\s*(?P<variable>\$[A-Za-z_]\w*)\s*=\s*\$LASTEXITCODE\s*$",
++            statements[next_index],
++        )
++        if capture is None or next_index + 1 >= len(statements):
++            continue
++        if is_powershell_exit_check(
++            statements[next_index + 1], capture.group("variable")
++        ):
++            return True
++    return False
++
++
++def require_live_windows_workflow_commands(
++    job_source: str,
++    build_command: re.Pattern,
++    test_command: re.Pattern,
++) -> None:
++    job_metadata = direct_yaml_metadata(job_source, 4)
++    if not yaml_execution_metadata_is_live(job_metadata):
++        raise AssertionError("Windows durable-journal job is disabled or ignored")
++    runner = job_metadata.get("runs-on", "").strip("'\"").lower()
++    if runner != "windows-latest":
++        raise AssertionError("durable-journal job is not bound to Windows")
++    live_build = False
++    live_test = False
++    for block, item_indent in extract_yaml_step_blocks(job_source):
++        first = direct_yaml_metadata(block, item_indent, True)
++        remaining = direct_yaml_metadata(block, item_indent + 2)
++        metadata = {**first, **remaining}
++        shell = metadata.get("shell", "").strip("'\"").lower()
++        if shell and not re.match(r"^(?:powershell|pwsh)(?:\s|$)", shell):
++            continue
++        run_body = strip_shell_heredocs(extract_yaml_run_bodies(block))
++        has_build = has_immediate_powershell_exit_propagation(run_body, build_command)
++        has_test = has_immediate_powershell_exit_propagation(run_body, test_command)
++        if not (has_build or has_test):
++            continue
++        if not yaml_execution_metadata_is_live(metadata):
++            continue
++        live_build |= has_build
++        live_test |= has_test
++    if not (live_build and live_test):
++        raise AssertionError(
++            "Windows durable-journal commands are unavailable in live steps"
++        )
++
++
++def strip_shell_heredocs(source: str) -> str:
++    lines = source.splitlines(keepends=True)
++    kept: list[str] = []
++    index = 0
++    while index < len(lines):
++        stripped = lines[index].strip()
++        here_string = re.search(r"@(?P<quote>['\"])\s*$", stripped)
++        if here_string:
++            terminator = here_string.group("quote") + "@"
++            index += 1
++            while index < len(lines) and lines[index].strip() != terminator:
++                index += 1
++            index += index < len(lines)
++            continue
++        heredoc = re.search(
++            r"<<-?\s*['\"]?(?P<end>[A-Za-z_][A-Za-z0-9_]*)['\"]?", lines[index]
++        )
++        if heredoc:
++            terminator = heredoc.group("end")
++            index += 1
++            while index < len(lines) and lines[index].strip() != terminator:
++                index += 1
++            index += index < len(lines)
++            continue
++        kept.append(lines[index])
++        index += 1
++    return "".join(kept)
++
++
++def require_compiler_selection_contract() -> None:
++    absolute_wrapper = "/fixture/toolchains/task020/c++ wrapper"
++    fallback = "c++"
++    lookups: list[str] = []
++
++    def fake_which(command: str) -> str | None:
++        lookups.append(command)
++        if command == absolute_wrapper:
++            return command
++        if command == fallback:
++            raise AssertionError("configured compiler fell back to PATH")
++        return None
++
++    configured = configured_compiler(
++        environment={"CXX": f'"{absolute_wrapper}" --task020-wrapper'},
++        which=fake_which,
++    )
++    if configured != [absolute_wrapper, "--task020-wrapper"]:
++        raise AssertionError("absolute configured compiler was not preserved")
++    if fallback in lookups:
++        raise AssertionError("configured compiler consulted the PATH fallback")
++
++    observed: list[tuple[list[str], Path]] = []
++
++    def recording_runner(command, **kwargs):
++        observed.append((command, kwargs["cwd"]))
++        return subprocess.CompletedProcess(command, 0, b"", b"")
++
++    output = Path("/fixture/output/durable-journal-public-seam")
++    failure = execute_public_seam(
++        output,
++        configured=configured,
++        environment={"MBEDCRYPTO_LIBRARY": "/fixture/libmbedcrypto.a"},
++        runner=recording_runner,
++    )
++    if failure is not None:
++        raise AssertionError(
++            "absolute configured compiler could not drive the public seam"
++        )
++    compile_commands = [
++        command for command, _cwd in observed if str(JOURNAL_SOURCE) in command
++    ]
++    if not compile_commands or any(
++        command[0] != absolute_wrapper for command in compile_commands
++    ):
++        raise AssertionError("public seam ignored the absolute configured compiler")
++    if any(command and command[0] == fallback for command, _cwd in observed):
++        raise AssertionError("public seam invoked the PATH fallback compiler")
++    if any(cwd != output.parent for _command, cwd in observed):
++        raise AssertionError("public seam escaped its temporary output directory")
++
++
++def require_command_contract() -> None:
++    output = Path("durable-journal-public-seam")
++    if os.name != "nt":
++        fallback = compiler_command(output, configured=["c++"], environment={})
++        if (
++            "-lmbedcrypto" not in fallback
++            or "-pthread" not in fallback
++            or f"-D{TESTING_DEFINITION}" not in fallback
++        ):
++            raise AssertionError("POSIX public seam omitted required link flags")
++        environment: Mapping[str, str] = {
++            "NLOHMANN_JSON_INCLUDE_DIR": "/fixture/nlohmann",
++            "MBEDTLS_INCLUDE_DIR": "/fixture/mbedtls",
++            "MBEDCRYPTO_LIBRARY": "/fixture/libmbedcrypto.a",
++        }
++        configured = compiler_command(
++            output, configured=["c++"], environment=environment
++        )
++        for include in (
++            str(INCLUDE_ROOT),
++            str(INTERNAL_INCLUDE_ROOT),
++            str(TEST_INCLUDE_ROOT),
++            "/fixture/nlohmann",
++            "/fixture/mbedtls",
++        ):
++            if include not in configured:
++                raise AssertionError(f"public seam omitted include {include}")
++        if "/fixture/libmbedcrypto.a" not in configured or "-lmbedcrypto" in configured:
++            raise AssertionError("public seam ignored configured mbedcrypto library")
++
++    environment = {
++        "NLOHMANN_JSON_INCLUDE_DIR": "C:/fixture/nlohmann",
++        "MBEDTLS_INCLUDE_DIR": "C:/fixture/mbedtls",
++        "MBEDCRYPTO_LIBRARY": "C:/fixture/mbedcrypto.lib",
++    }
++    command = compiler_command(output, configured=["cl.exe"], environment=environment)
++    for include in (
++        str(INCLUDE_ROOT),
++        str(INTERNAL_INCLUDE_ROOT),
++        str(TEST_INCLUDE_ROOT),
++        "C:/fixture/nlohmann",
++        "C:/fixture/mbedtls",
++    ):
++        if f"/I{include}" not in command:
++            raise AssertionError(f"MSVC public seam omitted include {include}")
++    if "C:/fixture/mbedcrypto.lib" not in command:
++        raise AssertionError("MSVC public seam ignored configured mbedcrypto library")
++    if f"/D{TESTING_DEFINITION}" not in command:
++        raise AssertionError("MSVC public seam omitted its test-only definition")
++
++    negative_posix = compile_only_command(
++        Path("forgery.cpp"), output, configured=["c++"]
++    )
++    ordered_system_includes = compile_only_command(
++        Path("forgery.cpp"),
++        output,
++        configured=["c++"],
++        system_includes=("/fixture/first", "/fixture/second"),
++    )
++    negative_msvc = compile_only_command(
++        Path("forgery.cpp"), output, configured=["cl.exe"]
++    )
++    if f"-U{TESTING_DEFINITION}" not in negative_posix or any(
++        token == f"-D{TESTING_DEFINITION}" for token in negative_posix
++    ):
++        raise AssertionError("POSIX forgery compile enabled test injection")
++    if f"/U{TESTING_DEFINITION}" not in negative_msvc or any(
++        token == f"/D{TESTING_DEFINITION}" for token in negative_msvc
++    ):
++        raise AssertionError("MSVC forgery compile enabled test injection")
++    if ordered_system_includes.index("/fixture/first") > (
++        ordered_system_includes.index("/fixture/second")
++    ):
++        raise AssertionError("POSIX system include precedence was reversed")
++    try:
++        compiler_command(output, configured=["cl.exe"], environment={})
++    except RuntimeError:
++        pass
++    else:
++        raise AssertionError("MSVC public seam accepted a missing mbedcrypto library")
++
++    tokenized = split_compiler_command(
++        '"C:\\Program Files\\Microsoft Visual Studio\\VC\\cl.exe" /O2',
++        windows=True,
++    )
++    if tokenized != [
++        "C:\\Program Files\\Microsoft Visual Studio\\VC\\cl.exe",
++        "/O2",
++    ]:
++        raise AssertionError("Windows CXX tokenization is not path-safe")
++    if split_compiler_command("c++ -O2", windows=False) != ["c++", "-O2"]:
++        raise AssertionError("POSIX CXX tokenization drifted")
++
++
++def run_stage(
++    command: list[str],
++    *,
++    workdir: Path,
++    failed: str,
++    timed_out: str,
++    unavailable: str,
++    runner=subprocess.run,
++) -> str | None:
++    try:
++        completed = runner(
++            command,
++            cwd=workdir,
++            check=False,
++            stdout=subprocess.PIPE,
++            stderr=subprocess.PIPE,
++            timeout=PROCESS_TIMEOUT_SECONDS,
++        )
++    except subprocess.TimeoutExpired:
++        return timed_out
++    except (OSError, UnicodeError):
++        return unavailable
++    if completed.returncode != 0:
++        return failed
++    return None
++
++
++def execute_public_seam(
++    output: Path,
++    *,
++    configured: list[str],
++    environment: Mapping[str, str],
++    runner=subprocess.run,
++) -> str | None:
++    try:
++        command = compiler_command(
++            output,
++            configured=configured,
++            environment=environment,
++        )
++    except (RuntimeError, OSError, UnicodeError, ValueError):
++        return COMPILER_UNAVAILABLE
++    failure = run_stage(
++        command,
++        workdir=output.parent,
++        failed=COMPILATION_FAILED,
++        timed_out=COMPILATION_TIMED_OUT,
++        unavailable=COMPILER_UNAVAILABLE,
++        runner=runner,
++    )
++    if failure is not None:
++        return failure
++    return run_stage(
++        [str(output)],
++        workdir=output.parent,
++        failed=CONTRACT_ASSERTION_FAILED,
++        timed_out=EXECUTION_TIMED_OUT,
++        unavailable=EXECUTABLE_UNAVAILABLE,
++        runner=runner,
++    )
++
++
++def race_worker_status(stdout: bytes) -> bytes | None:
++    match = re.fullmatch(rb"(conflict_before_write|published)\r?\n", stdout)
++    return None if match is None else match.group(1)
++
++
++def require_race_worker_status_contract() -> None:
++    for status in (b"conflict_before_write", b"published"):
++        if race_worker_status(status + b"\n") != status:
++            raise AssertionError("POSIX race-worker status is unavailable")
++        if race_worker_status(status + b"\r\n") != status:
++            raise AssertionError("Windows race-worker status is unavailable")
++    for invalid in (
++        b"published",
++        b"published\n\n",
++        b"published\r\r\n",
++        b"published\nconflict_before_write\n",
++        b"unknown\n",
++    ):
++        if race_worker_status(invalid) is not None:
++            raise AssertionError("malformed race-worker status was accepted")
++
++
++def require_cross_process_cas(output: Path) -> str | None:
++    with tempfile.TemporaryDirectory(
++        prefix="durable-residency-journal-process-race-",
++        dir=output.parent,
++    ) as directory:
++        root = Path(directory)
++        authority = root / "authority"
++        controls = root / "controls"
++        authority.mkdir()
++        controls.mkdir()
++        floor = controls / "trusted-floor.json"
++        init_failure = run_stage(
++            [str(output), "--race-init", str(authority), str(floor)],
++            workdir=output.parent,
++            failed=CONTRACT_ASSERTION_FAILED,
++            timed_out=EXECUTION_TIMED_OUT,
++            unavailable=EXECUTABLE_UNAVAILABLE,
++        )
++        if init_failure is not None:
++            return init_failure
++
++        ready_files = [controls / "left.ready", controls / "right.ready"]
++        go_file = controls / "go"
++        workers: list[subprocess.Popen] = []
++        try:
++            for ready_file in ready_files:
++                workers.append(
++                    subprocess.Popen(
++                        [
++                            str(output),
++                            "--race-worker",
++                            str(authority),
++                            str(floor),
++                            str(ready_file),
++                            str(go_file),
++                        ],
++                        cwd=output.parent,
++                        stdout=subprocess.PIPE,
++                        stderr=subprocess.PIPE,
++                    )
++                )
++
++            ready_deadline = time.monotonic() + 30
++            while not all(path.is_file() for path in ready_files):
++                if any(worker.poll() is not None for worker in workers):
++                    return CONTRACT_ASSERTION_FAILED
++                if time.monotonic() >= ready_deadline:
++                    return EXECUTION_TIMED_OUT
++                time.sleep(0.01)
++
++            go_file.write_bytes(b"go\n")
++            outputs: list[bytes] = []
++            for worker in workers:
++                stdout, stderr = worker.communicate(timeout=PROCESS_TIMEOUT_SECONDS)
++                if worker.returncode != 0 or stderr:
++                    return CONTRACT_ASSERTION_FAILED
++                status = race_worker_status(stdout)
++                if status is None:
++                    return CONTRACT_ASSERTION_FAILED
++                outputs.append(status)
++            if sorted(outputs) != [b"conflict_before_write", b"published"]:
++                return CONTRACT_ASSERTION_FAILED
++        except subprocess.TimeoutExpired:
++            return EXECUTION_TIMED_OUT
++        except (OSError, UnicodeError):
++            return EXECUTABLE_UNAVAILABLE
++        finally:
++            for worker in workers:
++                if worker.poll() is None:
++                    worker.kill()
++                    try:
++                        worker.communicate(timeout=5)
++                    except subprocess.TimeoutExpired:
++                        pass
++
++        return run_stage(
++            [str(output), "--race-verify", str(authority), str(floor)],
++            workdir=output.parent,
++            failed=CONTRACT_ASSERTION_FAILED,
++            timed_out=EXECUTION_TIMED_OUT,
++            unavailable=EXECUTABLE_UNAVAILABLE,
++        )
++
++
++def execute_existing_public_seam(
++    output: Path,
++    *,
++    stage_runner=run_stage,
++    race_runner=require_cross_process_cas,
++) -> str | None:
++    failure = stage_runner(
++        [str(output)],
++        workdir=output.parent,
++        failed=CONTRACT_ASSERTION_FAILED,
++        timed_out=EXECUTION_TIMED_OUT,
++        unavailable=EXECUTABLE_UNAVAILABLE,
++    )
++    if failure is not None:
++        return failure
++    return race_runner(output)
++
++
++def execute_hosted_public_seam(
++    output: Path,
++    compiler: list[str],
++    directory: Path,
++    *,
++    private_authority_gate: Path | None = None,
++    compile_runner=subprocess.run,
++    stage_runner=run_stage,
++    race_runner=require_cross_process_cas,
++) -> str | None:
++    if not (private_authority_gate is not None and is_msvc_frontend(compiler)):
++        failure = require_private_authority_construction(
++            directory,
++            configured=compiler,
++            runner=compile_runner,
++        )
++        if failure is not None:
++            return failure
++    return execute_existing_public_seam(
++        output,
++        stage_runner=stage_runner,
++        race_runner=race_runner,
++    )
++
++
++def require_existing_executable_contract() -> None:
++    with tempfile.TemporaryDirectory(
++        prefix="durable-residency-journal-hosted-contract-"
++    ) as temporary:
++        directory = Path(temporary)
++        output = directory / (
++            "durable-journal-public-seam.exe"
++            if os.name == "nt"
++            else "durable-journal-public-seam"
++        )
++        compiler = directory / "c++"
++        output.write_bytes(b"fixture executable")
++        compiler.write_bytes(b"fixture compiler")
++        gate_artifact = directory / "durable_journal_private_authority_gate.cpp.o"
++        gate_artifact.write_bytes(b"fixture object")
++        msvc_gate_artifact = directory / "durable_journal_private_authority_gate.obj"
++        msvc_gate_artifact.write_bytes(b"fixture object")
++        if os.name != "nt":
++            output.chmod(0o700)
++            compiler.chmod(0o700)
++
++        parsed_output, parsed_compiler, private_authority_gate = existing_executable(
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++                str(gate_artifact),
++            ]
++        )
++        if (
++            parsed_output != output
++            or parsed_compiler != [str(compiler)]
++            or private_authority_gate != gate_artifact
++        ):
++            raise AssertionError("hosted arguments changed executable identity")
++        _, _, parsed_msvc_gate = existing_executable(
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++                str(msvc_gate_artifact),
++            ]
++        )
++        if parsed_msvc_gate != msvc_gate_artifact:
++            raise AssertionError("MSVC build-gate artifact spelling was rejected")
++        if os.name != "nt":
++            executable_link = directory / "selected-executable-link"
++            compiler_link = directory / "selected-compiler-link"
++            executable_link.symlink_to(output)
++            compiler_link.symlink_to(compiler)
++            linked_output, linked_compiler, linked_private_authority_gate = (
++                existing_executable(
++                    [
++                        "--existing-executable",
++                        str(executable_link),
++                        "--compiler",
++                        str(compiler_link),
++                    ]
++                )
++            )
++            if (
++                linked_output != executable_link
++                or linked_compiler != [str(compiler_link)]
++                or linked_private_authority_gate
++            ):
++                raise AssertionError("hosted mode bypassed a selected wrapper")
++
++        invalid_arguments = (
++            [],
++            ["--existing-executable", str(output)],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "extra",
++            ],
++            [
++                "--compiler",
++                str(compiler),
++                "--existing-executable",
++                str(output),
++            ],
++            [
++                "--existing-executable",
++                output.name,
++                "--compiler",
++                str(compiler),
++            ],
++            [
++                "--existing-executable",
++                str(directory),
++                "--compiler",
++                str(compiler),
++            ],
++            [
++                "--existing-executable",
++                str(directory / "missing-executable"),
++                "--compiler",
++                str(compiler),
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                compiler.name,
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(directory),
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(directory / "missing-compiler"),
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--unknown-gate",
++                str(gate_artifact),
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++                "relative/gate.obj",
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++                str(directory / "missing-gate.obj"),
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++                str(directory),
++            ],
++            [
++                "--existing-executable",
++                str(output),
++                "--compiler",
++                str(compiler),
++                "--private-authority-gate",
++                str(output),
++            ],
++        )
++        for arguments in invalid_arguments:
++            try:
++                existing_executable(list(arguments))
++            except (AssertionError, RuntimeError):
++                pass
++            else:
++                raise AssertionError("hosted mode accepted invalid arguments")
++
++        observed: list[tuple[str, Path]] = []
++        compile_commands: list[list[str]] = []
++
++        def fake_compile(command, **kwargs):
++            compile_commands.append(command)
++            source = next(
++                (Path(token) for token in command if str(token).endswith(".cpp")),
++                None,
++            )
++            succeeded = (
++                source is not None
++                and source.name == "published_journal_positive_control.cpp"
++            )
++            return subprocess.CompletedProcess(
++                command,
++                0 if succeeded else 1,
++                b"",
++                b"",
++            )
++
++        def fake_stage(command, **kwargs):
++            observed.append(("semantic", Path(command[0])))
++            if kwargs["workdir"] != output.parent:
++                raise AssertionError("existing executable escaped its build directory")
++
++        def fake_race(executable):
++            observed.append(("race", executable))
++
++        failure = execute_hosted_public_seam(
++            output,
++            parsed_compiler,
++            directory,
++            private_authority_gate=private_authority_gate,
++            compile_runner=fake_compile,
++            stage_runner=fake_stage,
++            race_runner=fake_race,
++        )
++        if failure is not None or observed != [
++            ("semantic", output),
++            ("race", output),
++        ]:
++            raise AssertionError(
++                "existing-executable mode bypassed the semantic process race"
++            )
++        if not compile_commands or any(
++            command[0] != str(compiler) for command in compile_commands
++        ):
++            raise AssertionError("hosted mode ignored its explicit compiler")
++        forbidden_full_seam_inputs = {
++            str(JOURNAL_SOURCE),
++            str(DURABLE_SOURCE),
++            str(ADAPTER_COMMON),
++            str(native_adapter_source()),
++            str(TEST_SUPPORT),
++            str(PUBLIC_SEAM),
++        }
++        if any(
++            forbidden_full_seam_inputs.intersection(command)
++            for command in compile_commands
++        ):
++            raise AssertionError("hosted mode rebuilt the public seam")
++
++        msvc_compiler = directory / "cl.exe"
++        msvc_compiler.write_bytes(b"fixture compiler")
++        if os.name != "nt":
++            msvc_compiler.chmod(0o700)
++        compile_count = len(compile_commands)
++        observed.clear()
++        failure = execute_hosted_public_seam(
++            output,
++            [str(msvc_compiler)],
++            directory,
++            private_authority_gate=msvc_gate_artifact,
++            compile_runner=fake_compile,
++            stage_runner=fake_stage,
++            race_runner=fake_race,
++        )
++        if (
++            failure is not None
++            or len(compile_commands) != compile_count
++            or observed != [("semantic", output), ("race", output)]
++        ):
++            raise AssertionError("MSVC hosted mode ignored its CMake compile gate")
++        observed.clear()
++        failure = execute_hosted_public_seam(
++            output,
++            [str(msvc_compiler)],
++            directory,
++            private_authority_gate=None,
++            compile_runner=fake_compile,
++            stage_runner=fake_stage,
++            race_runner=fake_race,
++        )
++        if failure is not None or len(compile_commands) == compile_count:
++            raise AssertionError("MSVC hosted mode skipped an unproven compile gate")
++
++        race_called = False
++
++        def rejected_semantic(_command, **_kwargs):
++            return CONTRACT_ASSERTION_FAILED
++
++        def forbidden_race(_executable):
++            nonlocal race_called
++            race_called = True
++
++        failure = execute_existing_public_seam(
++            output,
++            stage_runner=rejected_semantic,
++            race_runner=forbidden_race,
++        )
++        if failure != CONTRACT_ASSERTION_FAILED or race_called:
++            raise AssertionError("hosted mode raced after semantic failure")
++
++
++def existing_executable(
++    arguments: list[str],
++) -> tuple[Path, list[str], Path | None]:
++    if (
++        len(arguments) not in (4, 6)
++        or arguments[0] != "--existing-executable"
++        or arguments[2] != "--compiler"
++        or (len(arguments) == 6 and arguments[4] != "--private-authority-gate")
++    ):
++        raise AssertionError("existing-executable arguments are invalid")
++    candidate = Path(arguments[1])
++    if not candidate.is_absolute() or not candidate.is_file():
++        raise AssertionError("existing executable is not an absolute regular file")
++    if not candidate.is_file() or (
++        os.name != "nt" and not os.access(candidate, os.X_OK)
++    ):
++        raise AssertionError("existing executable is not runnable")
++    private_authority_gate = None
++    if len(arguments) == 6:
++        private_authority_gate = Path(arguments[5])
++        if (
++            not private_authority_gate.is_absolute()
++            or not private_authority_gate.is_file()
++            or re.fullmatch(
++                r"durable_journal_private_authority_gate(?:\.cpp)?\.(?:o|obj)",
++                private_authority_gate.name,
++            )
++            is None
++        ):
++            raise AssertionError("private-authority build artifact is invalid")
++    return candidate, explicit_compiler(arguments[3]), private_authority_gate
++
++
++def failure_line(message: str) -> str:
++    rendered = f"{message}\n"
++    if rendered.count("\n") != 1 or len(rendered.encode("utf-8")) > 256:
++        raise AssertionError("public-seam failure line is not bounded")
++    return rendered
++
++
++def require_runner_failure_contract() -> None:
++    secret = "private-compiler-path/boom"
++    raw_output = f"raw tool output {secret}".encode()
++
++    class FakeRunner:
++        def __init__(self, outcomes):
++            self.outcomes = iter(outcomes)
++
++        def __call__(self, _command, **_kwargs):
++            outcome = next(self.outcomes)
++            if isinstance(outcome, BaseException):
++                raise outcome
++            return outcome
++
++    successful = subprocess.CompletedProcess([], 0, b"", b"")
++    failed = subprocess.CompletedProcess([], 17, raw_output, raw_output)
++    timeout = subprocess.TimeoutExpired([secret], 1, output=raw_output)
++    invalid_utf8 = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
++    cases = [
++        ([OSError(secret)], COMPILER_UNAVAILABLE),
++        ([invalid_utf8], COMPILER_UNAVAILABLE),
++        ([failed], COMPILATION_FAILED),
++        ([timeout], COMPILATION_TIMED_OUT),
++        ([successful, failed], CONTRACT_ASSERTION_FAILED),
++        ([successful, timeout], EXECUTION_TIMED_OUT),
++        ([successful, OSError(secret)], EXECUTABLE_UNAVAILABLE),
++    ]
++    environment = {"MBEDCRYPTO_LIBRARY": "/fixture/libmbedcrypto.a"}
++    for outcomes, expected in cases:
++        observed = execute_public_seam(
++            Path("durable-journal-public-seam"),
++            configured=[f"/{secret}/c++"],
++            environment=environment,
++            runner=FakeRunner(outcomes),
++        )
++        if observed != expected:
++            raise AssertionError("public-seam failure classification drifted")
++        rendered = failure_line(observed)
++        if secret in rendered or "Traceback" in rendered:
++            raise AssertionError("public-seam failure leaked process details")
++
++
++def required_test_files() -> tuple[Path, ...]:
++    return (
++        RUNNER,
++        PUBLIC_SEAM,
++        PRIVATE_AUTHORITY_GATE,
++        TEST_SUPPORT,
++        TEST_SUPPORT_HEADER,
++    )
++
++
++def required_production_files() -> tuple[Path, ...]:
++    return (
++        DURABLE_HEADER,
++        DURABLE_SOURCE,
++        ADAPTER_HEADER,
++        ADAPTER_COMMON,
++        ADAPTER_POSIX,
++        ADAPTER_WINDOWS,
++        ADAPTER_MACOS,
++    )
++
++
++def main() -> int:
++    if any(not path.is_file() for path in required_test_files()):
++        sys.stderr.write(failure_line(CONTRACT_ASSERTION_FAILED))
++        return 1
++    if any(not path.is_file() for path in required_production_files()):
++        sys.stderr.write(failure_line(UNAVAILABLE))
++        return 1
++
++    try:
++        arguments = sys.argv[1:]
++        hosted: tuple[Path, list[str], Path | None] | None = None
++        if arguments:
++            hosted = existing_executable(arguments)
++        require_command_contract()
++        require_compiler_selection_contract()
++        require_runner_failure_contract()
++        require_race_worker_status_contract()
++        require_existing_executable_contract()
++        require_platform_source_contract()
++        require_build_contract()
++        with tempfile.TemporaryDirectory(
++            prefix="durable-residency-journal-"
++        ) as directory:
++            temporary = Path(directory)
++            if hosted is not None:
++                output, configured, private_authority_gate = hosted
++                failure = execute_hosted_public_seam(
++                    output,
++                    configured,
++                    temporary,
++                    private_authority_gate=private_authority_gate,
++                )
++            else:
++                configured = configured_compiler()
++                suffix = ".exe" if os.name == "nt" else ""
++                output = temporary / f"durable_journal_public_seam{suffix}"
++                failure = execute_public_seam(
++                    output,
++                    configured=configured,
++                    environment=os.environ,
++                )
++                if failure is None:
++                    failure = require_private_authority_construction(
++                        temporary,
++                        configured=configured,
++                    )
++                if failure is None:
++                    failure = require_cross_process_cas(output)
++    except AssertionError:
++        failure = CONTRACT_ASSERTION_FAILED
++    except (
++        RuntimeError,
++        OSError,
++        subprocess.TimeoutExpired,
++        UnicodeError,
++        ValueError,
++    ):
++        failure = COMPILER_UNAVAILABLE
++
++    if failure is not None:
++        sys.stderr.write(failure_line(failure))
++        return 1
++    return 0
++
++
++if __name__ == "__main__":
++    raise SystemExit(main())

--- a/src/cpp/include/lemon/residency/durable_journal.h
+++ b/src/cpp/include/lemon/residency/durable_journal.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include "lemon/residency/journal.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace lemon::residency {
+
+inline constexpr std::string_view durable_journal_data_filename =
+    "journal.jsonl";
+inline constexpr std::string_view durable_journal_root_filename =
+    "authority-root.json";
+inline constexpr std::string_view durable_journal_lock_filename =
+    "authority.lock";
+
+struct JournalLimits {
+    std::size_t max_committed_bytes;
+    std::uint64_t max_committed_records;
+    std::size_t max_resident_heads;
+    std::size_t max_crash_tail_bytes;
+};
+
+enum class DurableJournalStatus {
+    Published,
+    ConflictBeforeWrite,
+    UnsupportedStorage,
+    CorruptOrRollback,
+    LimitExceeded,
+    RecoveryRequired,
+};
+
+enum class JournalQuiescence { Unconfirmed, Confirmed };
+
+enum class ExactSchemaExportStatus {
+    ExportedCandidate,
+    QuiescenceRequired,
+    ConflictBeforeRead,
+    RecoveryRequired,
+    UnsupportedStorage,
+    CorruptOrRollback,
+    SchemaMismatch,
+    LimitExceeded,
+};
+
+class DurableJournal;
+
+class TrustedReplayFloor {
+public:
+    TrustedReplayFloor() = delete;
+    static TrustedReplayFloor uninitialized();
+    static TrustedReplayFloor exact_root(std::string root);
+
+private:
+    friend class DurableJournal;
+    explicit TrustedReplayFloor(std::optional<std::string> root);
+    std::optional<std::string> root_;
+};
+
+namespace detail {
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+class DurableJournalTestFactory;
+#endif
+} // namespace detail
+
+class PublishedJournal {
+public:
+    PublishedJournal() = delete;
+    PublishedJournal(const PublishedJournal &) = delete;
+    PublishedJournal &operator=(const PublishedJournal &) = delete;
+    PublishedJournal(PublishedJournal &&) noexcept;
+    PublishedJournal &operator=(PublishedJournal &&) noexcept;
+    ~PublishedJournal();
+
+    bool available() const noexcept;
+    std::string_view root_bytes() const noexcept;
+    std::string_view journal_id() const noexcept;
+    std::uint64_t tip_sequence() const noexcept;
+
+private:
+    friend class DurableJournal;
+    class Impl;
+    explicit PublishedJournal(std::unique_ptr<Impl> impl);
+    std::unique_ptr<Impl> impl_;
+};
+
+struct DurableJournalResult {
+    DurableJournalStatus status;
+    std::optional<PublishedJournal> journal;
+    bool published() const noexcept;
+};
+
+struct ExactSchemaExportCandidate {
+    SchemaVersion schema;
+    std::string journal_bytes;
+    std::string authority_root_bytes;
+};
+
+struct ExactSchemaExportResult {
+    ExactSchemaExportStatus status;
+    std::optional<ExactSchemaExportCandidate> candidate;
+    bool exported() const noexcept;
+};
+
+class DurableJournal {
+public:
+    DurableJournal() = delete;
+    DurableJournal(const DurableJournal &) = delete;
+    DurableJournal &operator=(const DurableJournal &) = delete;
+    DurableJournal(DurableJournal &&) noexcept;
+    DurableJournal &operator=(DurableJournal &&) noexcept;
+    ~DurableJournal();
+
+    static DurableJournal native(std::filesystem::path directory,
+                                 JournalLimits limits);
+    DurableJournalResult
+    create_new(TrustedReplayFloor floor, const ParsedJournalRecord &genesis,
+               const RecoveryOriginVerifier *verifier = nullptr);
+    DurableJournalResult
+    recover_existing(TrustedReplayFloor floor,
+                     const RecoveryOriginVerifier *verifier = nullptr);
+    DurableJournalResult
+    append_and_publish(PublishedJournal &&authority,
+                       const ParsedJournalRecord &candidate,
+                       const RecoveryOriginVerifier *verifier = nullptr);
+    DurableJournalResult compact_physical(PublishedJournal &&authority);
+    ExactSchemaExportResult
+    export_exact_schema_candidate(const PublishedJournal &authority,
+                                  SchemaVersion target,
+                                  JournalQuiescence quiescence);
+
+private:
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    friend class detail::DurableJournalTestFactory;
+#endif
+    class Impl;
+    struct PersistenceState;
+    template <typename Adapter>
+    explicit DurableJournal(std::unique_ptr<Adapter> adapter,
+                            JournalLimits limits);
+    DurableJournalResult mint_published(JournalHistory &&history,
+                                        AuthorityRootCandidate root,
+                                        PersistenceState &&persistence_state);
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace lemon::residency

--- a/src/cpp/server/residency/durable_file_adapter_common.cpp
+++ b/src/cpp/server/residency/durable_file_adapter_common.cpp
@@ -1,0 +1,1 @@
+#include "platform/durable_file_adapter.cpp"

--- a/src/cpp/server/residency/durable_journal.cpp
+++ b/src/cpp/server/residency/durable_journal.cpp
@@ -1,0 +1,1030 @@
+#include "lemon/residency/durable_journal.h"
+
+#include "platform/durable_file_adapter.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace lemon::residency {
+
+namespace {
+
+std::mutex fenced_identities_mutex;
+
+struct IdentityFenceEpoch {};
+
+using IdentityFenceToken = std::shared_ptr<const IdentityFenceEpoch>;
+
+std::unordered_map<std::string, IdentityFenceToken> fenced_identities;
+
+DurableJournalResult journal_result(DurableJournalStatus status) {
+    return {status, std::nullopt};
+}
+
+ExactSchemaExportResult export_result(ExactSchemaExportStatus status) {
+    return {status, std::nullopt};
+}
+
+std::string journal_frame(const ParsedJournalRecord &record) {
+    std::string framed(record.canonical_bytes());
+    framed.push_back('\n');
+    return framed;
+}
+
+bool checked_add(std::size_t left, std::size_t right,
+                 std::size_t &sum) noexcept {
+    if (right > std::numeric_limits<std::size_t>::max() - left) {
+        return false;
+    }
+    sum = left + right;
+    return true;
+}
+
+bool limits_are_usable(const JournalLimits &limits,
+                       std::size_t &journal_read_limit) noexcept {
+    if (limits.max_committed_bytes == 0 ||
+        limits.max_committed_records == 0 ||
+        limits.max_resident_heads == 0 ||
+        limits.max_crash_tail_bytes == 0) {
+        return false;
+    }
+    return checked_add(limits.max_committed_bytes,
+                       limits.max_crash_tail_bytes, journal_read_limit) &&
+           journal_read_limit < std::numeric_limits<std::size_t>::max();
+}
+
+std::string_view directory_identity(std::string_view identity) noexcept {
+    const auto delimiter = identity.rfind("/lock:");
+    if (delimiter == std::string_view::npos) {
+        return identity;
+    }
+    return identity.substr(0, delimiter);
+}
+
+bool same_directory_identity(std::string_view left,
+                             std::string_view right) noexcept {
+    return directory_identity(left) == directory_identity(right);
+}
+
+bool authority_root_matches(const AuthorityRootCandidate &root,
+                            std::string_view bytes) noexcept {
+    return root.canonical_bytes() == bytes;
+}
+
+IdentityFenceToken fence_identity(std::string_view identity) {
+    if (identity.empty()) {
+        return nullptr;
+    }
+    auto token = std::make_shared<IdentityFenceEpoch>();
+    std::lock_guard lock(fenced_identities_mutex);
+    fenced_identities.insert_or_assign(
+        std::string(directory_identity(identity)), token);
+    return token;
+}
+
+IdentityFenceToken identity_fence(std::string_view identity) {
+    std::lock_guard lock(fenced_identities_mutex);
+    const auto found =
+        fenced_identities.find(std::string(directory_identity(identity)));
+    return found == fenced_identities.end() ? nullptr : found->second;
+}
+
+void clear_identity_fence(std::string_view identity,
+                          const IdentityFenceToken &observed) {
+    if (!observed) {
+        return;
+    }
+    std::lock_guard lock(fenced_identities_mutex);
+    const auto found =
+        fenced_identities.find(std::string(directory_identity(identity)));
+    if (found != fenced_identities.end() && found->second == observed) {
+        fenced_identities.erase(found);
+    }
+}
+
+bool identity_is_fenced(std::string_view identity) {
+    return static_cast<bool>(identity_fence(identity));
+}
+
+} // namespace
+
+struct DurableJournal::PersistenceState {
+    std::string storage_identity;
+    std::string committed_prefix_bytes;
+    std::uint64_t committed_records = 0;
+    std::unordered_set<std::string> resident_heads;
+    bool journal_stage_present = false;
+    bool root_stage_present = false;
+    IdentityFenceToken fence_to_clear;
+    DurableJournalStatus unlock_failure_status =
+        DurableJournalStatus::RecoveryRequired;
+};
+
+class PublishedJournal::Impl {
+public:
+    Impl(JournalHistory &&selected_history, AuthorityRootCandidate selected_root,
+         std::string selected_storage_identity,
+         std::string selected_committed_prefix_bytes,
+         std::uint64_t selected_committed_records,
+         std::unordered_set<std::string> selected_resident_heads,
+         bool selected_journal_stage_present,
+         bool selected_root_stage_present)
+        : history(std::move(selected_history)), root(std::move(selected_root)),
+          storage_identity(std::move(selected_storage_identity)),
+          committed_prefix_bytes(std::move(selected_committed_prefix_bytes)),
+          committed_records(selected_committed_records),
+          resident_heads(std::move(selected_resident_heads)),
+          journal_stage_present(selected_journal_stage_present),
+          root_stage_present(selected_root_stage_present) {}
+
+    JournalHistory history;
+    AuthorityRootCandidate root;
+    std::string storage_identity;
+    std::string committed_prefix_bytes;
+    std::uint64_t committed_records;
+    std::unordered_set<std::string> resident_heads;
+    bool journal_stage_present;
+    bool root_stage_present;
+};
+
+class DurableJournal::Impl {
+public:
+    struct ReplayResult {
+        DurableJournalStatus status = DurableJournalStatus::CorruptOrRollback;
+        std::optional<JournalHistory> history;
+        std::optional<AuthorityRootCandidate> previous_root;
+        PersistenceState persistence;
+        std::size_t committed_bytes = 0;
+    };
+
+    Impl(std::unique_ptr<detail::DurableFileAdapter> selected_adapter,
+         JournalLimits selected_limits)
+        : adapter(std::move(selected_adapter)), limits(selected_limits) {}
+
+    bool acquire_identity(std::string &identity) {
+        if (!adapter) {
+            return false;
+        }
+        const auto locked = adapter->lock_authority();
+        if (!locked.succeeded()) {
+            return false;
+        }
+        lock_held = true;
+        auto observed = adapter->authority_identity();
+        if (!observed.result.succeeded() || observed.identity.empty()) {
+            static_cast<void>(release_lock());
+            return false;
+        }
+        identity = std::move(observed.identity);
+        return true;
+    }
+
+    detail::DurableFileResult
+    preflight_and_inspect(detail::DurableFixedNamespaceResult &fixed) {
+        const auto preflight = adapter->preflight_capabilities();
+        if (!preflight.succeeded()) {
+            return preflight;
+        }
+        fixed = adapter->inspect_fixed_namespace();
+        return fixed.result;
+    }
+
+    bool revalidate_authority(std::string_view expected_identity,
+                              std::string_view expected_root,
+                              std::string_view expected_journal,
+                              bool expected_journal_stage,
+                              bool expected_root_stage,
+                              std::size_t journal_read_limit) {
+        if (!lock_held) {
+            return false;
+        }
+        const auto identity = adapter->authority_identity();
+        if (!identity.result.succeeded() ||
+            identity.identity != expected_identity) {
+            return false;
+        }
+        const auto fixed = adapter->inspect_fixed_namespace();
+        if (!fixed.result.succeeded() || !fixed.journal_present ||
+            !fixed.root_present || !fixed.lock_present ||
+            fixed.journal_stage_present != expected_journal_stage ||
+            fixed.root_stage_present != expected_root_stage) {
+            return false;
+        }
+        const auto root = adapter->read_root(max_journal_input_bytes);
+        if (!root.result.succeeded() || root.truncated ||
+            root.bytes != expected_root) {
+            return false;
+        }
+        const auto journal = adapter->read_journal(journal_read_limit);
+        return journal.result.succeeded() && !journal.truncated &&
+               journal.bytes == expected_journal;
+    }
+
+    detail::DurableFileResult release_lock() {
+        if (!lock_held) {
+            return {detail::DurableFileStatus::Succeeded, {}};
+        }
+        auto released = adapter->unlock_authority();
+        lock_held = false;
+        return released;
+    }
+
+    ReplayResult replay_prefix(std::string_view root_bytes,
+                               std::string_view journal_bytes,
+                               const std::string &storage_identity,
+                               const std::optional<std::string> &floor,
+                               const RecoveryOriginVerifier *verifier,
+                               bool journal_stage_present,
+                               bool root_stage_present) const {
+        ReplayResult replay;
+        replay.persistence.storage_identity = storage_identity;
+        replay.persistence.journal_stage_present = journal_stage_present;
+        replay.persistence.root_stage_present = root_stage_present;
+        std::size_t cursor = 0;
+        bool floor_seen = false;
+        while (cursor < journal_bytes.size()) {
+            const auto newline = journal_bytes.find('\n', cursor);
+            if (newline == std::string_view::npos) {
+                return replay;
+            }
+            const auto frame_end = newline + 1;
+            if (frame_end > limits.max_committed_bytes ||
+                replay.persistence.committed_records ==
+                    limits.max_committed_records) {
+                replay.status = DurableJournalStatus::LimitExceeded;
+                return replay;
+            }
+            const auto record_bytes =
+                journal_bytes.substr(cursor, newline - cursor);
+            const auto parsed_record = parse_record_candidate(record_bytes);
+            if (!parsed_record.candidate.has_value()) {
+                return replay;
+            }
+            replay.persistence.resident_heads.emplace(
+                parsed_record.candidate->resident_id());
+            if (replay.persistence.resident_heads.size() >
+                limits.max_resident_heads) {
+                replay.status = DurableJournalStatus::LimitExceeded;
+                return replay;
+            }
+            ++replay.persistence.committed_records;
+            if (!replay.history.has_value()) {
+                auto history_result =
+                    begin_history(*parsed_record.candidate, verifier);
+                if (!history_result.history.has_value()) {
+                    return replay;
+                }
+                replay.history.emplace(std::move(*history_result.history));
+            } else {
+                auto history_result = advance_history(
+                    std::move(*replay.history), *parsed_record.candidate,
+                    verifier);
+                if (!history_result.history.has_value()) {
+                    replay.history.reset();
+                    return replay;
+                }
+                replay.history.emplace(std::move(*history_result.history));
+            }
+            const auto sealed = seal_authority_root_candidate(
+                *replay.history,
+                replay.previous_root.has_value() ? &*replay.previous_root
+                                                 : nullptr);
+            if (!sealed.candidate.has_value()) {
+                replay.history.reset();
+                return replay;
+            }
+            if (floor.has_value() &&
+                sealed.candidate->canonical_bytes() == *floor) {
+                floor_seen = true;
+            }
+            if (sealed.candidate->canonical_bytes() == root_bytes) {
+                replay.committed_bytes = frame_end;
+                replay.persistence.committed_prefix_bytes =
+                    std::string(journal_bytes.substr(0, frame_end));
+                if (!floor.has_value() || !floor_seen) {
+                    replay.history.reset();
+                    return replay;
+                }
+                replay.status = DurableJournalStatus::Published;
+                return replay;
+            }
+            replay.previous_root.emplace(std::move(*sealed.candidate));
+            cursor = frame_end;
+        }
+        replay.history.reset();
+        return replay;
+    }
+
+    bool token_within_limits(const PublishedJournal::Impl &published) const {
+        std::size_t ignored = 0;
+        return limits_are_usable(limits, ignored) &&
+               published.committed_prefix_bytes.size() <=
+                   limits.max_committed_bytes &&
+               published.committed_records <= limits.max_committed_records &&
+               published.resident_heads.size() <= limits.max_resident_heads;
+    }
+
+    std::unique_ptr<detail::DurableFileAdapter> adapter;
+    JournalLimits limits;
+    bool lock_held = false;
+};
+
+TrustedReplayFloor::TrustedReplayFloor(std::optional<std::string> root)
+    : root_(std::move(root)) {}
+
+TrustedReplayFloor TrustedReplayFloor::uninitialized() {
+    return TrustedReplayFloor(std::nullopt);
+}
+
+TrustedReplayFloor TrustedReplayFloor::exact_root(std::string root) {
+    return TrustedReplayFloor(std::move(root));
+}
+
+PublishedJournal::PublishedJournal(std::unique_ptr<Impl> impl)
+    : impl_(std::move(impl)) {}
+
+PublishedJournal::PublishedJournal(PublishedJournal &&) noexcept = default;
+
+PublishedJournal &
+PublishedJournal::operator=(PublishedJournal &&) noexcept = default;
+
+PublishedJournal::~PublishedJournal() = default;
+
+bool PublishedJournal::available() const noexcept { return impl_ != nullptr; }
+
+std::string_view PublishedJournal::root_bytes() const noexcept {
+    return impl_ == nullptr ? std::string_view{} : impl_->root.canonical_bytes();
+}
+
+std::string_view PublishedJournal::journal_id() const noexcept {
+    return impl_ == nullptr ? std::string_view{} : impl_->history.journal_id();
+}
+
+std::uint64_t PublishedJournal::tip_sequence() const noexcept {
+    return impl_ == nullptr ? 0 : impl_->history.tip_sequence();
+}
+
+bool DurableJournalResult::published() const noexcept {
+    return status == DurableJournalStatus::Published && journal.has_value() &&
+           journal->available();
+}
+
+bool ExactSchemaExportResult::exported() const noexcept {
+    return status == ExactSchemaExportStatus::ExportedCandidate &&
+           candidate.has_value();
+}
+
+template <typename Adapter>
+DurableJournal::DurableJournal(std::unique_ptr<Adapter> adapter,
+                               JournalLimits limits)
+    : impl_(std::make_unique<Impl>(std::move(adapter), limits)) {}
+
+DurableJournal::DurableJournal(DurableJournal &&) noexcept = default;
+
+DurableJournal &DurableJournal::operator=(DurableJournal &&) noexcept = default;
+
+DurableJournal::~DurableJournal() = default;
+
+DurableJournal DurableJournal::native(std::filesystem::path directory,
+                                      JournalLimits limits) {
+    return DurableJournal(
+        detail::make_platform_durable_file_adapter(directory), limits);
+}
+
+DurableJournalResult
+DurableJournal::mint_published(JournalHistory &&history,
+                               AuthorityRootCandidate root,
+    PersistenceState &&persistence_state) {
+    const auto fence_to_clear = std::move(persistence_state.fence_to_clear);
+    const auto unlock_failure_status =
+        persistence_state.unlock_failure_status;
+    auto published = PublishedJournal(std::make_unique<PublishedJournal::Impl>(
+        std::move(history), std::move(root),
+        std::move(persistence_state.storage_identity),
+        std::move(persistence_state.committed_prefix_bytes),
+        persistence_state.committed_records,
+        std::move(persistence_state.resident_heads),
+        persistence_state.journal_stage_present,
+        persistence_state.root_stage_present));
+    const auto unlocked = impl_->release_lock();
+    if (!unlocked.succeeded()) {
+        return journal_result(unlock_failure_status);
+    }
+    clear_identity_fence(published.impl_->storage_identity, fence_to_clear);
+    return {DurableJournalStatus::Published,
+            std::optional<PublishedJournal>(std::move(published))};
+}
+
+DurableJournalResult DurableJournal::create_new(
+    TrustedReplayFloor floor, const ParsedJournalRecord &genesis,
+    const RecoveryOriginVerifier *verifier) {
+    std::size_t journal_read_limit = 0;
+    if (!impl_ || floor.root_.has_value() ||
+        !limits_are_usable(impl_->limits, journal_read_limit)) {
+        return journal_result(floor.root_.has_value()
+                                  ? DurableJournalStatus::CorruptOrRollback
+                                  : DurableJournalStatus::LimitExceeded);
+    }
+    auto history_result = begin_history(genesis, verifier);
+    if (!history_result.history) {
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    auto root_result =
+        seal_authority_root_candidate(*history_result.history, nullptr);
+    if (!root_result.candidate) {
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    const auto framed = journal_frame(genesis);
+    if (framed.size() > impl_->limits.max_committed_bytes ||
+        impl_->limits.max_committed_records < 1 ||
+        impl_->limits.max_resident_heads < 1) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+
+    std::string identity;
+    if (!impl_->acquire_identity(identity)) {
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    const auto retained_fence = identity_fence(identity);
+    detail::DurableFixedNamespaceResult fixed{};
+    const auto preflight = impl_->preflight_and_inspect(fixed);
+    if (!preflight.succeeded()) {
+        if (preflight.effect_may_have_occurred() && !retained_fence) {
+            fence_identity(identity);
+        }
+        static_cast<void>(impl_->release_lock());
+        return journal_result(
+            retained_fence || preflight.effect_may_have_occurred()
+                ? DurableJournalStatus::RecoveryRequired
+                : DurableJournalStatus::UnsupportedStorage);
+    }
+    if (retained_fence &&
+        (!fixed.lock_present || fixed.journal_present || fixed.root_present ||
+         fixed.journal_stage_present || fixed.root_stage_present)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    if (fixed.journal_stage_present || fixed.root_stage_present ||
+        fixed.journal_present != fixed.root_present) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    if (fixed.journal_present && fixed.root_present) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::ConflictBeforeWrite);
+    }
+    const auto absent_root = impl_->adapter->read_root(max_journal_input_bytes);
+    if (absent_root.result.status != detail::DurableFileStatus::NotFound) {
+        static_cast<void>(impl_->release_lock());
+        if (retained_fence) {
+            return journal_result(DurableJournalStatus::RecoveryRequired);
+        }
+        return journal_result(absent_root.result.succeeded()
+                                  ? DurableJournalStatus::CorruptOrRollback
+                                  : DurableJournalStatus::UnsupportedStorage);
+    }
+
+    const auto provisional_fence =
+        retained_fence ? retained_fence : fence_identity(identity);
+    const auto created = impl_->adapter->create_journal(framed);
+    if (!created.succeeded()) {
+        const bool create_definitely_before_effect =
+            !created.effect_may_have_occurred();
+        const auto after_create =
+            impl_->adapter->inspect_fixed_namespace();
+        const auto live_identity = impl_->adapter->authority_identity();
+        const bool fixed_namespace_provably_fresh =
+            after_create.result.succeeded() &&
+            !after_create.journal_present && !after_create.root_present &&
+            !after_create.journal_stage_present &&
+            !after_create.root_stage_present && after_create.lock_present;
+        const bool authority_identity_still_matches =
+            live_identity.result.succeeded() &&
+            live_identity.identity == identity;
+        const auto unlocked = impl_->release_lock();
+        const bool safe_to_clear_fence =
+            create_definitely_before_effect &&
+            fixed_namespace_provably_fresh &&
+            authority_identity_still_matches && unlocked.succeeded();
+        if (safe_to_clear_fence) {
+            clear_identity_fence(identity, provisional_fence);
+            return journal_result(DurableJournalStatus::UnsupportedStorage);
+        }
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    const auto replaced = impl_->adapter->replace_root(
+        root_result.candidate->canonical_bytes());
+    if (!replaced.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    if (!impl_->revalidate_authority(
+            identity, root_result.candidate->canonical_bytes(), framed, false,
+            false, journal_read_limit)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    PersistenceState persistence_state;
+    persistence_state.storage_identity = identity;
+    persistence_state.committed_prefix_bytes = framed;
+    persistence_state.committed_records = 1;
+    persistence_state.resident_heads.emplace(genesis.resident_id());
+    persistence_state.fence_to_clear = provisional_fence;
+    return mint_published(std::move(*history_result.history),
+                          std::move(*root_result.candidate),
+                          std::move(persistence_state));
+}
+
+DurableJournalResult DurableJournal::recover_existing(
+    TrustedReplayFloor floor, const RecoveryOriginVerifier *verifier) {
+    std::size_t journal_read_limit = 0;
+    if (!impl_ || !floor.root_.has_value()) {
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    if (!limits_are_usable(impl_->limits, journal_read_limit)) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    std::string identity;
+    if (!impl_->acquire_identity(identity)) {
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    detail::DurableFixedNamespaceResult fixed{};
+    const auto preflight = impl_->preflight_and_inspect(fixed);
+    if (!preflight.succeeded()) {
+        if (preflight.effect_may_have_occurred()) {
+            fence_identity(identity);
+        }
+        static_cast<void>(impl_->release_lock());
+        return journal_result(
+            preflight.effect_may_have_occurred()
+                ? DurableJournalStatus::RecoveryRequired
+                : DurableJournalStatus::UnsupportedStorage);
+    }
+    if (!fixed.journal_present || !fixed.root_present) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    const auto root_read = impl_->adapter->read_root(max_journal_input_bytes);
+    if (!root_read.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (root_read.truncated) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    const auto journal_read = impl_->adapter->read_journal(journal_read_limit);
+    if (!journal_read.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (journal_read.truncated) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    auto replay = impl_->replay_prefix(
+        root_read.bytes, journal_read.bytes, identity, floor.root_, verifier,
+        fixed.journal_stage_present, fixed.root_stage_present);
+    if (replay.status != DurableJournalStatus::Published ||
+        !replay.history.has_value()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(replay.status);
+    }
+    auto parsed = parse_authority_root_candidate(
+        root_read.bytes, *replay.history,
+        replay.previous_root.has_value() ? &*replay.previous_root : nullptr);
+    if (!parsed.candidate) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    const auto tail_bytes = journal_read.bytes.size() - replay.committed_bytes;
+    if (tail_bytes > impl_->limits.max_crash_tail_bytes) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    IdentityFenceToken provisional_fence;
+    if (tail_bytes != 0) {
+        provisional_fence = fence_identity(identity);
+        const auto repaired =
+            impl_->adapter->truncate_journal(replay.committed_bytes);
+        if (!repaired.succeeded()) {
+            const auto unlocked = impl_->release_lock();
+            if (!repaired.effect_may_have_occurred() &&
+                unlocked.succeeded()) {
+                clear_identity_fence(identity, provisional_fence);
+            }
+            return journal_result(
+                repaired.effect_may_have_occurred()
+                    ? DurableJournalStatus::RecoveryRequired
+                    : DurableJournalStatus::UnsupportedStorage);
+        }
+    }
+    if (!impl_->revalidate_authority(
+            identity, parsed.candidate->canonical_bytes(),
+            replay.persistence.committed_prefix_bytes,
+            fixed.journal_stage_present, fixed.root_stage_present,
+            journal_read_limit)) {
+        if (!provisional_fence) {
+            fence_identity(identity);
+        }
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    const auto unlock_fence =
+        tail_bytes == 0 ? identity_fence(identity) : provisional_fence;
+    auto persistence_state = std::move(replay.persistence);
+    persistence_state.fence_to_clear = unlock_fence;
+    persistence_state.unlock_failure_status =
+        tail_bytes == 0 ? DurableJournalStatus::UnsupportedStorage
+                        : DurableJournalStatus::RecoveryRequired;
+    return mint_published(std::move(*replay.history),
+                          std::move(*parsed.candidate),
+                          std::move(persistence_state));
+}
+
+DurableJournalResult DurableJournal::append_and_publish(
+    PublishedJournal &&authority, const ParsedJournalRecord &candidate,
+    const RecoveryOriginVerifier *verifier) {
+    auto authority_state = std::move(authority.impl_);
+    if (!impl_ || !authority_state) {
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    auto history_result = advance_history(std::move(authority_state->history),
+                                          candidate, verifier);
+    if (!history_result.history) {
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    std::size_t journal_read_limit = 0;
+    if (!limits_are_usable(impl_->limits, journal_read_limit)) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    const auto framed = journal_frame(candidate);
+    std::size_t next_committed_bytes = 0;
+    if (!checked_add(
+            authority_state->committed_prefix_bytes.size(),
+            framed.size(), next_committed_bytes) ||
+        next_committed_bytes > impl_->limits.max_committed_bytes ||
+        authority_state->committed_records ==
+            std::numeric_limits<std::uint64_t>::max() ||
+        authority_state->committed_records + 1 >
+            impl_->limits.max_committed_records) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    auto resident_heads = authority_state->resident_heads;
+    resident_heads.emplace(candidate.resident_id());
+    if (resident_heads.size() > impl_->limits.max_resident_heads) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    auto expected_journal = authority_state->committed_prefix_bytes;
+    expected_journal.append(framed);
+
+    if (identity_is_fenced(authority_state->storage_identity)) {
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    std::string identity;
+    if (!impl_->acquire_identity(identity)) {
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (identity != authority_state->storage_identity) {
+        const auto status =
+            same_directory_identity(identity,
+                                    authority_state->storage_identity)
+                ? DurableJournalStatus::UnsupportedStorage
+                : DurableJournalStatus::CorruptOrRollback;
+        static_cast<void>(impl_->release_lock());
+        return journal_result(status);
+    }
+    if (identity_is_fenced(identity)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    detail::DurableFixedNamespaceResult fixed{};
+    const auto preflight = impl_->preflight_and_inspect(fixed);
+    if (!preflight.succeeded()) {
+        if (preflight.effect_may_have_occurred()) {
+            fence_identity(identity);
+        }
+        static_cast<void>(impl_->release_lock());
+        return journal_result(
+            preflight.effect_may_have_occurred()
+                ? DurableJournalStatus::RecoveryRequired
+                : DurableJournalStatus::UnsupportedStorage);
+    }
+    if (!fixed.journal_present || !fixed.root_present) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    if (fixed.journal_stage_present !=
+            authority_state->journal_stage_present ||
+        fixed.root_stage_present !=
+            authority_state->root_stage_present) {
+        fence_identity(identity);
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    const auto current_root =
+        impl_->adapter->read_root(max_journal_input_bytes);
+    if (!current_root.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (current_root.truncated ||
+        !authority_root_matches(authority_state->root, current_root.bytes)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::ConflictBeforeWrite);
+    }
+    const auto current_journal =
+        impl_->adapter->read_journal(journal_read_limit);
+    if (!current_journal.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (current_journal.truncated ||
+        current_journal.bytes !=
+            authority_state->committed_prefix_bytes) {
+        fence_identity(identity);
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+
+    const auto provisional_fence = fence_identity(identity);
+    const auto appended = impl_->adapter->append_journal(framed);
+    if (!appended.succeeded()) {
+        const auto unlocked = impl_->release_lock();
+        if (!appended.effect_may_have_occurred() && unlocked.succeeded()) {
+            clear_identity_fence(identity, provisional_fence);
+        }
+        return journal_result(appended.effect_may_have_occurred()
+                                  ? DurableJournalStatus::RecoveryRequired
+                                  : DurableJournalStatus::UnsupportedStorage);
+    }
+    auto root_result = seal_authority_root_candidate(
+        *history_result.history, &authority_state->root);
+    if (!root_result.candidate) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    const auto replaced = impl_->adapter->replace_root(
+        root_result.candidate->canonical_bytes());
+    if (!replaced.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    if (!impl_->revalidate_authority(
+            identity, root_result.candidate->canonical_bytes(),
+            expected_journal, authority_state->journal_stage_present, false,
+            journal_read_limit)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    PersistenceState persistence_state;
+    persistence_state.storage_identity = std::move(authority_state->storage_identity);
+    persistence_state.committed_prefix_bytes = std::move(expected_journal);
+    persistence_state.committed_records =
+        authority_state->committed_records + 1;
+    persistence_state.journal_stage_present = authority_state->journal_stage_present;
+    persistence_state.resident_heads = std::move(resident_heads);
+    persistence_state.root_stage_present = false;
+    persistence_state.fence_to_clear = provisional_fence;
+    return mint_published(std::move(*history_result.history),
+                          std::move(*root_result.candidate),
+                          std::move(persistence_state));
+}
+
+DurableJournalResult
+DurableJournal::compact_physical(PublishedJournal &&authority) {
+    auto authority_state = std::move(authority.impl_);
+    if (!impl_ || !authority_state) {
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    if (!impl_->token_within_limits(*authority_state)) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    std::size_t journal_read_limit = 0;
+    if (!limits_are_usable(impl_->limits, journal_read_limit)) {
+        return journal_result(DurableJournalStatus::LimitExceeded);
+    }
+    if (identity_is_fenced(authority_state->storage_identity)) {
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    std::string identity;
+    if (!impl_->acquire_identity(identity)) {
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (identity != authority_state->storage_identity) {
+        const auto status =
+            same_directory_identity(identity,
+                                    authority_state->storage_identity)
+                ? DurableJournalStatus::UnsupportedStorage
+                : DurableJournalStatus::CorruptOrRollback;
+        static_cast<void>(impl_->release_lock());
+        return journal_result(status);
+    }
+    if (identity_is_fenced(identity)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    detail::DurableFixedNamespaceResult fixed{};
+    const auto preflight = impl_->preflight_and_inspect(fixed);
+    if (!preflight.succeeded()) {
+        if (preflight.effect_may_have_occurred()) {
+            fence_identity(identity);
+        }
+        static_cast<void>(impl_->release_lock());
+        return journal_result(
+            preflight.effect_may_have_occurred()
+                ? DurableJournalStatus::RecoveryRequired
+                : DurableJournalStatus::UnsupportedStorage);
+    }
+    if (!fixed.journal_present || !fixed.root_present) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::CorruptOrRollback);
+    }
+    if (fixed.journal_stage_present !=
+            authority_state->journal_stage_present ||
+        fixed.root_stage_present != authority_state->root_stage_present) {
+        fence_identity(identity);
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    const auto current_root =
+        impl_->adapter->read_root(max_journal_input_bytes);
+    if (!current_root.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (current_root.truncated ||
+        !authority_root_matches(authority_state->root, current_root.bytes)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::ConflictBeforeWrite);
+    }
+    const auto current_journal =
+        impl_->adapter->read_journal(journal_read_limit);
+    if (!current_journal.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::UnsupportedStorage);
+    }
+    if (current_journal.truncated ||
+        current_journal.bytes !=
+            authority_state->committed_prefix_bytes) {
+        fence_identity(identity);
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    const auto provisional_fence = fence_identity(identity);
+    const auto replaced = impl_->adapter->replace_journal(
+        authority_state->committed_prefix_bytes);
+    if (!replaced.succeeded()) {
+        const auto unlocked = impl_->release_lock();
+        if (!replaced.effect_may_have_occurred() && unlocked.succeeded()) {
+            clear_identity_fence(identity, provisional_fence);
+        }
+        return journal_result(replaced.effect_may_have_occurred()
+                                  ? DurableJournalStatus::RecoveryRequired
+                                  : DurableJournalStatus::UnsupportedStorage);
+    }
+    if (!impl_->revalidate_authority(
+            identity, authority_state->root.canonical_bytes(),
+            authority_state->committed_prefix_bytes, false,
+            authority_state->root_stage_present, journal_read_limit)) {
+        static_cast<void>(impl_->release_lock());
+        return journal_result(DurableJournalStatus::RecoveryRequired);
+    }
+    PersistenceState persistence_state;
+    persistence_state.storage_identity = std::move(authority_state->storage_identity);
+    persistence_state.committed_prefix_bytes =
+        std::move(authority_state->committed_prefix_bytes);
+    persistence_state.committed_records = authority_state->committed_records;
+    persistence_state.resident_heads = std::move(authority_state->resident_heads);
+    persistence_state.journal_stage_present = false;
+    persistence_state.root_stage_present = authority_state->root_stage_present;
+    persistence_state.fence_to_clear = provisional_fence;
+    return mint_published(std::move(authority_state->history),
+                          std::move(authority_state->root),
+                          std::move(persistence_state));
+}
+
+ExactSchemaExportResult DurableJournal::export_exact_schema_candidate(
+    const PublishedJournal &authority, SchemaVersion target,
+    JournalQuiescence quiescence) {
+    if (!impl_ || !authority.impl_) {
+        return export_result(ExactSchemaExportStatus::CorruptOrRollback);
+    }
+    if (quiescence != JournalQuiescence::Confirmed) {
+        return export_result(ExactSchemaExportStatus::QuiescenceRequired);
+    }
+    if (target.major != supported_journal_schema.major ||
+        target.minor != supported_journal_schema.minor) {
+        return export_result(ExactSchemaExportStatus::SchemaMismatch);
+    }
+    if (!impl_->token_within_limits(*authority.impl_)) {
+        return export_result(ExactSchemaExportStatus::LimitExceeded);
+    }
+    std::size_t journal_read_limit = 0;
+    if (!limits_are_usable(impl_->limits, journal_read_limit)) {
+        return export_result(ExactSchemaExportStatus::LimitExceeded);
+    }
+    if (identity_is_fenced(authority.impl_->storage_identity)) {
+        return export_result(ExactSchemaExportStatus::RecoveryRequired);
+    }
+    std::string identity;
+    if (!impl_->acquire_identity(identity)) {
+        return export_result(ExactSchemaExportStatus::UnsupportedStorage);
+    }
+    if (identity != authority.impl_->storage_identity) {
+        const auto status =
+            same_directory_identity(identity,
+                                    authority.impl_->storage_identity)
+                ? ExactSchemaExportStatus::UnsupportedStorage
+                : ExactSchemaExportStatus::CorruptOrRollback;
+        static_cast<void>(impl_->release_lock());
+        return export_result(status);
+    }
+    if (identity_is_fenced(identity)) {
+        static_cast<void>(impl_->release_lock());
+        return export_result(ExactSchemaExportStatus::RecoveryRequired);
+    }
+    detail::DurableFixedNamespaceResult fixed{};
+    const auto preflight = impl_->preflight_and_inspect(fixed);
+    if (!preflight.succeeded()) {
+        if (preflight.effect_may_have_occurred()) {
+            fence_identity(identity);
+        }
+        static_cast<void>(impl_->release_lock());
+        return export_result(
+            preflight.effect_may_have_occurred()
+                ? ExactSchemaExportStatus::RecoveryRequired
+                : ExactSchemaExportStatus::UnsupportedStorage);
+    }
+    if (!fixed.journal_present || !fixed.root_present) {
+        static_cast<void>(impl_->release_lock());
+        return export_result(ExactSchemaExportStatus::CorruptOrRollback);
+    }
+    const auto current_root =
+        impl_->adapter->read_root(max_journal_input_bytes);
+    if (!current_root.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return export_result(ExactSchemaExportStatus::UnsupportedStorage);
+    }
+    if (current_root.truncated) {
+        static_cast<void>(impl_->release_lock());
+        return export_result(ExactSchemaExportStatus::CorruptOrRollback);
+    }
+    if (current_root.bytes != authority.impl_->root.canonical_bytes()) {
+        const auto parsed = parse_authority_root_candidate(
+            current_root.bytes, authority.impl_->history);
+        const auto status = parsed.status == JournalStatus::InvalidHistory
+                                ? ExactSchemaExportStatus::ConflictBeforeRead
+                                : ExactSchemaExportStatus::CorruptOrRollback;
+        static_cast<void>(impl_->release_lock());
+        return export_result(status);
+    }
+    const auto current_journal =
+        impl_->adapter->read_journal(journal_read_limit);
+    if (!current_journal.result.succeeded()) {
+        static_cast<void>(impl_->release_lock());
+        return export_result(ExactSchemaExportStatus::UnsupportedStorage);
+    }
+    if (current_journal.truncated ||
+        current_journal.bytes !=
+            authority.impl_->committed_prefix_bytes) {
+        static_cast<void>(impl_->release_lock());
+        return export_result(ExactSchemaExportStatus::CorruptOrRollback);
+    }
+    const auto unlocked = impl_->release_lock();
+    if (!unlocked.succeeded()) {
+        return export_result(ExactSchemaExportStatus::UnsupportedStorage);
+    }
+    return {ExactSchemaExportStatus::ExportedCandidate,
+            ExactSchemaExportCandidate{
+                supported_journal_schema,
+                authority.impl_->committed_prefix_bytes,
+                std::string(authority.impl_->root.canonical_bytes())}};
+}
+
+namespace detail {
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+DurableJournal DurableJournalTestFactory::make(
+    std::unique_ptr<DurableFileAdapter> adapter, JournalLimits limits) {
+    return DurableJournal(std::move(adapter), limits);
+}
+
+DurableJournal make_durable_journal_for_test(
+    std::unique_ptr<DurableFileAdapter> adapter, JournalLimits limits) {
+    return DurableJournalTestFactory::make(std::move(adapter), limits);
+}
+#endif
+
+} // namespace detail
+
+} // namespace lemon::residency

--- a/src/cpp/server/residency/platform/durable_file_adapter.cpp
+++ b/src/cpp/server/residency/platform/durable_file_adapter.cpp
@@ -1,0 +1,190 @@
+#include "platform/durable_file_adapter.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace lemon::residency::detail {
+
+namespace {
+
+DurableFileResult result(DurableFileStatus status) {
+    return {status, {}};
+}
+
+DurableFileResult combine_transaction_results(
+    const DurableFileResult &operation_result,
+    const DurableFileResult &flush_result,
+    const DurableFileResult &close_result) {
+    if (operation_result.effect_may_have_occurred()) {
+        return result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    if (!operation_result.succeeded()) {
+        return operation_result;
+    }
+    if (flush_result.succeeded() && close_result.succeeded()) {
+        return result(DurableFileStatus::Succeeded);
+    }
+    return result(DurableFileStatus::EffectMayHaveOccurred);
+}
+
+DurableFileResult combine_read_results(const DurableFileResult &read_result,
+                                       const DurableFileResult &close_result,
+                                       bool observed_bytes) {
+    if (read_result.effect_may_have_occurred() ||
+        close_result.effect_may_have_occurred() ||
+        (observed_bytes && !close_result.succeeded())) {
+        return result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    if (!read_result.succeeded()) {
+        return read_result;
+    }
+    return close_result;
+}
+
+} // namespace
+
+bool DurableFileResult::succeeded() const noexcept {
+    return status == DurableFileStatus::Succeeded;
+}
+
+bool DurableFileResult::effect_may_have_occurred() const noexcept {
+    return status == DurableFileStatus::EffectMayHaveOccurred;
+}
+
+DurableFileResult retry_interrupted(DurableInterruptibleCall &call) {
+    while (true) {
+        auto call_result = call.attempt();
+        if (call_result.status != DurableFileStatus::Interrupted) {
+            return call_result;
+        }
+    }
+}
+
+DurableFileResult write_all(DurableFileChannel &channel,
+                            std::string_view bytes) {
+    std::size_t written = 0;
+    while (written < bytes.size()) {
+        const auto write_result = channel.write_some(bytes.substr(written));
+        if (write_result.result.status == DurableFileStatus::Interrupted) {
+            continue;
+        }
+        if (!write_result.result.succeeded()) {
+            if (written != 0 &&
+                !write_result.result.effect_may_have_occurred()) {
+                return result(DurableFileStatus::EffectMayHaveOccurred);
+            }
+            return write_result.result;
+        }
+        const auto remaining = bytes.size() - written;
+        if (write_result.bytes_written == 0 ||
+            write_result.bytes_written > remaining) {
+            return result(written == 0 ? DurableFileStatus::FailedBeforeEffect
+                                       : DurableFileStatus::EffectMayHaveOccurred);
+        }
+        written += write_result.bytes_written;
+    }
+    return result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult flush_retrying_interrupts(DurableFileChannel &channel) {
+    while (true) {
+        auto flush_result = channel.flush();
+        if (flush_result.status != DurableFileStatus::Interrupted) {
+            return flush_result;
+        }
+    }
+}
+
+DurableFileResult truncate_retrying_interrupts(DurableFileChannel &channel,
+                                               std::size_t bytes) {
+    while (true) {
+        auto truncate_result = channel.truncate(bytes);
+        if (truncate_result.status != DurableFileStatus::Interrupted) {
+            return truncate_result;
+        }
+    }
+}
+
+DurableFileResult close_once(DurableFileChannel &channel) {
+    return channel.close();
+}
+
+DurableFileResult close_read_once(DurableReadChannel &channel) {
+    return channel.close();
+}
+
+DurableFileResult write_flush_close(DurableFileChannel &channel,
+                                    std::string_view bytes) {
+    const auto write_result = write_all(channel, bytes);
+    const auto flush_result = flush_retrying_interrupts(channel);
+    const auto close_result = close_once(channel);
+    if (write_result.effect_may_have_occurred()) {
+        return result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return combine_transaction_results(write_result, flush_result, close_result);
+}
+
+DurableFileResult truncate_flush_close(DurableFileChannel &channel,
+                                       std::size_t bytes) {
+    const auto truncate_result = truncate_retrying_interrupts(channel, bytes);
+    const auto flush_result = flush_retrying_interrupts(channel);
+    const auto close_result = close_once(channel);
+    if (truncate_result.effect_may_have_occurred()) {
+        return result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return combine_transaction_results(truncate_result, flush_result,
+                                       close_result);
+}
+
+DurableReadResult read_bounded_close(DurableReadChannel &channel,
+                                     std::size_t max_bytes) {
+    std::string retained;
+    bool truncated = false;
+    auto read_result = result(DurableFileStatus::Succeeded);
+    while (true) {
+        const auto requested = std::min(
+            (max_bytes == std::numeric_limits<std::size_t>::max()
+                 ? max_bytes
+                 : max_bytes + 1) -
+                retained.size(),
+            durable_read_chunk_bytes);
+        const auto chunk_result = channel.read_some(requested);
+        if (chunk_result.result.status == DurableFileStatus::Interrupted) {
+            continue;
+        }
+        if (chunk_result.bytes.size() > requested ||
+            (chunk_result.result.succeeded() && chunk_result.bytes.empty() &&
+             !chunk_result.end_of_file)) {
+            read_result = result(retained.empty()
+                                     ? DurableFileStatus::FailedBeforeEffect
+                                     : DurableFileStatus::EffectMayHaveOccurred);
+            break;
+        }
+        if (!chunk_result.bytes.empty()) {
+            retained.append(chunk_result.bytes);
+        }
+        if (!chunk_result.result.succeeded()) {
+            read_result = chunk_result.result;
+            if (!retained.empty() &&
+                !read_result.effect_may_have_occurred()) {
+                read_result = result(DurableFileStatus::EffectMayHaveOccurred);
+            }
+            break;
+        }
+        if (retained.size() > max_bytes) {
+            retained.resize(max_bytes);
+            truncated = true;
+            break;
+        }
+        if (chunk_result.end_of_file) {
+            break;
+        }
+    }
+    const auto close_result = close_read_once(channel);
+    return {combine_read_results(read_result, close_result, !retained.empty()),
+            std::move(retained), truncated};
+}
+
+} // namespace lemon::residency::detail

--- a/src/cpp/server/residency/platform/durable_file_adapter.h
+++ b/src/cpp/server/residency/platform/durable_file_adapter.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include "lemon/residency/durable_journal.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace lemon::residency::detail {
+
+inline constexpr std::size_t durable_read_chunk_bytes = 64 * 1024;
+
+enum class DurableFileStatus {
+    Succeeded,
+    NotFound,
+    AlreadyExists,
+    Unsupported,
+    Interrupted,
+    FailedBeforeEffect,
+    EffectMayHaveOccurred,
+};
+
+struct DurableFileResult {
+    DurableFileStatus status = DurableFileStatus::Unsupported;
+    std::string diagnostic;
+
+    bool succeeded() const noexcept;
+    bool effect_may_have_occurred() const noexcept;
+};
+
+struct DurableReadResult {
+    DurableFileResult result;
+    std::string bytes;
+    bool truncated = false;
+};
+
+struct DurableReadChunkResult {
+    DurableFileResult result;
+    std::string bytes;
+    bool end_of_file = false;
+};
+
+struct DurableIdentityResult {
+    DurableFileResult result;
+    std::string identity;
+};
+
+struct DurableFixedNamespaceResult {
+    DurableFileResult result;
+    bool journal_present;
+    bool root_present;
+    bool journal_stage_present;
+    bool root_stage_present;
+    bool lock_present;
+};
+
+struct DurableWriteResult {
+    DurableFileResult result;
+    std::size_t bytes_written = 0;
+};
+
+class DurableFileChannel {
+public:
+    virtual ~DurableFileChannel() = default;
+
+    virtual DurableWriteResult write_some(std::string_view bytes) = 0;
+    virtual DurableFileResult flush() = 0;
+    virtual DurableFileResult truncate(std::size_t bytes) = 0;
+    virtual DurableFileResult close() = 0;
+};
+
+class DurableReadChannel {
+public:
+    virtual ~DurableReadChannel() = default;
+
+    virtual DurableReadChunkResult read_some(std::size_t max_bytes) = 0;
+    virtual DurableFileResult close() = 0;
+};
+
+class DurableInterruptibleCall {
+public:
+    virtual ~DurableInterruptibleCall() = default;
+    virtual DurableFileResult attempt() = 0;
+};
+
+DurableFileResult retry_interrupted(DurableInterruptibleCall &call);
+DurableFileResult write_all(DurableFileChannel &channel,
+                            std::string_view bytes);
+DurableFileResult flush_retrying_interrupts(DurableFileChannel &channel);
+DurableFileResult truncate_retrying_interrupts(DurableFileChannel &channel,
+                                               std::size_t bytes);
+DurableFileResult close_once(DurableFileChannel &channel);
+DurableFileResult close_read_once(DurableReadChannel &channel);
+DurableFileResult write_flush_close(DurableFileChannel &channel,
+                                    std::string_view bytes);
+DurableFileResult truncate_flush_close(DurableFileChannel &channel,
+                                       std::size_t bytes);
+DurableReadResult read_bounded_close(DurableReadChannel &channel,
+                                     std::size_t max_bytes);
+
+class DurableFileAdapter {
+public:
+    virtual ~DurableFileAdapter() = default;
+
+    virtual DurableFileResult lock_authority() = 0;
+    virtual DurableIdentityResult authority_identity() = 0;
+    virtual DurableFileResult preflight_capabilities() = 0;
+    virtual DurableFixedNamespaceResult inspect_fixed_namespace() = 0;
+    virtual DurableReadResult read_root(std::size_t max_bytes) = 0;
+    virtual DurableReadResult read_journal(std::size_t max_bytes) = 0;
+    virtual DurableFileResult create_journal(std::string_view bytes) = 0;
+    virtual DurableFileResult append_journal(std::string_view bytes) = 0;
+    virtual DurableFileResult truncate_journal(std::size_t bytes) = 0;
+    virtual DurableFileResult replace_journal(std::string_view bytes) = 0;
+    virtual DurableFileResult replace_root(std::string_view bytes) = 0;
+    virtual DurableFileResult unlock_authority() = 0;
+};
+
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter(const std::filesystem::path &directory);
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+enum class DurablePreflightTestFault {
+    ProbeIdentityCaptureFailureOnce,
+    StageIdentityCaptureFailureOnce,
+    StageCreateCollisionExhaustion,
+};
+
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter_for_test(
+    const std::filesystem::path &directory, DurablePreflightTestFault fault);
+
+class DurableJournalTestFactory {
+public:
+    static DurableJournal make(std::unique_ptr<DurableFileAdapter> adapter,
+                               JournalLimits limits);
+};
+
+DurableJournal
+make_durable_journal_for_test(std::unique_ptr<DurableFileAdapter> adapter,
+                              JournalLimits limits);
+#endif
+
+} // namespace lemon::residency::detail

--- a/src/cpp/server/residency/platform/durable_file_adapter_macos.cpp
+++ b/src/cpp/server/residency/platform/durable_file_adapter_macos.cpp
@@ -1,0 +1,1194 @@
+#include "platform/durable_file_adapter.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace lemon::residency::detail {
+
+namespace {
+
+constexpr std::string_view journal_name = "journal.jsonl";
+constexpr std::string_view root_name = "authority-root.json";
+constexpr std::string_view lock_name = "authority.lock";
+constexpr std::string_view journal_stage_name = ".journal.jsonl.stage";
+constexpr std::string_view root_stage_name = ".authority-root.json.stage";
+constexpr std::size_t preflight_collision_attempts = 8;
+std::atomic<std::uint64_t> preflight_sequence{0};
+
+struct PreflightNames {
+    std::string probe;
+    std::string stage;
+};
+
+PreflightNames next_preflight_names() {
+    const auto sequence =
+        preflight_sequence.fetch_add(1, std::memory_order_relaxed);
+    auto probe = ".durability-probe." +
+                 std::to_string(static_cast<std::uint64_t>(::getpid())) + "." +
+                 std::to_string(sequence);
+    return {probe, probe + ".stage"};
+}
+
+DurableFileResult make_result(DurableFileStatus status) {
+    return {status, {}};
+}
+
+DurableFileResult make_errno_result(DurableFileStatus status,
+                                    int error_number) {
+    return {status, std::strerror(error_number)};
+}
+
+DurableFileResult open_error_result(int error_number) {
+    if (error_number == EINTR) {
+        return make_errno_result(DurableFileStatus::Interrupted, error_number);
+    }
+    if (error_number == ENOENT) {
+        return make_errno_result(DurableFileStatus::NotFound, error_number);
+    }
+    if (error_number == EEXIST) {
+        return make_errno_result(DurableFileStatus::AlreadyExists,
+                                 error_number);
+    }
+    if (error_number == ELOOP || error_number == EISDIR ||
+        error_number == ENOTDIR) {
+        return make_errno_result(DurableFileStatus::Unsupported, error_number);
+    }
+    return make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                             error_number);
+}
+
+DurableFileResult close_open_descriptor(int descriptor,
+                                        DurableFileResult operation_result) {
+    if (::close(descriptor) != 0 && operation_result.succeeded()) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    return operation_result;
+}
+
+void close_best_effort(int descriptor) {
+    if (descriptor >= 0) {
+        static_cast<void>(::close(descriptor));
+    }
+}
+
+class MacosDurableFileChannel final : public DurableFileChannel {
+public:
+    explicit MacosDurableFileChannel(int descriptor)
+        : descriptor_(descriptor) {}
+
+    ~MacosDurableFileChannel() override { close_best_effort(descriptor_); }
+
+    DurableWriteResult write_some(std::string_view bytes) override {
+        const auto request = std::min(
+            bytes.size(), static_cast<std::size_t>(
+                              std::numeric_limits<ssize_t>::max()));
+        const auto written = ::write(descriptor_, bytes.data(), request);
+        if (written < 0) {
+            if (errno == EINTR) {
+                return {make_errno_result(DurableFileStatus::Interrupted,
+                                          errno),
+                        0};
+            }
+            return {make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                      errno),
+                    0};
+        }
+        return {make_result(DurableFileStatus::Succeeded),
+                static_cast<std::size_t>(written)};
+    }
+
+    DurableFileResult flush() override {
+        if (::fcntl(descriptor_, F_FULLFSYNC) != 0) {
+            if (errno == EINTR) {
+                return make_errno_result(DurableFileStatus::Interrupted,
+                                         errno);
+            }
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableFileResult truncate(std::size_t bytes) override {
+        if (bytes > static_cast<std::size_t>(
+                        std::numeric_limits<off_t>::max())) {
+            return make_result(DurableFileStatus::FailedBeforeEffect);
+        }
+        if (::ftruncate(descriptor_, static_cast<off_t>(bytes)) != 0) {
+            if (errno == EINTR) {
+                return make_errno_result(DurableFileStatus::Interrupted,
+                                         errno);
+            }
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableFileResult close() override {
+        const auto descriptor = std::exchange(descriptor_, -1);
+        if (::close(descriptor) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    int descriptor_;
+};
+
+class MacosDurableReadChannel final : public DurableReadChannel {
+public:
+    explicit MacosDurableReadChannel(int descriptor)
+        : descriptor_(descriptor) {}
+
+    ~MacosDurableReadChannel() override { close_best_effort(descriptor_); }
+
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const auto request =
+            std::min(max_bytes, std::size_t(2147483647));
+        std::string buffer(request, '\0');
+        const auto transferred =
+            ::read(descriptor_, buffer.data(), request);
+        if (transferred < 0) {
+            if (errno == EINTR) {
+                return {make_errno_result(DurableFileStatus::Interrupted,
+                                          errno),
+                        {}, false};
+            }
+            return {make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                      errno),
+                    {}, false};
+        }
+        buffer.resize(static_cast<std::size_t>(transferred));
+        return {make_result(DurableFileStatus::Succeeded), std::move(buffer),
+                transferred == 0};
+    }
+
+    DurableFileResult close() override {
+        const auto descriptor = std::exchange(descriptor_, -1);
+        if (::close(descriptor) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    int descriptor_;
+};
+
+DurableFileResult lock_file_retrying_interrupts(int lock_fd) {
+    class LockCall final : public DurableInterruptibleCall {
+    public:
+        explicit LockCall(int lock_fd) : lock_fd_(lock_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(lock_fd_, LOCK_EX) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::FailedBeforeEffect, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int lock_fd_;
+    };
+    LockCall call(lock_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult unlock_file_retrying_interrupts(int lock_fd) {
+    class UnlockCall final : public DurableInterruptibleCall {
+    public:
+        explicit UnlockCall(int lock_fd) : lock_fd_(lock_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(lock_fd_, LOCK_UN) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int lock_fd_;
+    };
+    UnlockCall call(lock_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult lock_directory_retrying_interrupts(int directory_fd) {
+    class DirectoryLockCall final : public DurableInterruptibleCall {
+    public:
+        explicit DirectoryLockCall(int directory_fd)
+            : directory_fd_(directory_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(directory_fd_, LOCK_EX) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::FailedBeforeEffect, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int directory_fd_;
+    };
+    DirectoryLockCall call(directory_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult unlock_directory_retrying_interrupts(int directory_fd) {
+    class DirectoryUnlockCall final : public DurableInterruptibleCall {
+    public:
+        explicit DirectoryUnlockCall(int directory_fd)
+            : directory_fd_(directory_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(directory_fd_, LOCK_UN) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int directory_fd_;
+    };
+    DirectoryUnlockCall call(directory_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
+    class DirectorySyncCall final : public DurableInterruptibleCall {
+    public:
+        explicit DirectorySyncCall(int directory_fd)
+            : directory_fd_(directory_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::fsync(directory_fd_) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int directory_fd_;
+    };
+    DirectorySyncCall call(directory_fd);
+    return retry_interrupted(call);
+}
+
+struct MacosFileIdentity {
+    dev_t device;
+    ino_t inode;
+};
+
+DurableFileResult capture_regular_identity(
+    int descriptor, MacosFileIdentity &identity) {
+    struct stat information {};
+    if (::fstat(descriptor, &information) != 0) {
+        return make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                 errno);
+    }
+    if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+        return make_result(DurableFileStatus::Unsupported);
+    }
+    identity = {information.st_dev, information.st_ino};
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult post_create_failure(DurableFileResult failure) {
+    failure.status = DurableFileStatus::EffectMayHaveOccurred;
+    return failure;
+}
+
+bool same_file_identity(const MacosFileIdentity &left,
+                        const MacosFileIdentity &right) {
+    return left.device == right.device && left.inode == right.inode;
+}
+
+DurableFileResult verify_replaced_target(
+    int directory_fd, std::string_view target_name,
+    const MacosFileIdentity &expected_identity,
+    std::string_view expected_bytes) {
+    int descriptor;
+    do {
+        descriptor = ::openat(directory_fd, target_name.data(),
+                              O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    } while (descriptor < 0 && errno == EINTR);
+    if (descriptor < 0) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    struct stat information {};
+    if (::fstat(descriptor, &information) != 0) {
+        const auto error_number = errno;
+        return close_open_descriptor(
+            descriptor,
+            make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                              error_number));
+    }
+    if (!S_ISREG(information.st_mode) || information.st_nlink != 1 ||
+        information.st_dev != expected_identity.device ||
+        information.st_ino != expected_identity.inode) {
+        return close_open_descriptor(
+            descriptor,
+            make_result(DurableFileStatus::EffectMayHaveOccurred));
+    }
+    MacosDurableReadChannel channel(descriptor);
+    const auto observed = read_bounded_close(channel, expected_bytes.size());
+    if (!observed.result.succeeded()) {
+        return {DurableFileStatus::EffectMayHaveOccurred,
+                observed.result.diagnostic};
+    }
+    const auto observed_bytes =
+        std::string_view(observed.bytes.data(), observed.bytes.size());
+    if (observed.truncated || observed_bytes != expected_bytes) {
+        return make_result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult clear_verified_stage(int descriptor) {
+    while (::ftruncate(descriptor, 0) != 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult verify_owned_probe(
+    int directory_fd, std::string_view name,
+    const MacosFileIdentity &expected_identity) {
+    struct stat information {};
+    if (::fstatat(directory_fd, name.data(), &information,
+                  AT_SYMLINK_NOFOLLOW) != 0) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    const MacosFileIdentity observed{information.st_dev,
+                                     information.st_ino};
+    if (!S_ISREG(information.st_mode) || information.st_nlink != 1 ||
+        !same_file_identity(observed, expected_identity)) {
+        return make_result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult remove_owned_probe(
+    int directory_fd, std::string_view name,
+    const MacosFileIdentity &expected_identity) {
+    const auto verified =
+        verify_owned_probe(directory_fd, name, expected_identity);
+    if (!verified.succeeded()) {
+        return verified;
+    }
+    if (::unlinkat(directory_fd, name.data(), 0) != 0) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+class MacosDurableFileAdapter final : public DurableFileAdapter {
+public:
+    explicit MacosDurableFileAdapter(int directory_fd)
+        : directory_fd_(directory_fd) {}
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    MacosDurableFileAdapter(int directory_fd,
+                            DurablePreflightTestFault preflight_test_fault)
+        : directory_fd_(directory_fd),
+          preflight_test_fault_(preflight_test_fault) {}
+#endif
+
+    ~MacosDurableFileAdapter() override {
+        close_best_effort(lock_fd_);
+        close_best_effort(directory_fd_);
+    }
+
+    DurableFileResult lock_authority() override {
+        if (directory_fd_ < 0 || lock_fd_ >= 0 || directory_lock_held_) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto directory_lock_result =
+            lock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_lock_result.succeeded()) {
+            return directory_lock_result;
+        }
+        directory_lock_held_ = true;
+
+        int opened_fd;
+        do {
+            opened_fd = ::openat(directory_fd_, lock_name.data(),
+                                 O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                                 0600);
+        } while (opened_fd < 0 && errno == EINTR);
+        if (opened_fd < 0) {
+            const auto error_number = errno;
+            return release_directory_after_failed_lock(
+                open_error_result(error_number));
+        }
+        lock_fd_ = opened_fd;
+        const auto lock_result = lock_file_retrying_interrupts(lock_fd_);
+        if (!lock_result.succeeded()) {
+            return close_unlocked_after_failed_lock(lock_result);
+        }
+
+        struct stat opened_information {};
+        if (::fstat(lock_fd_, &opened_information) != 0) {
+            const auto error_number = errno;
+            return abandon_failed_lock(make_errno_result(
+                DurableFileStatus::Unsupported, error_number));
+        }
+        struct stat current_information {};
+        if (::fstatat(directory_fd_, lock_name.data(), &current_information,
+                      AT_SYMLINK_NOFOLLOW) != 0) {
+            const auto error_number = errno;
+            return abandon_failed_lock(make_errno_result(
+                DurableFileStatus::Unsupported, error_number));
+        }
+        if (!S_ISREG(opened_information.st_mode) ||
+            !S_ISREG(current_information.st_mode) ||
+            opened_information.st_nlink == 0 ||
+            current_information.st_nlink == 0 ||
+            opened_information.st_dev != current_information.st_dev ||
+            opened_information.st_ino != current_information.st_ino) {
+            return abandon_failed_lock(
+                make_result(DurableFileStatus::Unsupported));
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableIdentityResult authority_identity() override {
+        if (directory_fd_ < 0 || lock_fd_ < 0 || !directory_lock_held_) {
+            return {make_result(DurableFileStatus::Unsupported), {}};
+        }
+        struct stat directory_information {};
+        if (::fstat(directory_fd_, &directory_information) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }
+        struct stat lock_information {};
+        if (::fstat(lock_fd_, &lock_information) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }
+        struct stat current_lock_information {};
+        if (::fstatat(directory_fd_, lock_name.data(),
+                      &current_lock_information, AT_SYMLINK_NOFOLLOW) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }
+        if (!S_ISDIR(directory_information.st_mode) ||
+            !S_ISREG(lock_information.st_mode) ||
+            !S_ISREG(current_lock_information.st_mode) ||
+            lock_information.st_nlink == 0 ||
+            current_lock_information.st_nlink == 0 ||
+            lock_information.st_dev != current_lock_information.st_dev ||
+            lock_information.st_ino != current_lock_information.st_ino) {
+            return {make_result(DurableFileStatus::Unsupported), {}};
+        }
+        return {make_result(DurableFileStatus::Succeeded),
+                "directory:" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(directory_information.st_dev)) +
+                    ":" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(directory_information.st_ino)) +
+                    "/lock:" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(lock_information.st_dev)) +
+                    ":" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(lock_information.st_ino))};
+    }
+
+    DurableFileResult preflight_capabilities() override {
+        if (directory_fd_ < 0 || lock_fd_ < 0) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        for (const auto name : {journal_name, root_name, lock_name,
+                                journal_stage_name, root_stage_name}) {
+            struct stat information {};
+            if (::fstatat(directory_fd_, name.data(), &information,
+                          AT_SYMLINK_NOFOLLOW) != 0) {
+                if (errno == ENOENT) {
+                    continue;
+                }
+                return make_errno_result(DurableFileStatus::Unsupported,
+                                         errno);
+            }
+            if (!S_ISREG(information.st_mode) ||
+                (name != lock_name && information.st_nlink != 1) ||
+                (name == lock_name && information.st_nlink == 0)) {
+                return make_result(DurableFileStatus::Unsupported);
+            }
+        }
+
+        bool scratch_create_succeeded = false;
+        const auto terminal_failure = [&](DurableFileResult failure) {
+            if (scratch_create_succeeded && !failure.succeeded()) {
+                failure.status = DurableFileStatus::EffectMayHaveOccurred;
+            }
+            return failure;
+        };
+        for (std::size_t attempt = 0;
+             attempt < preflight_collision_attempts; ++attempt) {
+            const auto names = next_preflight_names();
+            MacosFileIdentity probe_identity {};
+            MacosFileIdentity stage_identity {};
+            bool probe_owned = false;
+            bool stage_owned = false;
+            const auto cleanup_owned = [&]() {
+                auto result = make_result(DurableFileStatus::Succeeded);
+                if (stage_owned) {
+                    const auto removed = remove_owned_probe(
+                        directory_fd_, names.stage, stage_identity);
+                    if (removed.succeeded()) {
+                        stage_owned = false;
+                    } else {
+                        result = removed;
+                    }
+                }
+                if (probe_owned) {
+                    const auto removed = remove_owned_probe(
+                        directory_fd_, names.probe, probe_identity);
+                    if (removed.succeeded()) {
+                        probe_owned = false;
+                    } else if (result.succeeded()) {
+                        result = removed;
+                    }
+                }
+                return result;
+            };
+            const auto fail_after_cleanup =
+                [&](DurableFileResult failure) {
+                    const auto cleanup = cleanup_owned();
+                    return terminal_failure(cleanup.succeeded() ? failure
+                                                                : cleanup);
+                };
+
+            int probe_fd;
+            do {
+                probe_fd = ::openat(directory_fd_, names.probe.c_str(),
+                                    O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC |
+                                        O_NOFOLLOW,
+                                    0600);
+            } while (probe_fd < 0 && errno == EINTR);
+            if (probe_fd < 0) {
+                if (errno == EEXIST) {
+                    continue;
+                }
+                return terminal_failure(open_error_result(errno));
+            }
+            scratch_create_succeeded = true;
+            auto probe_safe =
+                capture_regular_identity(probe_fd, probe_identity);
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            probe_safe = apply_created_identity_test_fault(
+                DurablePreflightTestFault::ProbeIdentityCaptureFailureOnce,
+                std::move(probe_safe));
+#endif
+            if (!probe_safe.succeeded()) {
+                return terminal_failure(close_open_descriptor(
+                    probe_fd, post_create_failure(probe_safe)));
+            }
+            probe_owned = true;
+            MacosDurableFileChannel probe_channel(probe_fd);
+            auto flush_probe =
+                write_flush_close(probe_channel, "durability-probe");
+            if (!flush_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                flush_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return flush_probe;
+            }
+
+            int truncate_fd;
+            do {
+                truncate_fd = ::openat(directory_fd_, names.probe.c_str(),
+                                       O_RDWR | O_CLOEXEC | O_NOFOLLOW);
+            } while (truncate_fd < 0 && errno == EINTR);
+            if (truncate_fd < 0) {
+                return fail_after_cleanup(open_error_result(errno));
+            }
+            MacosFileIdentity truncate_identity {};
+            const auto truncate_safe =
+                capture_regular_identity(truncate_fd, truncate_identity);
+            if (!truncate_safe.succeeded() ||
+                !same_file_identity(truncate_identity, probe_identity)) {
+                const auto result = close_open_descriptor(
+                    truncate_fd,
+                    truncate_safe.succeeded()
+                        ? make_result(DurableFileStatus::EffectMayHaveOccurred)
+                        : post_create_failure(truncate_safe));
+                return fail_after_cleanup(result);
+            }
+            MacosDurableFileChannel truncate_channel(truncate_fd);
+            auto truncate_probe =
+                truncate_flush_close(truncate_channel, 0);
+            if (!truncate_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                truncate_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return truncate_probe;
+            }
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            const auto collision = seed_stage_collision_for_test(names.stage);
+            if (!collision.succeeded()) {
+                return fail_after_cleanup(collision);
+            }
+#endif
+            int stage_fd;
+            do {
+                stage_fd = ::openat(directory_fd_, names.stage.c_str(),
+                                    O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                        O_NOFOLLOW,
+                                    0600);
+            } while (stage_fd < 0 && errno == EINTR);
+            if (stage_fd < 0) {
+                const auto error_number = errno;
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                if (error_number == EEXIST) {
+                    continue;
+                }
+                return terminal_failure(open_error_result(error_number));
+            }
+            scratch_create_succeeded = true;
+            auto stage_safe =
+                capture_regular_identity(stage_fd, stage_identity);
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            stage_safe = apply_created_identity_test_fault(
+                DurablePreflightTestFault::StageIdentityCaptureFailureOnce,
+                std::move(stage_safe));
+#endif
+            if (!stage_safe.succeeded()) {
+                return fail_after_cleanup(
+                    close_open_descriptor(stage_fd,
+                                          post_create_failure(stage_safe)));
+            }
+            stage_owned = true;
+            MacosDurableFileChannel stage_channel(stage_fd);
+            auto replace_probe =
+                write_flush_close(stage_channel, "replacement-probe");
+            if (!replace_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                replace_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return replace_probe;
+            }
+            const auto stage_current = verify_owned_probe(
+                directory_fd_, names.stage, stage_identity);
+            const auto probe_current = verify_owned_probe(
+                directory_fd_, names.probe, probe_identity);
+            if (!stage_current.succeeded() || !probe_current.succeeded()) {
+                return fail_after_cleanup(
+                    !stage_current.succeeded() ? stage_current
+                                               : probe_current);
+            }
+            const auto replaced =
+                ::renameat(directory_fd_, names.stage.c_str(), directory_fd_,
+                           names.probe.c_str());
+            if (replaced != 0) {
+                return fail_after_cleanup(make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno));
+            }
+            probe_identity = stage_identity;
+            probe_owned = true;
+            stage_owned = false;
+            const auto cleanup = cleanup_owned();
+            if (!cleanup.succeeded()) {
+                return terminal_failure(cleanup);
+            }
+            const auto namespace_result =
+                sync_directory_retrying_interrupts(directory_fd_);
+            if (!namespace_result.succeeded()) {
+                return terminal_failure(namespace_result);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+        return terminal_failure(
+            make_errno_result(DurableFileStatus::AlreadyExists, EEXIST));
+    }
+
+    DurableFixedNamespaceResult inspect_fixed_namespace() override {
+        DurableFixedNamespaceResult inspected{
+            make_result(DurableFileStatus::Succeeded), false, false, false,
+            false, false};
+        const std::array<std::pair<std::string_view, bool *>, 5> entries{
+            std::pair{journal_name, &inspected.journal_present},
+            std::pair{root_name, &inspected.root_present},
+            std::pair{journal_stage_name, &inspected.journal_stage_present},
+            std::pair{root_stage_name, &inspected.root_stage_present},
+            std::pair{lock_name, &inspected.lock_present},
+        };
+        for (const auto &[name, present] : entries) {
+            struct stat information {};
+            if (::fstatat(directory_fd_, name.data(), &information,
+                          AT_SYMLINK_NOFOLLOW) != 0) {
+                if (errno == ENOENT) {
+                    continue;
+                }
+                inspected.result =
+                    make_errno_result(DurableFileStatus::Unsupported, errno);
+                return inspected;
+            }
+            if (!S_ISREG(information.st_mode) ||
+                (name != lock_name && information.st_nlink != 1) ||
+                (name == lock_name && information.st_nlink == 0)) {
+                inspected.result =
+                    make_result(DurableFileStatus::Unsupported);
+                return inspected;
+            }
+            *present = true;
+        }
+        return inspected;
+    }
+
+    DurableReadResult read_root(std::size_t max_bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, root_name.data(),
+                                  O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return {open_error_result(errno), {}, false};
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_errno_result(DurableFileStatus::Unsupported,
+                                          errno)),
+                    {}, false};
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        MacosDurableReadChannel channel(descriptor);
+        return read_bounded_close(channel, max_bytes);
+    }
+
+    DurableReadResult read_journal(std::size_t max_bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return {open_error_result(errno), {}, false};
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_errno_result(DurableFileStatus::Unsupported,
+                                          errno)),
+                    {}, false};
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        MacosDurableReadChannel channel(descriptor);
+        return read_bounded_close(channel, max_bytes);
+    }
+
+    DurableFileResult create_journal(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                      O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        MacosDurableFileChannel channel(descriptor);
+        const auto persisted = write_flush_close(channel, bytes);
+        if (!persisted.succeeded() &&
+            !persisted.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    persisted.diagnostic};
+        }
+        return persisted;
+    }
+
+    DurableFileResult append_journal(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_WRONLY | O_APPEND | O_CLOEXEC |
+                                      O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::Unsupported));
+        }
+        MacosDurableFileChannel channel(descriptor);
+        return write_flush_close(channel, bytes);
+    }
+
+    DurableFileResult truncate_journal(std::size_t bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_RDWR | O_CLOEXEC | O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::Unsupported));
+        }
+        MacosDurableFileChannel channel(descriptor);
+        return truncate_flush_close(channel, bytes);
+    }
+
+    DurableFileResult replace_journal(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_stage_name.data(),
+                                  O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        const MacosFileIdentity staged_identity{information.st_dev,
+                                                information.st_ino};
+        const auto cleared = clear_verified_stage(descriptor);
+        if (!cleared.succeeded()) {
+            return close_open_descriptor(descriptor, cleared);
+        }
+        MacosDurableFileChannel channel(descriptor);
+        const auto staged = write_flush_close(channel, bytes);
+        if (!staged.succeeded() && !staged.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    staged.diagnostic};
+        }
+        if (!staged.succeeded()) {
+            return staged;
+        }
+        if (::renameat(directory_fd_, journal_stage_name.data(), directory_fd_,
+                       journal_name.data()) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        const auto namespace_result =
+            sync_directory_retrying_interrupts(directory_fd_);
+        if (!namespace_result.succeeded()) {
+            return namespace_result;
+        }
+        return verify_replaced_target(directory_fd_, journal_name,
+                                      staged_identity, bytes);
+    }
+
+    DurableFileResult replace_root(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, root_stage_name.data(),
+                                  O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        const MacosFileIdentity staged_identity{information.st_dev,
+                                                information.st_ino};
+        const auto cleared = clear_verified_stage(descriptor);
+        if (!cleared.succeeded()) {
+            return close_open_descriptor(descriptor, cleared);
+        }
+        MacosDurableFileChannel channel(descriptor);
+        const auto staged = write_flush_close(channel, bytes);
+        if (!staged.succeeded() && !staged.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    staged.diagnostic};
+        }
+        if (!staged.succeeded()) {
+            return staged;
+        }
+        if (::renameat(directory_fd_, root_stage_name.data(), directory_fd_,
+                       root_name.data()) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        const auto namespace_result =
+            sync_directory_retrying_interrupts(directory_fd_);
+        if (!namespace_result.succeeded()) {
+            return namespace_result;
+        }
+        return verify_replaced_target(directory_fd_, root_name,
+                                      staged_identity, bytes);
+    }
+
+    DurableFileResult unlock_authority() override {
+        if (lock_fd_ < 0 || !directory_lock_held_) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto descriptor = std::exchange(lock_fd_, -1);
+        const auto unlock_result =
+            unlock_file_retrying_interrupts(descriptor);
+        const auto close_result = ::close(descriptor);
+        const auto close_error_number = close_result == 0 ? 0 : errno;
+        const auto directory_unlock_result =
+            unlock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_unlock_result.succeeded()) {
+            return directory_unlock_result;
+        }
+        directory_lock_held_ = false;
+        if (!unlock_result.succeeded() && close_result != 0) {
+            return make_result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        if (!unlock_result.succeeded()) {
+            return unlock_result;
+        }
+        if (close_result != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred,
+                close_error_number);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    DurableFileResult release_directory_after_failed_lock(
+        DurableFileResult failure) {
+        const auto directory_unlock_result =
+            unlock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_unlock_result.succeeded()) {
+            return directory_unlock_result;
+        }
+        directory_lock_held_ = false;
+        return failure;
+    }
+
+    DurableFileResult close_unlocked_after_failed_lock(
+        DurableFileResult failure) {
+        const auto descriptor = std::exchange(lock_fd_, -1);
+        if (::close(descriptor) != 0) {
+            const auto error_number = errno;
+            failure = make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, error_number);
+        }
+        return release_directory_after_failed_lock(std::move(failure));
+    }
+
+    DurableFileResult abandon_failed_lock(DurableFileResult failure) {
+        const auto descriptor = std::exchange(lock_fd_, -1);
+        const auto unlock_result =
+            unlock_file_retrying_interrupts(descriptor);
+        const auto close_result = ::close(descriptor);
+        const auto close_error_number = close_result == 0 ? 0 : errno;
+        const auto directory_unlock_result =
+            unlock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_unlock_result.succeeded()) {
+            return directory_unlock_result;
+        }
+        directory_lock_held_ = false;
+        if (!unlock_result.succeeded() && close_result != 0) {
+            return make_result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        if (!unlock_result.succeeded()) {
+            return unlock_result;
+        }
+        if (close_result != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred,
+                close_error_number);
+        }
+        return failure;
+    }
+
+    int directory_fd_;
+    int lock_fd_ = -1;
+    bool directory_lock_held_ = false;
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    DurableFileResult seed_stage_collision_for_test(
+        const std::string &name) noexcept {
+        if (preflight_test_fault_ !=
+            DurablePreflightTestFault::StageCreateCollisionExhaustion) {
+            return make_result(DurableFileStatus::Succeeded);
+        }
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, name.c_str(),
+                                  O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                      O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        MacosDurableFileChannel channel(descriptor);
+        const auto written = write_flush_close(
+            channel, "caller-owned-stage-collision");
+        if (!written.succeeded()) {
+            return written;
+        }
+        return sync_directory_retrying_interrupts(directory_fd_);
+    }
+
+    DurableFileResult apply_created_identity_test_fault(
+        DurablePreflightTestFault phase,
+        DurableFileResult captured) noexcept {
+        if (captured.succeeded() && preflight_test_fault_ == phase &&
+            !preflight_test_fault_taken_) {
+            preflight_test_fault_taken_ = true;
+            return make_result(DurableFileStatus::FailedBeforeEffect);
+        }
+        return captured;
+    }
+    std::optional<DurablePreflightTestFault> preflight_test_fault_;
+    bool preflight_test_fault_taken_ = false;
+#endif
+};
+
+} // namespace
+
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter(const std::filesystem::path &directory) {
+    int directory_fd;
+    do {
+        directory_fd = ::open(directory.c_str(),
+                              O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+    } while (directory_fd < 0 && errno == EINTR);
+    return std::make_unique<MacosDurableFileAdapter>(directory_fd);
+}
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter_for_test(
+    const std::filesystem::path &directory, DurablePreflightTestFault fault) {
+    int directory_fd;
+    do {
+        directory_fd = ::open(directory.c_str(),
+                              O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+    } while (directory_fd < 0 && errno == EINTR);
+    return std::make_unique<MacosDurableFileAdapter>(directory_fd, fault);
+}
+#endif
+
+} // namespace lemon::residency::detail

--- a/src/cpp/server/residency/platform/durable_file_adapter_macos.cpp
+++ b/src/cpp/server/residency/platform/durable_file_adapter_macos.cpp
@@ -5,13 +5,13 @@
 #include <atomic>
 #include <cerrno>
 #include <cstdint>
-#include <cstring>
 #include <filesystem>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 #include <fcntl.h>
@@ -52,7 +52,7 @@ DurableFileResult make_result(DurableFileStatus status) {
 
 DurableFileResult make_errno_result(DurableFileStatus status,
                                     int error_number) {
-    return {status, std::strerror(error_number)};
+    return {status, std::generic_category().message(error_number)};
 }
 
 DurableFileResult open_error_result(int error_number) {

--- a/src/cpp/server/residency/platform/durable_file_adapter_posix.cpp
+++ b/src/cpp/server/residency/platform/durable_file_adapter_posix.cpp
@@ -5,13 +5,13 @@
 #include <atomic>
 #include <cerrno>
 #include <cstdint>
-#include <cstring>
 #include <filesystem>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 #include <fcntl.h>
@@ -52,7 +52,7 @@ DurableFileResult make_result(DurableFileStatus status) {
 
 DurableFileResult make_errno_result(DurableFileStatus status,
                                     int error_number) {
-    return {status, std::strerror(error_number)};
+    return {status, std::generic_category().message(error_number)};
 }
 
 DurableFileResult open_error_result(int error_number) {

--- a/src/cpp/server/residency/platform/durable_file_adapter_posix.cpp
+++ b/src/cpp/server/residency/platform/durable_file_adapter_posix.cpp
@@ -1,0 +1,1194 @@
+#include "platform/durable_file_adapter.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace lemon::residency::detail {
+
+namespace {
+
+constexpr std::string_view journal_name = "journal.jsonl";
+constexpr std::string_view root_name = "authority-root.json";
+constexpr std::string_view lock_name = "authority.lock";
+constexpr std::string_view journal_stage_name = ".journal.jsonl.stage";
+constexpr std::string_view root_stage_name = ".authority-root.json.stage";
+constexpr std::size_t preflight_collision_attempts = 8;
+std::atomic<std::uint64_t> preflight_sequence{0};
+
+struct PreflightNames {
+    std::string probe;
+    std::string stage;
+};
+
+PreflightNames next_preflight_names() {
+    const auto sequence =
+        preflight_sequence.fetch_add(1, std::memory_order_relaxed);
+    auto probe = ".durability-probe." +
+                 std::to_string(static_cast<std::uint64_t>(::getpid())) + "." +
+                 std::to_string(sequence);
+    return {probe, probe + ".stage"};
+}
+
+DurableFileResult make_result(DurableFileStatus status) {
+    return {status, {}};
+}
+
+DurableFileResult make_errno_result(DurableFileStatus status,
+                                    int error_number) {
+    return {status, std::strerror(error_number)};
+}
+
+DurableFileResult open_error_result(int error_number) {
+    if (error_number == EINTR) {
+        return make_errno_result(DurableFileStatus::Interrupted, error_number);
+    }
+    if (error_number == ENOENT) {
+        return make_errno_result(DurableFileStatus::NotFound, error_number);
+    }
+    if (error_number == EEXIST) {
+        return make_errno_result(DurableFileStatus::AlreadyExists,
+                                 error_number);
+    }
+    if (error_number == ELOOP || error_number == EISDIR ||
+        error_number == ENOTDIR) {
+        return make_errno_result(DurableFileStatus::Unsupported, error_number);
+    }
+    return make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                             error_number);
+}
+
+DurableFileResult close_open_descriptor(int descriptor,
+                                        DurableFileResult operation_result) {
+    if (::close(descriptor) != 0 && operation_result.succeeded()) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    return operation_result;
+}
+
+void close_best_effort(int descriptor) {
+    if (descriptor >= 0) {
+        static_cast<void>(::close(descriptor));
+    }
+}
+
+class PosixDurableFileChannel final : public DurableFileChannel {
+public:
+    explicit PosixDurableFileChannel(int descriptor)
+        : descriptor_(descriptor) {}
+
+    ~PosixDurableFileChannel() override { close_best_effort(descriptor_); }
+
+    DurableWriteResult write_some(std::string_view bytes) override {
+        const auto request = std::min(
+            bytes.size(), static_cast<std::size_t>(
+                              std::numeric_limits<ssize_t>::max()));
+        const auto written = ::write(descriptor_, bytes.data(), request);
+        if (written < 0) {
+            if (errno == EINTR) {
+                return {make_errno_result(DurableFileStatus::Interrupted,
+                                          errno),
+                        0};
+            }
+            return {make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                      errno),
+                    0};
+        }
+        return {make_result(DurableFileStatus::Succeeded),
+                static_cast<std::size_t>(written)};
+    }
+
+    DurableFileResult flush() override {
+        if (::fsync(descriptor_) != 0) {
+            if (errno == EINTR) {
+                return make_errno_result(DurableFileStatus::Interrupted,
+                                         errno);
+            }
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableFileResult truncate(std::size_t bytes) override {
+        if (bytes > static_cast<std::size_t>(
+                        std::numeric_limits<off_t>::max())) {
+            return make_result(DurableFileStatus::FailedBeforeEffect);
+        }
+        if (::ftruncate(descriptor_, static_cast<off_t>(bytes)) != 0) {
+            if (errno == EINTR) {
+                return make_errno_result(DurableFileStatus::Interrupted,
+                                         errno);
+            }
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableFileResult close() override {
+        const auto descriptor = std::exchange(descriptor_, -1);
+        if (::close(descriptor) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    int descriptor_;
+};
+
+class PosixDurableReadChannel final : public DurableReadChannel {
+public:
+    explicit PosixDurableReadChannel(int descriptor)
+        : descriptor_(descriptor) {}
+
+    ~PosixDurableReadChannel() override { close_best_effort(descriptor_); }
+
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const auto request =
+            std::min(max_bytes, std::size_t(2147483647));
+        std::string buffer(request, '\0');
+        const auto transferred =
+            ::read(descriptor_, buffer.data(), request);
+        if (transferred < 0) {
+            if (errno == EINTR) {
+                return {make_errno_result(DurableFileStatus::Interrupted,
+                                          errno),
+                        {}, false};
+            }
+            return {make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                      errno),
+                    {}, false};
+        }
+        buffer.resize(static_cast<std::size_t>(transferred));
+        return {make_result(DurableFileStatus::Succeeded), std::move(buffer),
+                transferred == 0};
+    }
+
+    DurableFileResult close() override {
+        const auto descriptor = std::exchange(descriptor_, -1);
+        if (::close(descriptor) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    int descriptor_;
+};
+
+DurableFileResult lock_file_retrying_interrupts(int lock_fd) {
+    class LockCall final : public DurableInterruptibleCall {
+    public:
+        explicit LockCall(int lock_fd) : lock_fd_(lock_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(lock_fd_, LOCK_EX) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::FailedBeforeEffect, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int lock_fd_;
+    };
+    LockCall call(lock_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult unlock_file_retrying_interrupts(int lock_fd) {
+    class UnlockCall final : public DurableInterruptibleCall {
+    public:
+        explicit UnlockCall(int lock_fd) : lock_fd_(lock_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(lock_fd_, LOCK_UN) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int lock_fd_;
+    };
+    UnlockCall call(lock_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult lock_directory_retrying_interrupts(int directory_fd) {
+    class DirectoryLockCall final : public DurableInterruptibleCall {
+    public:
+        explicit DirectoryLockCall(int directory_fd)
+            : directory_fd_(directory_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(directory_fd_, LOCK_EX) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::FailedBeforeEffect, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int directory_fd_;
+    };
+    DirectoryLockCall call(directory_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult unlock_directory_retrying_interrupts(int directory_fd) {
+    class DirectoryUnlockCall final : public DurableInterruptibleCall {
+    public:
+        explicit DirectoryUnlockCall(int directory_fd)
+            : directory_fd_(directory_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::flock(directory_fd_, LOCK_UN) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int directory_fd_;
+    };
+    DirectoryUnlockCall call(directory_fd);
+    return retry_interrupted(call);
+}
+
+DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
+    class DirectorySyncCall final : public DurableInterruptibleCall {
+    public:
+        explicit DirectorySyncCall(int directory_fd)
+            : directory_fd_(directory_fd) {}
+
+        DurableFileResult attempt() override {
+            if (::fsync(directory_fd_) != 0) {
+                if (errno == EINTR) {
+                    return make_errno_result(DurableFileStatus::Interrupted,
+                                             errno);
+                }
+                return make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+
+    private:
+        int directory_fd_;
+    };
+    DirectorySyncCall call(directory_fd);
+    return retry_interrupted(call);
+}
+
+struct PosixFileIdentity {
+    dev_t device;
+    ino_t inode;
+};
+
+DurableFileResult capture_regular_identity(
+    int descriptor, PosixFileIdentity &identity) {
+    struct stat information {};
+    if (::fstat(descriptor, &information) != 0) {
+        return make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                 errno);
+    }
+    if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+        return make_result(DurableFileStatus::Unsupported);
+    }
+    identity = {information.st_dev, information.st_ino};
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult post_create_failure(DurableFileResult failure) {
+    failure.status = DurableFileStatus::EffectMayHaveOccurred;
+    return failure;
+}
+
+bool same_file_identity(const PosixFileIdentity &left,
+                        const PosixFileIdentity &right) {
+    return left.device == right.device && left.inode == right.inode;
+}
+
+DurableFileResult verify_replaced_target(
+    int directory_fd, std::string_view target_name,
+    const PosixFileIdentity &expected_identity,
+    std::string_view expected_bytes) {
+    int descriptor;
+    do {
+        descriptor = ::openat(directory_fd, target_name.data(),
+                              O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    } while (descriptor < 0 && errno == EINTR);
+    if (descriptor < 0) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    struct stat information {};
+    if (::fstat(descriptor, &information) != 0) {
+        const auto error_number = errno;
+        return close_open_descriptor(
+            descriptor,
+            make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                              error_number));
+    }
+    if (!S_ISREG(information.st_mode) || information.st_nlink != 1 ||
+        information.st_dev != expected_identity.device ||
+        information.st_ino != expected_identity.inode) {
+        return close_open_descriptor(
+            descriptor,
+            make_result(DurableFileStatus::EffectMayHaveOccurred));
+    }
+    PosixDurableReadChannel channel(descriptor);
+    const auto observed = read_bounded_close(channel, expected_bytes.size());
+    if (!observed.result.succeeded()) {
+        return {DurableFileStatus::EffectMayHaveOccurred,
+                observed.result.diagnostic};
+    }
+    const auto observed_bytes =
+        std::string_view(observed.bytes.data(), observed.bytes.size());
+    if (observed.truncated || observed_bytes != expected_bytes) {
+        return make_result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult clear_verified_stage(int descriptor) {
+    while (::ftruncate(descriptor, 0) != 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult verify_owned_probe(
+    int directory_fd, std::string_view name,
+    const PosixFileIdentity &expected_identity) {
+    struct stat information {};
+    if (::fstatat(directory_fd, name.data(), &information,
+                  AT_SYMLINK_NOFOLLOW) != 0) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    const PosixFileIdentity observed{information.st_dev,
+                                     information.st_ino};
+    if (!S_ISREG(information.st_mode) || information.st_nlink != 1 ||
+        !same_file_identity(observed, expected_identity)) {
+        return make_result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult remove_owned_probe(
+    int directory_fd, std::string_view name,
+    const PosixFileIdentity &expected_identity) {
+    const auto verified =
+        verify_owned_probe(directory_fd, name, expected_identity);
+    if (!verified.succeeded()) {
+        return verified;
+    }
+    if (::unlinkat(directory_fd, name.data(), 0) != 0) {
+        return make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                 errno);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+class PosixDurableFileAdapter final : public DurableFileAdapter {
+public:
+    explicit PosixDurableFileAdapter(int directory_fd)
+        : directory_fd_(directory_fd) {}
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    PosixDurableFileAdapter(int directory_fd,
+                            DurablePreflightTestFault preflight_test_fault)
+        : directory_fd_(directory_fd),
+          preflight_test_fault_(preflight_test_fault) {}
+#endif
+
+    ~PosixDurableFileAdapter() override {
+        close_best_effort(lock_fd_);
+        close_best_effort(directory_fd_);
+    }
+
+    DurableFileResult lock_authority() override {
+        if (directory_fd_ < 0 || lock_fd_ >= 0 || directory_lock_held_) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto directory_lock_result =
+            lock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_lock_result.succeeded()) {
+            return directory_lock_result;
+        }
+        directory_lock_held_ = true;
+
+        int opened_fd;
+        do {
+            opened_fd = ::openat(directory_fd_, lock_name.data(),
+                                 O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                                 0600);
+        } while (opened_fd < 0 && errno == EINTR);
+        if (opened_fd < 0) {
+            const auto error_number = errno;
+            return release_directory_after_failed_lock(
+                open_error_result(error_number));
+        }
+        lock_fd_ = opened_fd;
+        const auto lock_result = lock_file_retrying_interrupts(lock_fd_);
+        if (!lock_result.succeeded()) {
+            return close_unlocked_after_failed_lock(lock_result);
+        }
+
+        struct stat opened_information {};
+        if (::fstat(lock_fd_, &opened_information) != 0) {
+            const auto error_number = errno;
+            return abandon_failed_lock(make_errno_result(
+                DurableFileStatus::Unsupported, error_number));
+        }
+        struct stat current_information {};
+        if (::fstatat(directory_fd_, lock_name.data(), &current_information,
+                      AT_SYMLINK_NOFOLLOW) != 0) {
+            const auto error_number = errno;
+            return abandon_failed_lock(make_errno_result(
+                DurableFileStatus::Unsupported, error_number));
+        }
+        if (!S_ISREG(opened_information.st_mode) ||
+            !S_ISREG(current_information.st_mode) ||
+            opened_information.st_nlink == 0 ||
+            current_information.st_nlink == 0 ||
+            opened_information.st_dev != current_information.st_dev ||
+            opened_information.st_ino != current_information.st_ino) {
+            return abandon_failed_lock(
+                make_result(DurableFileStatus::Unsupported));
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableIdentityResult authority_identity() override {
+        if (directory_fd_ < 0 || lock_fd_ < 0 || !directory_lock_held_) {
+            return {make_result(DurableFileStatus::Unsupported), {}};
+        }
+        struct stat directory_information {};
+        if (::fstat(directory_fd_, &directory_information) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }
+        struct stat lock_information {};
+        if (::fstat(lock_fd_, &lock_information) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }
+        struct stat current_lock_information {};
+        if (::fstatat(directory_fd_, lock_name.data(),
+                      &current_lock_information, AT_SYMLINK_NOFOLLOW) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }
+        if (!S_ISDIR(directory_information.st_mode) ||
+            !S_ISREG(lock_information.st_mode) ||
+            !S_ISREG(current_lock_information.st_mode) ||
+            lock_information.st_nlink == 0 ||
+            current_lock_information.st_nlink == 0 ||
+            lock_information.st_dev != current_lock_information.st_dev ||
+            lock_information.st_ino != current_lock_information.st_ino) {
+            return {make_result(DurableFileStatus::Unsupported), {}};
+        }
+        return {make_result(DurableFileStatus::Succeeded),
+                "directory:" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(directory_information.st_dev)) +
+                    ":" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(directory_information.st_ino)) +
+                    "/lock:" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(lock_information.st_dev)) +
+                    ":" +
+                    std::to_string(
+                        static_cast<std::uintmax_t>(lock_information.st_ino))};
+    }
+
+    DurableFileResult preflight_capabilities() override {
+        if (directory_fd_ < 0 || lock_fd_ < 0) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        for (const auto name : {journal_name, root_name, lock_name,
+                                journal_stage_name, root_stage_name}) {
+            struct stat information {};
+            if (::fstatat(directory_fd_, name.data(), &information,
+                          AT_SYMLINK_NOFOLLOW) != 0) {
+                if (errno == ENOENT) {
+                    continue;
+                }
+                return make_errno_result(DurableFileStatus::Unsupported,
+                                         errno);
+            }
+            if (!S_ISREG(information.st_mode) ||
+                (name != lock_name && information.st_nlink != 1) ||
+                (name == lock_name && information.st_nlink == 0)) {
+                return make_result(DurableFileStatus::Unsupported);
+            }
+        }
+
+        bool scratch_create_succeeded = false;
+        const auto terminal_failure = [&](DurableFileResult failure) {
+            if (scratch_create_succeeded && !failure.succeeded()) {
+                failure.status = DurableFileStatus::EffectMayHaveOccurred;
+            }
+            return failure;
+        };
+        for (std::size_t attempt = 0;
+             attempt < preflight_collision_attempts; ++attempt) {
+            const auto names = next_preflight_names();
+            PosixFileIdentity probe_identity {};
+            PosixFileIdentity stage_identity {};
+            bool probe_owned = false;
+            bool stage_owned = false;
+            const auto cleanup_owned = [&]() {
+                auto result = make_result(DurableFileStatus::Succeeded);
+                if (stage_owned) {
+                    const auto removed = remove_owned_probe(
+                        directory_fd_, names.stage, stage_identity);
+                    if (removed.succeeded()) {
+                        stage_owned = false;
+                    } else {
+                        result = removed;
+                    }
+                }
+                if (probe_owned) {
+                    const auto removed = remove_owned_probe(
+                        directory_fd_, names.probe, probe_identity);
+                    if (removed.succeeded()) {
+                        probe_owned = false;
+                    } else if (result.succeeded()) {
+                        result = removed;
+                    }
+                }
+                return result;
+            };
+            const auto fail_after_cleanup =
+                [&](DurableFileResult failure) {
+                    const auto cleanup = cleanup_owned();
+                    return terminal_failure(cleanup.succeeded() ? failure
+                                                                : cleanup);
+                };
+
+            int probe_fd;
+            do {
+                probe_fd = ::openat(directory_fd_, names.probe.c_str(),
+                                    O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC |
+                                        O_NOFOLLOW,
+                                    0600);
+            } while (probe_fd < 0 && errno == EINTR);
+            if (probe_fd < 0) {
+                if (errno == EEXIST) {
+                    continue;
+                }
+                return terminal_failure(open_error_result(errno));
+            }
+            scratch_create_succeeded = true;
+            auto probe_safe =
+                capture_regular_identity(probe_fd, probe_identity);
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            probe_safe = apply_created_identity_test_fault(
+                DurablePreflightTestFault::ProbeIdentityCaptureFailureOnce,
+                std::move(probe_safe));
+#endif
+            if (!probe_safe.succeeded()) {
+                return terminal_failure(close_open_descriptor(
+                    probe_fd, post_create_failure(probe_safe)));
+            }
+            probe_owned = true;
+            PosixDurableFileChannel probe_channel(probe_fd);
+            auto flush_probe =
+                write_flush_close(probe_channel, "durability-probe");
+            if (!flush_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                flush_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return flush_probe;
+            }
+
+            int truncate_fd;
+            do {
+                truncate_fd = ::openat(directory_fd_, names.probe.c_str(),
+                                       O_RDWR | O_CLOEXEC | O_NOFOLLOW);
+            } while (truncate_fd < 0 && errno == EINTR);
+            if (truncate_fd < 0) {
+                return fail_after_cleanup(open_error_result(errno));
+            }
+            PosixFileIdentity truncate_identity {};
+            const auto truncate_safe =
+                capture_regular_identity(truncate_fd, truncate_identity);
+            if (!truncate_safe.succeeded() ||
+                !same_file_identity(truncate_identity, probe_identity)) {
+                const auto result = close_open_descriptor(
+                    truncate_fd,
+                    truncate_safe.succeeded()
+                        ? make_result(DurableFileStatus::EffectMayHaveOccurred)
+                        : post_create_failure(truncate_safe));
+                return fail_after_cleanup(result);
+            }
+            PosixDurableFileChannel truncate_channel(truncate_fd);
+            auto truncate_probe =
+                truncate_flush_close(truncate_channel, 0);
+            if (!truncate_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                truncate_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return truncate_probe;
+            }
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            const auto collision = seed_stage_collision_for_test(names.stage);
+            if (!collision.succeeded()) {
+                return fail_after_cleanup(collision);
+            }
+#endif
+            int stage_fd;
+            do {
+                stage_fd = ::openat(directory_fd_, names.stage.c_str(),
+                                    O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                        O_NOFOLLOW,
+                                    0600);
+            } while (stage_fd < 0 && errno == EINTR);
+            if (stage_fd < 0) {
+                const auto error_number = errno;
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                if (error_number == EEXIST) {
+                    continue;
+                }
+                return terminal_failure(open_error_result(error_number));
+            }
+            scratch_create_succeeded = true;
+            auto stage_safe =
+                capture_regular_identity(stage_fd, stage_identity);
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            stage_safe = apply_created_identity_test_fault(
+                DurablePreflightTestFault::StageIdentityCaptureFailureOnce,
+                std::move(stage_safe));
+#endif
+            if (!stage_safe.succeeded()) {
+                return fail_after_cleanup(
+                    close_open_descriptor(stage_fd,
+                                          post_create_failure(stage_safe)));
+            }
+            stage_owned = true;
+            PosixDurableFileChannel stage_channel(stage_fd);
+            auto replace_probe =
+                write_flush_close(stage_channel, "replacement-probe");
+            if (!replace_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                replace_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return replace_probe;
+            }
+            const auto stage_current = verify_owned_probe(
+                directory_fd_, names.stage, stage_identity);
+            const auto probe_current = verify_owned_probe(
+                directory_fd_, names.probe, probe_identity);
+            if (!stage_current.succeeded() || !probe_current.succeeded()) {
+                return fail_after_cleanup(
+                    !stage_current.succeeded() ? stage_current
+                                               : probe_current);
+            }
+            const auto replaced =
+                ::renameat(directory_fd_, names.stage.c_str(), directory_fd_,
+                           names.probe.c_str());
+            if (replaced != 0) {
+                return fail_after_cleanup(make_errno_result(
+                    DurableFileStatus::EffectMayHaveOccurred, errno));
+            }
+            probe_identity = stage_identity;
+            probe_owned = true;
+            stage_owned = false;
+            const auto cleanup = cleanup_owned();
+            if (!cleanup.succeeded()) {
+                return terminal_failure(cleanup);
+            }
+            const auto namespace_result =
+                sync_directory_retrying_interrupts(directory_fd_);
+            if (!namespace_result.succeeded()) {
+                return terminal_failure(namespace_result);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+        return terminal_failure(
+            make_errno_result(DurableFileStatus::AlreadyExists, EEXIST));
+    }
+
+    DurableFixedNamespaceResult inspect_fixed_namespace() override {
+        DurableFixedNamespaceResult inspected{
+            make_result(DurableFileStatus::Succeeded), false, false, false,
+            false, false};
+        const std::array<std::pair<std::string_view, bool *>, 5> entries{
+            std::pair{journal_name, &inspected.journal_present},
+            std::pair{root_name, &inspected.root_present},
+            std::pair{journal_stage_name, &inspected.journal_stage_present},
+            std::pair{root_stage_name, &inspected.root_stage_present},
+            std::pair{lock_name, &inspected.lock_present},
+        };
+        for (const auto &[name, present] : entries) {
+            struct stat information {};
+            if (::fstatat(directory_fd_, name.data(), &information,
+                          AT_SYMLINK_NOFOLLOW) != 0) {
+                if (errno == ENOENT) {
+                    continue;
+                }
+                inspected.result =
+                    make_errno_result(DurableFileStatus::Unsupported, errno);
+                return inspected;
+            }
+            if (!S_ISREG(information.st_mode) ||
+                (name != lock_name && information.st_nlink != 1) ||
+                (name == lock_name && information.st_nlink == 0)) {
+                inspected.result =
+                    make_result(DurableFileStatus::Unsupported);
+                return inspected;
+            }
+            *present = true;
+        }
+        return inspected;
+    }
+
+    DurableReadResult read_root(std::size_t max_bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, root_name.data(),
+                                  O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return {open_error_result(errno), {}, false};
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_errno_result(DurableFileStatus::Unsupported,
+                                          errno)),
+                    {}, false};
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        PosixDurableReadChannel channel(descriptor);
+        return read_bounded_close(channel, max_bytes);
+    }
+
+    DurableReadResult read_journal(std::size_t max_bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return {open_error_result(errno), {}, false};
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_errno_result(DurableFileStatus::Unsupported,
+                                          errno)),
+                    {}, false};
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return {close_open_descriptor(
+                        descriptor,
+                        make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        PosixDurableReadChannel channel(descriptor);
+        return read_bounded_close(channel, max_bytes);
+    }
+
+    DurableFileResult create_journal(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                      O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        PosixDurableFileChannel channel(descriptor);
+        const auto persisted = write_flush_close(channel, bytes);
+        if (!persisted.succeeded() &&
+            !persisted.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    persisted.diagnostic};
+        }
+        return persisted;
+    }
+
+    DurableFileResult append_journal(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_WRONLY | O_APPEND | O_CLOEXEC |
+                                      O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::Unsupported));
+        }
+        PosixDurableFileChannel channel(descriptor);
+        return write_flush_close(channel, bytes);
+    }
+
+    DurableFileResult truncate_journal(std::size_t bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_name.data(),
+                                  O_RDWR | O_CLOEXEC | O_NOFOLLOW);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::FailedBeforeEffect,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::Unsupported));
+        }
+        PosixDurableFileChannel channel(descriptor);
+        return truncate_flush_close(channel, bytes);
+    }
+
+    DurableFileResult replace_journal(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, journal_stage_name.data(),
+                                  O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        const PosixFileIdentity staged_identity{information.st_dev,
+                                                information.st_ino};
+        const auto cleared = clear_verified_stage(descriptor);
+        if (!cleared.succeeded()) {
+            return close_open_descriptor(descriptor, cleared);
+        }
+        PosixDurableFileChannel channel(descriptor);
+        const auto staged = write_flush_close(channel, bytes);
+        if (!staged.succeeded() && !staged.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    staged.diagnostic};
+        }
+        if (!staged.succeeded()) {
+            return staged;
+        }
+        if (::renameat(directory_fd_, journal_stage_name.data(), directory_fd_,
+                       journal_name.data()) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        const auto namespace_result =
+            sync_directory_retrying_interrupts(directory_fd_);
+        if (!namespace_result.succeeded()) {
+            return namespace_result;
+        }
+        return verify_replaced_target(directory_fd_, journal_name,
+                                      staged_identity, bytes);
+    }
+
+    DurableFileResult replace_root(std::string_view bytes) override {
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, root_stage_name.data(),
+                                  O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        struct stat information {};
+        if (::fstat(descriptor, &information) != 0) {
+            return close_open_descriptor(
+                descriptor,
+                make_errno_result(DurableFileStatus::EffectMayHaveOccurred,
+                                  errno));
+        }
+        if (!S_ISREG(information.st_mode) || information.st_nlink != 1) {
+            return close_open_descriptor(
+                descriptor,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        const PosixFileIdentity staged_identity{information.st_dev,
+                                                information.st_ino};
+        const auto cleared = clear_verified_stage(descriptor);
+        if (!cleared.succeeded()) {
+            return close_open_descriptor(descriptor, cleared);
+        }
+        PosixDurableFileChannel channel(descriptor);
+        const auto staged = write_flush_close(channel, bytes);
+        if (!staged.succeeded() && !staged.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    staged.diagnostic};
+        }
+        if (!staged.succeeded()) {
+            return staged;
+        }
+        if (::renameat(directory_fd_, root_stage_name.data(), directory_fd_,
+                       root_name.data()) != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, errno);
+        }
+        const auto namespace_result =
+            sync_directory_retrying_interrupts(directory_fd_);
+        if (!namespace_result.succeeded()) {
+            return namespace_result;
+        }
+        return verify_replaced_target(directory_fd_, root_name,
+                                      staged_identity, bytes);
+    }
+
+    DurableFileResult unlock_authority() override {
+        if (lock_fd_ < 0 || !directory_lock_held_) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto descriptor = std::exchange(lock_fd_, -1);
+        const auto unlock_result =
+            unlock_file_retrying_interrupts(descriptor);
+        const auto close_result = ::close(descriptor);
+        const auto close_error_number = close_result == 0 ? 0 : errno;
+        const auto directory_unlock_result =
+            unlock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_unlock_result.succeeded()) {
+            return directory_unlock_result;
+        }
+        directory_lock_held_ = false;
+        if (!unlock_result.succeeded() && close_result != 0) {
+            return make_result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        if (!unlock_result.succeeded()) {
+            return unlock_result;
+        }
+        if (close_result != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred,
+                close_error_number);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    DurableFileResult release_directory_after_failed_lock(
+        DurableFileResult failure) {
+        const auto directory_unlock_result =
+            unlock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_unlock_result.succeeded()) {
+            return directory_unlock_result;
+        }
+        directory_lock_held_ = false;
+        return failure;
+    }
+
+    DurableFileResult close_unlocked_after_failed_lock(
+        DurableFileResult failure) {
+        const auto descriptor = std::exchange(lock_fd_, -1);
+        if (::close(descriptor) != 0) {
+            const auto error_number = errno;
+            failure = make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred, error_number);
+        }
+        return release_directory_after_failed_lock(std::move(failure));
+    }
+
+    DurableFileResult abandon_failed_lock(DurableFileResult failure) {
+        const auto descriptor = std::exchange(lock_fd_, -1);
+        const auto unlock_result =
+            unlock_file_retrying_interrupts(descriptor);
+        const auto close_result = ::close(descriptor);
+        const auto close_error_number = close_result == 0 ? 0 : errno;
+        const auto directory_unlock_result =
+            unlock_directory_retrying_interrupts(directory_fd_);
+        if (!directory_unlock_result.succeeded()) {
+            return directory_unlock_result;
+        }
+        directory_lock_held_ = false;
+        if (!unlock_result.succeeded() && close_result != 0) {
+            return make_result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        if (!unlock_result.succeeded()) {
+            return unlock_result;
+        }
+        if (close_result != 0) {
+            return make_errno_result(
+                DurableFileStatus::EffectMayHaveOccurred,
+                close_error_number);
+        }
+        return failure;
+    }
+
+    int directory_fd_;
+    int lock_fd_ = -1;
+    bool directory_lock_held_ = false;
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    DurableFileResult seed_stage_collision_for_test(
+        const std::string &name) noexcept {
+        if (preflight_test_fault_ !=
+            DurablePreflightTestFault::StageCreateCollisionExhaustion) {
+            return make_result(DurableFileStatus::Succeeded);
+        }
+        int descriptor;
+        do {
+            descriptor = ::openat(directory_fd_, name.c_str(),
+                                  O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC |
+                                      O_NOFOLLOW,
+                                  0600);
+        } while (descriptor < 0 && errno == EINTR);
+        if (descriptor < 0) {
+            return open_error_result(errno);
+        }
+        PosixDurableFileChannel channel(descriptor);
+        const auto written = write_flush_close(
+            channel, "caller-owned-stage-collision");
+        if (!written.succeeded()) {
+            return written;
+        }
+        return sync_directory_retrying_interrupts(directory_fd_);
+    }
+
+    DurableFileResult apply_created_identity_test_fault(
+        DurablePreflightTestFault phase,
+        DurableFileResult captured) noexcept {
+        if (captured.succeeded() && preflight_test_fault_ == phase &&
+            !preflight_test_fault_taken_) {
+            preflight_test_fault_taken_ = true;
+            return make_result(DurableFileStatus::FailedBeforeEffect);
+        }
+        return captured;
+    }
+    std::optional<DurablePreflightTestFault> preflight_test_fault_;
+    bool preflight_test_fault_taken_ = false;
+#endif
+};
+
+} // namespace
+
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter(const std::filesystem::path &directory) {
+    int directory_fd;
+    do {
+        directory_fd = ::open(directory.c_str(),
+                              O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+    } while (directory_fd < 0 && errno == EINTR);
+    return std::make_unique<PosixDurableFileAdapter>(directory_fd);
+}
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter_for_test(
+    const std::filesystem::path &directory, DurablePreflightTestFault fault) {
+    int directory_fd;
+    do {
+        directory_fd = ::open(directory.c_str(),
+                              O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOFOLLOW);
+    } while (directory_fd < 0 && errno == EINTR);
+    return std::make_unique<PosixDurableFileAdapter>(directory_fd, fault);
+}
+#endif
+
+} // namespace lemon::residency::detail

--- a/src/cpp/server/residency/platform/durable_file_adapter_windows.cpp
+++ b/src/cpp/server/residency/platform/durable_file_adapter_windows.cpp
@@ -1,0 +1,1467 @@
+#include "platform/durable_file_adapter.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+namespace lemon::residency::detail {
+
+namespace {
+
+constexpr std::wstring_view journal_name = L"journal.jsonl";
+constexpr std::wstring_view root_name = L"authority-root.json";
+constexpr std::wstring_view lock_name = L"authority.lock";
+constexpr std::wstring_view journal_stage_name = L".journal.jsonl.stage";
+constexpr std::wstring_view root_stage_name = L".authority-root.json.stage";
+constexpr std::size_t preflight_collision_attempts = 8;
+std::atomic<std::uint64_t> preflight_sequence{0};
+
+struct PreflightNames {
+    std::wstring probe;
+    std::wstring stage;
+};
+
+PreflightNames next_preflight_names() {
+    const auto sequence =
+        preflight_sequence.fetch_add(1, std::memory_order_relaxed);
+    auto probe = L".durability-probe." +
+                 std::to_wstring(
+                     static_cast<std::uint64_t>(::GetCurrentProcessId())) +
+                 L"." + std::to_wstring(sequence);
+    return {probe, probe + L".stage"};
+}
+
+DurableFileResult make_result(DurableFileStatus status) {
+    return {status, {}};
+}
+
+DurableFileResult make_windows_result(DurableFileStatus status, DWORD error) {
+    return {status, std::to_string(error)};
+}
+
+DurableFileResult open_error_result(DWORD error) {
+    if (error == ERROR_OPERATION_ABORTED) {
+        return make_windows_result(DurableFileStatus::Interrupted, error);
+    }
+    if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+        return make_windows_result(DurableFileStatus::NotFound, error);
+    }
+    if (error == ERROR_FILE_EXISTS || error == ERROR_ALREADY_EXISTS) {
+        return make_windows_result(DurableFileStatus::AlreadyExists, error);
+    }
+    if (error == ERROR_CANT_ACCESS_FILE || error == ERROR_DIRECTORY ||
+        error == ERROR_INVALID_NAME || error == ERROR_REPARSE_TAG_INVALID) {
+        return make_windows_result(DurableFileStatus::Unsupported, error);
+    }
+    return make_windows_result(DurableFileStatus::FailedBeforeEffect, error);
+}
+
+void close_best_effort(HANDLE handle) {
+    if (handle != INVALID_HANDLE_VALUE) {
+        static_cast<void>(::CloseHandle(handle));
+    }
+}
+
+DurableFileResult close_open_handle(HANDLE handle,
+                                    DurableFileResult operation_result) {
+    if (!::CloseHandle(handle) && operation_result.succeeded()) {
+        return make_windows_result(
+            DurableFileStatus::EffectMayHaveOccurred, ::GetLastError());
+    }
+    return operation_result;
+}
+
+std::string file_id_string(const FILE_ID_INFO &information) {
+    constexpr char digits[] = "0123456789abcdef";
+    std::string encoded = std::to_string(information.VolumeSerialNumber);
+    encoded.push_back(':');
+    for (const auto byte : information.FileId.Identifier) {
+        encoded.push_back(digits[(byte >> 4) & 0x0f]);
+        encoded.push_back(digits[byte & 0x0f]);
+    }
+    return encoded;
+}
+
+class WindowsDurableFileChannel final : public DurableFileChannel {
+public:
+    explicit WindowsDurableFileChannel(HANDLE handle) : handle_(handle) {}
+
+    ~WindowsDurableFileChannel() override { close_best_effort(handle_); }
+
+    DurableWriteResult write_some(std::string_view bytes) override {
+        const auto request = static_cast<DWORD>(
+            std::min(bytes.size(), std::size_t(MAXDWORD)));
+        DWORD written = 0;
+        if (!::WriteFile(handle_, bytes.data(), request, &written, nullptr)) {
+            const auto error = ::GetLastError();
+            return {::lemon::residency::detail::DurableFileResult{
+                        ::lemon::residency::detail::DurableFileStatus::
+                            EffectMayHaveOccurred,
+                        ::std::to_string(error)},
+                    0};
+        }
+        return {::lemon::residency::detail::DurableFileResult{
+                    ::lemon::residency::detail::DurableFileStatus::Succeeded,
+                    {}},
+                written};
+    }
+
+    DurableFileResult flush() override {
+        if (!::FlushFileBuffers(handle_)) {
+            const auto error = ::GetLastError();
+            if (error == ERROR_OPERATION_ABORTED) {
+                return make_windows_result(DurableFileStatus::Interrupted,
+                                           error);
+            }
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, error);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableFileResult truncate(std::size_t bytes) override {
+        if (bytes > static_cast<std::size_t>(
+                        std::numeric_limits<LONGLONG>::max())) {
+            return make_result(DurableFileStatus::FailedBeforeEffect);
+        }
+        LARGE_INTEGER position {};
+        position.QuadPart = static_cast<LONGLONG>(bytes);
+        if (!::SetFilePointerEx(handle_, position, nullptr, FILE_BEGIN)) {
+            const auto error = ::GetLastError();
+            if (error == ERROR_OPERATION_ABORTED) {
+                return make_windows_result(DurableFileStatus::Interrupted,
+                                           error);
+            }
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, error);
+        }
+        if (!::SetEndOfFile(handle_)) {
+            const auto error = ::GetLastError();
+            if (error == ERROR_OPERATION_ABORTED) {
+                return make_windows_result(DurableFileStatus::Interrupted,
+                                           error);
+            }
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, error);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableFileResult close() override {
+        const auto handle = std::exchange(handle_, INVALID_HANDLE_VALUE);
+        if (!::CloseHandle(handle)) {
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, ::GetLastError());
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    HANDLE handle_;
+};
+
+class WindowsDurableReadChannel final : public DurableReadChannel {
+public:
+    explicit WindowsDurableReadChannel(HANDLE handle) : handle_(handle) {}
+
+    ~WindowsDurableReadChannel() override { close_best_effort(handle_); }
+
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const DWORD request = static_cast<DWORD>(
+            std::min(max_bytes, std::size_t(MAXDWORD)));
+        std::string buffer(request, '\0');
+        DWORD transferred = 0;
+        if (!::ReadFile(handle_, buffer.data(), request, &transferred,
+                        nullptr)) {
+            const auto error = ::GetLastError();
+            if (error == ERROR_OPERATION_ABORTED) {
+                return {make_windows_result(DurableFileStatus::Interrupted,
+                                            error),
+                        {}, false};
+            }
+            return {make_windows_result(
+                        DurableFileStatus::FailedBeforeEffect, error),
+                    {}, false};
+        }
+        buffer.resize(transferred);
+        return {make_result(DurableFileStatus::Succeeded), std::move(buffer),
+                transferred == 0};
+    }
+
+    DurableFileResult close() override {
+        const auto handle = std::exchange(handle_, INVALID_HANDLE_VALUE);
+        if (!::CloseHandle(handle)) {
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, ::GetLastError());
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    HANDLE handle_;
+};
+
+std::filesystem::path child_path(const std::filesystem::path &directory,
+                                 std::wstring_view name) {
+    return directory / std::filesystem::path(name);
+}
+
+std::optional<std::filesystem::path>
+final_directory_path(HANDLE directory_handle) {
+    constexpr DWORD flags = FILE_NAME_NORMALIZED | VOLUME_NAME_DOS;
+    auto capacity = ::GetFinalPathNameByHandleW(directory_handle, nullptr, 0,
+                                                flags);
+    if (capacity == 0) {
+        return std::nullopt;
+    }
+    std::wstring buffer(static_cast<std::size_t>(capacity), L'\0');
+    while (true) {
+        const auto length = ::GetFinalPathNameByHandleW(
+            directory_handle, buffer.data(), capacity, flags);
+        if (length == 0) {
+            return std::nullopt;
+        }
+        if (length < capacity) {
+            buffer.resize(static_cast<std::size_t>(length));
+            return std::filesystem::path(std::move(buffer));
+        }
+        if (length == MAXDWORD) {
+            return std::nullopt;
+        }
+        capacity = length + 1;
+        buffer.assign(static_cast<std::size_t>(capacity), L'\0');
+    }
+}
+
+DurableFileResult validate_open_regular_single_link(HANDLE handle) {
+    FILE_ATTRIBUTE_TAG_INFO attributes {};
+    if (!::GetFileInformationByHandleEx(
+            handle, FileAttributeTagInfo, &attributes,
+            sizeof(attributes))) {
+        const auto error = ::GetLastError();
+        return make_windows_result(DurableFileStatus::Unsupported, error);
+    }
+    if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+        (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        return make_result(DurableFileStatus::Unsupported);
+    }
+    FILE_STANDARD_INFO standard {};
+    if (!::GetFileInformationByHandleEx(handle, FileStandardInfo, &standard,
+                                        sizeof(standard))) {
+        const auto error = ::GetLastError();
+        return make_windows_result(DurableFileStatus::Unsupported, error);
+    }
+    if (standard.NumberOfLinks != 1) {
+        return make_result(DurableFileStatus::Unsupported);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+bool same_file_identity(const FILE_ID_INFO &left,
+                        const FILE_ID_INFO &right) {
+    return left.VolumeSerialNumber == right.VolumeSerialNumber &&
+           std::memcmp(left.FileId.Identifier, right.FileId.Identifier,
+                       sizeof(left.FileId.Identifier)) == 0;
+}
+
+DurableFileResult capture_regular_identity(HANDLE handle,
+                                           FILE_ID_INFO &identity) {
+    const auto safe = validate_open_regular_single_link(handle);
+    if (!safe.succeeded()) {
+        return safe;
+    }
+    if (!::GetFileInformationByHandleEx(handle, FileIdInfo, &identity,
+                                        sizeof(identity))) {
+        return make_windows_result(DurableFileStatus::Unsupported,
+                                   ::GetLastError());
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult post_create_failure(DurableFileResult failure) {
+    failure.status = DurableFileStatus::EffectMayHaveOccurred;
+    return failure;
+}
+
+DurableFileResult open_verified_owned_probe(
+    const std::filesystem::path &path, const FILE_ID_INFO &expected_identity,
+    DWORD access, HANDLE &handle) {
+    handle = ::CreateFileW(
+        path.c_str(), access, FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr, OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return make_windows_result(DurableFileStatus::EffectMayHaveOccurred,
+                                   ::GetLastError());
+    }
+    FILE_ID_INFO observed {};
+    const auto safe = capture_regular_identity(handle, observed);
+    if (!safe.succeeded() ||
+        !same_file_identity(observed, expected_identity)) {
+        const auto result =
+            safe.succeeded()
+                ? make_result(DurableFileStatus::EffectMayHaveOccurred)
+                : DurableFileResult{DurableFileStatus::EffectMayHaveOccurred,
+                                    safe.diagnostic};
+        const auto opened = handle;
+        handle = INVALID_HANDLE_VALUE;
+        return close_open_handle(opened, result);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult verify_owned_probe(
+    const std::filesystem::path &path,
+    const FILE_ID_INFO &expected_identity) {
+    HANDLE handle = INVALID_HANDLE_VALUE;
+    const auto verified = open_verified_owned_probe(
+        path, expected_identity, FILE_READ_ATTRIBUTES, handle);
+    if (!verified.succeeded()) {
+        return verified;
+    }
+    return close_open_handle(handle, verified);
+}
+
+DurableFileResult remove_owned_probe(
+    const std::filesystem::path &path,
+    const FILE_ID_INFO &expected_identity) {
+    HANDLE handle = INVALID_HANDLE_VALUE;
+    const auto verified = open_verified_owned_probe(
+        path, expected_identity, DELETE | FILE_READ_ATTRIBUTES, handle);
+    if (!verified.succeeded()) {
+        return verified;
+    }
+    FILE_DISPOSITION_INFO disposition {TRUE};
+    if (!::SetFileInformationByHandle(handle, FileDispositionInfo,
+                                      &disposition,
+                                      sizeof(disposition))) {
+        const auto error = ::GetLastError();
+        return close_open_handle(
+            handle,
+            make_windows_result(DurableFileStatus::EffectMayHaveOccurred,
+                                error));
+    }
+    return close_open_handle(handle,
+                             make_result(DurableFileStatus::Succeeded));
+}
+
+DurableFileResult verify_replaced_target(
+    const std::filesystem::path &target_path,
+    const FILE_ID_INFO &expected_identity, std::string_view expected_bytes) {
+    const auto handle = ::CreateFileW(
+        target_path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr, OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    if (handle == INVALID_HANDLE_VALUE) {
+        const auto error = ::GetLastError();
+        return make_windows_result(DurableFileStatus::EffectMayHaveOccurred,
+                                   error);
+    }
+    FILE_ATTRIBUTE_TAG_INFO attributes {};
+    if (!::GetFileInformationByHandleEx(
+            handle, FileAttributeTagInfo, &attributes,
+            sizeof(attributes))) {
+        const auto error = ::GetLastError();
+        return close_open_handle(
+            handle,
+            make_windows_result(DurableFileStatus::EffectMayHaveOccurred,
+                                error));
+    }
+    if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+        (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        return close_open_handle(
+            handle,
+            make_result(DurableFileStatus::EffectMayHaveOccurred));
+    }
+    FILE_STANDARD_INFO standard {};
+    if (!::GetFileInformationByHandleEx(handle, FileStandardInfo, &standard,
+                                        sizeof(standard))) {
+        const auto error = ::GetLastError();
+        return close_open_handle(
+            handle,
+            make_windows_result(DurableFileStatus::EffectMayHaveOccurred,
+                                error));
+    }
+    if (standard.NumberOfLinks != 1) {
+        return close_open_handle(
+            handle,
+            make_result(DurableFileStatus::EffectMayHaveOccurred));
+    }
+    FILE_ID_INFO identity {};
+    if (!::GetFileInformationByHandleEx(handle, FileIdInfo, &identity,
+                                        sizeof(identity))) {
+        const auto error = ::GetLastError();
+        return close_open_handle(
+            handle,
+            make_windows_result(DurableFileStatus::EffectMayHaveOccurred,
+                                error));
+    }
+    if (!same_file_identity(identity, expected_identity)) {
+        return close_open_handle(
+            handle,
+            make_result(DurableFileStatus::EffectMayHaveOccurred));
+    }
+    WindowsDurableReadChannel channel(handle);
+    const auto observed = read_bounded_close(channel, expected_bytes.size());
+    if (!observed.result.succeeded()) {
+        return {DurableFileStatus::EffectMayHaveOccurred,
+                observed.result.diagnostic};
+    }
+    const auto observed_bytes =
+        std::string_view(observed.bytes.data(), observed.bytes.size());
+    if (observed.truncated || observed_bytes != expected_bytes) {
+        return make_result(DurableFileStatus::EffectMayHaveOccurred);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+DurableFileResult clear_verified_stage(HANDLE handle) {
+    LARGE_INTEGER beginning {};
+    while (!::SetFilePointerEx(handle, beginning, nullptr, FILE_BEGIN)) {
+        const auto error = ::GetLastError();
+        if (error == ERROR_OPERATION_ABORTED) {
+            continue;
+        }
+        return make_windows_result(
+            DurableFileStatus::EffectMayHaveOccurred, error);
+    }
+    while (!::SetEndOfFile(handle)) {
+        const auto error = ::GetLastError();
+        if (error == ERROR_OPERATION_ABORTED) {
+            continue;
+        }
+        return make_windows_result(
+            DurableFileStatus::EffectMayHaveOccurred, error);
+    }
+    return make_result(DurableFileStatus::Succeeded);
+}
+
+class WindowsDurableFileAdapter final : public DurableFileAdapter {
+public:
+    WindowsDurableFileAdapter(std::filesystem::path bound_directory,
+                              HANDLE directory_handle)
+        : directory_(std::move(bound_directory)),
+          directory_handle_(directory_handle) {}
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    WindowsDurableFileAdapter(std::filesystem::path bound_directory,
+                              HANDLE directory_handle,
+                              DurablePreflightTestFault preflight_test_fault)
+        : directory_(std::move(bound_directory)),
+          directory_handle_(directory_handle),
+          preflight_test_fault_(preflight_test_fault) {}
+#endif
+
+    ~WindowsDurableFileAdapter() override {
+        close_best_effort(lock_handle_);
+        close_best_effort(directory_handle_);
+    }
+
+    DurableFileResult lock_authority() override {
+        if (!bound() || lock_handle_ != INVALID_HANDLE_VALUE) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto lock_path = child_path(directory_, lock_name);
+        const auto opened = ::CreateFileW(
+            lock_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (opened == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        FILE_ATTRIBUTE_TAG_INFO opened_attributes {};
+        if (!::GetFileInformationByHandleEx(
+                opened, FileAttributeTagInfo, &opened_attributes,
+                sizeof(opened_attributes))) {
+            return close_open_handle(
+                opened, make_windows_result(DurableFileStatus::Unsupported,
+                                            ::GetLastError()));
+        }
+        if ((opened_attributes.FileAttributes &
+             FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (opened_attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) !=
+                0) {
+            return close_open_handle(
+                opened, make_result(DurableFileStatus::Unsupported));
+        }
+        FILE_STANDARD_INFO opened_standard {};
+        if (!::GetFileInformationByHandleEx(opened, FileStandardInfo,
+                                            &opened_standard,
+                                            sizeof(opened_standard))) {
+            return close_open_handle(
+                opened, make_windows_result(DurableFileStatus::Unsupported,
+                                            ::GetLastError()));
+        }
+        if (opened_standard.NumberOfLinks == 0) {
+            return close_open_handle(
+                opened, make_result(DurableFileStatus::Unsupported));
+        }
+
+        OVERLAPPED lock_overlapped {};
+        if (!::LockFileEx(opened, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD,
+                          MAXDWORD, &lock_overlapped)) {
+            const auto error = ::GetLastError();
+            close_best_effort(opened);
+            if (error == ERROR_OPERATION_ABORTED) {
+                return make_windows_result(DurableFileStatus::Interrupted,
+                                           error);
+            }
+            return make_windows_result(DurableFileStatus::FailedBeforeEffect,
+                                       error);
+        }
+
+        FILE_ID_INFO opened_id {};
+        if (!::GetFileInformationByHandleEx(opened, FileIdInfo, &opened_id,
+                                            sizeof(opened_id))) {
+            const auto error = ::GetLastError();
+            close_best_effort(opened);
+            return make_windows_result(DurableFileStatus::Unsupported,
+                                       error);
+        }
+        const auto current = ::CreateFileW(
+            lock_path.c_str(), FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (current == INVALID_HANDLE_VALUE) {
+            const auto error = ::GetLastError();
+            close_best_effort(opened);
+            return make_windows_result(DurableFileStatus::Unsupported,
+                                       error);
+        }
+        FILE_ATTRIBUTE_TAG_INFO current_attributes {};
+        if (!::GetFileInformationByHandleEx(
+                current, FileAttributeTagInfo, &current_attributes,
+                sizeof(current_attributes))) {
+            const auto error = ::GetLastError();
+            close_best_effort(current);
+            close_best_effort(opened);
+            return make_windows_result(DurableFileStatus::Unsupported,
+                                       error);
+        }
+        if ((current_attributes.FileAttributes &
+             FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (current_attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) !=
+                0) {
+            close_best_effort(current);
+            close_best_effort(opened);
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        FILE_STANDARD_INFO current_standard {};
+        if (!::GetFileInformationByHandleEx(current, FileStandardInfo,
+                                            &current_standard,
+                                            sizeof(current_standard))) {
+            const auto error = ::GetLastError();
+            close_best_effort(current);
+            close_best_effort(opened);
+            return make_windows_result(DurableFileStatus::Unsupported,
+                                       error);
+        }
+        if (current_standard.NumberOfLinks == 0) {
+            close_best_effort(current);
+            close_best_effort(opened);
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        FILE_ID_INFO current_id {};
+        if (!::GetFileInformationByHandleEx(current, FileIdInfo, &current_id,
+                                            sizeof(current_id))) {
+            const auto error = ::GetLastError();
+            close_best_effort(current);
+            close_best_effort(opened);
+            return make_windows_result(DurableFileStatus::Unsupported,
+                                       error);
+        }
+        if (opened_id.VolumeSerialNumber !=
+                current_id.VolumeSerialNumber ||
+            std::memcmp(opened_id.FileId.Identifier,
+                        current_id.FileId.Identifier,
+                        sizeof(opened_id.FileId.Identifier)) != 0) {
+            close_best_effort(current);
+            close_best_effort(opened);
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        if (!::CloseHandle(current)) {
+            const auto error = ::GetLastError();
+            close_best_effort(opened);
+            return make_windows_result(DurableFileStatus::Unsupported,
+                                       error);
+        }
+        lock_handle_ = opened;
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+    DurableIdentityResult authority_identity() override {
+        if (directory_handle_ == INVALID_HANDLE_VALUE ||
+            lock_handle_ == INVALID_HANDLE_VALUE) {
+            return {make_result(DurableFileStatus::Unsupported), {}};
+        }
+        FILE_ID_INFO directory_id {};
+        if (!::GetFileInformationByHandleEx(directory_handle_, FileIdInfo,
+                                            &directory_id,
+                                            sizeof(directory_id))) {
+            return {make_windows_result(DurableFileStatus::Unsupported,
+                                        ::GetLastError()),
+                    {}};
+        }
+        FILE_ID_INFO lock_id {};
+        if (!::GetFileInformationByHandleEx(lock_handle_, FileIdInfo, &lock_id,
+                                            sizeof(lock_id))) {
+            return {make_windows_result(DurableFileStatus::Unsupported,
+                                        ::GetLastError()),
+                    {}};
+        }
+        return {make_result(DurableFileStatus::Succeeded),
+                "directory:" + file_id_string(directory_id) +
+                    "/lock:" + file_id_string(lock_id)};
+    }
+
+    DurableFileResult preflight_capabilities() override {
+        if (!bound() || lock_handle_ == INVALID_HANDLE_VALUE) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        for (const auto name : {journal_name, root_name, lock_name,
+                                journal_stage_name, root_stage_name}) {
+            const auto path = child_path(directory_, name);
+            const auto fixed_handle = ::CreateFileW(
+                path.c_str(), FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+            if (fixed_handle == INVALID_HANDLE_VALUE) {
+                const auto error = ::GetLastError();
+                if (error == ERROR_FILE_NOT_FOUND ||
+                    error == ERROR_PATH_NOT_FOUND) {
+                    continue;
+                }
+                return make_windows_result(DurableFileStatus::Unsupported,
+                                           error);
+            }
+            FILE_ATTRIBUTE_TAG_INFO attributes {};
+            if (!::GetFileInformationByHandleEx(
+                    fixed_handle, FileAttributeTagInfo, &attributes,
+                    sizeof(attributes))) {
+                return close_open_handle(
+                    fixed_handle,
+                    make_windows_result(DurableFileStatus::Unsupported,
+                                        ::GetLastError()));
+            }
+            if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) !=
+                    0 ||
+                (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                return close_open_handle(
+                    fixed_handle,
+                    make_result(DurableFileStatus::Unsupported));
+            }
+            FILE_STANDARD_INFO standard {};
+            if (!::GetFileInformationByHandleEx(
+                    fixed_handle, FileStandardInfo, &standard,
+                    sizeof(standard))) {
+                return close_open_handle(
+                    fixed_handle,
+                    make_windows_result(DurableFileStatus::Unsupported,
+                                        ::GetLastError()));
+            }
+            if ((name != lock_name && standard.NumberOfLinks != 1) ||
+                (name == lock_name && standard.NumberOfLinks == 0)) {
+                return close_open_handle(
+                    fixed_handle,
+                    make_result(DurableFileStatus::Unsupported));
+            }
+            const auto closed = ::CloseHandle(fixed_handle);
+            if (!closed) {
+                return make_windows_result(DurableFileStatus::Unsupported,
+                                           ::GetLastError());
+            }
+        }
+
+        bool scratch_create_succeeded = false;
+        const auto terminal_failure = [&](DurableFileResult failure) {
+            if (scratch_create_succeeded && !failure.succeeded()) {
+                failure.status = DurableFileStatus::EffectMayHaveOccurred;
+            }
+            return failure;
+        };
+        for (std::size_t attempt = 0;
+             attempt < preflight_collision_attempts; ++attempt) {
+            const auto names = next_preflight_names();
+            const auto probe_path = child_path(directory_, names.probe);
+            const auto stage_path = child_path(directory_, names.stage);
+            FILE_ID_INFO probe_identity {};
+            FILE_ID_INFO stage_identity {};
+            bool probe_owned = false;
+            bool stage_owned = false;
+            const auto cleanup_owned = [&]() {
+                auto result = make_result(DurableFileStatus::Succeeded);
+                if (stage_owned) {
+                    const auto removed =
+                        remove_owned_probe(stage_path, stage_identity);
+                    if (removed.succeeded()) {
+                        stage_owned = false;
+                    } else {
+                        result = removed;
+                    }
+                }
+                if (probe_owned) {
+                    const auto removed =
+                        remove_owned_probe(probe_path, probe_identity);
+                    if (removed.succeeded()) {
+                        probe_owned = false;
+                    } else if (result.succeeded()) {
+                        result = removed;
+                    }
+                }
+                return result;
+            };
+            const auto fail_after_cleanup =
+                [&](DurableFileResult failure) {
+                    const auto cleanup = cleanup_owned();
+                    return terminal_failure(cleanup.succeeded() ? failure
+                                                                : cleanup);
+                };
+
+            const auto probe_handle = ::CreateFileW(
+                probe_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                nullptr, CREATE_NEW,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+                nullptr);
+            if (probe_handle == INVALID_HANDLE_VALUE) {
+                const auto error = ::GetLastError();
+                if (error == ERROR_FILE_EXISTS ||
+                    error == ERROR_ALREADY_EXISTS) {
+                    continue;
+                }
+                return terminal_failure(open_error_result(error));
+            }
+            scratch_create_succeeded = true;
+            auto probe_safe =
+                capture_regular_identity(probe_handle, probe_identity);
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            probe_safe = apply_created_identity_test_fault(
+                DurablePreflightTestFault::ProbeIdentityCaptureFailureOnce,
+                std::move(probe_safe));
+#endif
+            if (!probe_safe.succeeded()) {
+                return terminal_failure(close_open_handle(
+                    probe_handle, post_create_failure(probe_safe)));
+            }
+            probe_owned = true;
+            WindowsDurableFileChannel probe_channel(probe_handle);
+            auto flush_probe =
+                write_flush_close(probe_channel, "durability-probe");
+            if (!flush_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                flush_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return flush_probe;
+            }
+
+            const auto truncate_handle = ::CreateFileW(
+                probe_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                nullptr, OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+                nullptr);
+            if (truncate_handle == INVALID_HANDLE_VALUE) {
+                return fail_after_cleanup(
+                    open_error_result(::GetLastError()));
+            }
+            FILE_ID_INFO truncate_identity {};
+            const auto truncate_safe = capture_regular_identity(
+                truncate_handle, truncate_identity);
+            if (!truncate_safe.succeeded() ||
+                !same_file_identity(truncate_identity, probe_identity)) {
+                const auto result = close_open_handle(
+                    truncate_handle,
+                    truncate_safe.succeeded()
+                        ? make_result(DurableFileStatus::EffectMayHaveOccurred)
+                        : post_create_failure(truncate_safe));
+                return fail_after_cleanup(result);
+            }
+            WindowsDurableFileChannel truncate_channel(truncate_handle);
+            auto truncate_probe =
+                truncate_flush_close(truncate_channel, 0);
+            if (!truncate_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                truncate_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return truncate_probe;
+            }
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            const auto collision = seed_stage_collision_for_test(stage_path);
+            if (!collision.succeeded()) {
+                return fail_after_cleanup(collision);
+            }
+#endif
+            const auto stage_handle = ::CreateFileW(
+                stage_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                nullptr, CREATE_NEW,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+                nullptr);
+            if (stage_handle == INVALID_HANDLE_VALUE) {
+                const auto error = ::GetLastError();
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                if (error == ERROR_FILE_EXISTS ||
+                    error == ERROR_ALREADY_EXISTS) {
+                    continue;
+                }
+                return terminal_failure(open_error_result(error));
+            }
+            scratch_create_succeeded = true;
+            auto stage_safe =
+                capture_regular_identity(stage_handle, stage_identity);
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+            stage_safe = apply_created_identity_test_fault(
+                DurablePreflightTestFault::StageIdentityCaptureFailureOnce,
+                std::move(stage_safe));
+#endif
+            if (!stage_safe.succeeded()) {
+                return fail_after_cleanup(
+                    close_open_handle(stage_handle,
+                                      post_create_failure(stage_safe)));
+            }
+            stage_owned = true;
+            WindowsDurableFileChannel stage_channel(stage_handle);
+            auto replace_probe =
+                write_flush_close(stage_channel, "replacement-probe");
+            if (!replace_probe.succeeded()) {
+                const auto cleanup = cleanup_owned();
+                if (!cleanup.succeeded()) {
+                    return terminal_failure(cleanup);
+                }
+                replace_probe.status =
+                    DurableFileStatus::EffectMayHaveOccurred;
+                return replace_probe;
+            }
+            const auto stage_current =
+                verify_owned_probe(stage_path, stage_identity);
+            const auto probe_current =
+                verify_owned_probe(probe_path, probe_identity);
+            if (!stage_current.succeeded() || !probe_current.succeeded()) {
+                return fail_after_cleanup(
+                    !stage_current.succeeded() ? stage_current
+                                               : probe_current);
+            }
+            if (!::MoveFileExW(stage_path.c_str(), probe_path.c_str(),
+                               MOVEFILE_REPLACE_EXISTING |
+                                   MOVEFILE_WRITE_THROUGH)) {
+                return fail_after_cleanup(make_windows_result(
+                    DurableFileStatus::EffectMayHaveOccurred,
+                    ::GetLastError()));
+            }
+            probe_identity = stage_identity;
+            probe_owned = true;
+            stage_owned = false;
+            const auto cleanup = cleanup_owned();
+            if (!cleanup.succeeded()) {
+                return terminal_failure(cleanup);
+            }
+            return make_result(DurableFileStatus::Succeeded);
+        }
+        return terminal_failure(make_windows_result(
+            DurableFileStatus::AlreadyExists, ERROR_FILE_EXISTS));
+    }
+
+    DurableFixedNamespaceResult inspect_fixed_namespace() override {
+        if (!bound()) {
+            return {make_result(DurableFileStatus::Unsupported), false, false,
+                    false, false, false};
+        }
+        DurableFixedNamespaceResult inspected{
+            make_result(DurableFileStatus::Succeeded), false, false, false,
+            false, false};
+        const std::array<std::pair<std::wstring_view, bool *>, 5> entries{
+            std::pair{journal_name, &inspected.journal_present},
+            std::pair{root_name, &inspected.root_present},
+            std::pair{journal_stage_name, &inspected.journal_stage_present},
+            std::pair{root_stage_name, &inspected.root_stage_present},
+            std::pair{lock_name, &inspected.lock_present},
+        };
+        for (const auto &[name, present] : entries) {
+            const auto path = child_path(directory_, name);
+            const auto handle = ::CreateFileW(
+                path.c_str(), FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+            if (handle == INVALID_HANDLE_VALUE) {
+                const auto error = ::GetLastError();
+                if (error == ERROR_FILE_NOT_FOUND ||
+                    error == ERROR_PATH_NOT_FOUND) {
+                    continue;
+                }
+                inspected.result = make_windows_result(
+                    DurableFileStatus::Unsupported, error);
+                return inspected;
+            }
+            FILE_ATTRIBUTE_TAG_INFO attributes {};
+            if (!::GetFileInformationByHandleEx(
+                    handle, FileAttributeTagInfo, &attributes,
+                    sizeof(attributes))) {
+                inspected.result = close_open_handle(
+                    handle,
+                    make_windows_result(DurableFileStatus::Unsupported,
+                                        ::GetLastError()));
+                return inspected;
+            }
+            if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) !=
+                    0 ||
+                (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                inspected.result = close_open_handle(
+                    handle, make_result(DurableFileStatus::Unsupported));
+                return inspected;
+            }
+            FILE_STANDARD_INFO standard {};
+            if (!::GetFileInformationByHandleEx(
+                    handle, FileStandardInfo, &standard,
+                    sizeof(standard))) {
+                inspected.result = close_open_handle(
+                    handle,
+                    make_windows_result(DurableFileStatus::Unsupported,
+                                        ::GetLastError()));
+                return inspected;
+            }
+            if ((name != lock_name && standard.NumberOfLinks != 1) ||
+                (name == lock_name && standard.NumberOfLinks == 0)) {
+                inspected.result = close_open_handle(
+                    handle, make_result(DurableFileStatus::Unsupported));
+                return inspected;
+            }
+            if (!::CloseHandle(handle)) {
+                inspected.result = make_windows_result(
+                    DurableFileStatus::Unsupported, ::GetLastError());
+                return inspected;
+            }
+            *present = true;
+        }
+        return inspected;
+    }
+
+    DurableReadResult read_root(std::size_t max_bytes) override {
+        if (!bound()) {
+            return {make_result(DurableFileStatus::Unsupported), {}, false};
+        }
+        const auto path = child_path(directory_, root_name);
+        const auto handle = ::CreateFileW(
+            path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+            nullptr, OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return {open_error_result(::GetLastError()), {}, false};
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return {close_open_handle(
+                        handle,
+                        make_windows_result(DurableFileStatus::Unsupported,
+                                            ::GetLastError())),
+                    {}, false};
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return {close_open_handle(
+                        handle, make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return {close_open_handle(
+                        handle,
+                        make_windows_result(DurableFileStatus::Unsupported,
+                                            ::GetLastError())),
+                    {}, false};
+        }
+        if (standard.NumberOfLinks != 1) {
+            return {close_open_handle(
+                        handle, make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        WindowsDurableReadChannel channel(handle);
+        return read_bounded_close(channel, max_bytes);
+    }
+
+    DurableReadResult read_journal(std::size_t max_bytes) override {
+        if (!bound()) {
+            return {make_result(DurableFileStatus::Unsupported), {}, false};
+        }
+        const auto path = child_path(directory_, journal_name);
+        const auto handle = ::CreateFileW(
+            path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+            nullptr, OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return {open_error_result(::GetLastError()), {}, false};
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return {close_open_handle(
+                        handle,
+                        make_windows_result(DurableFileStatus::Unsupported,
+                                            ::GetLastError())),
+                    {}, false};
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return {close_open_handle(
+                        handle, make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return {close_open_handle(
+                        handle,
+                        make_windows_result(DurableFileStatus::Unsupported,
+                                            ::GetLastError())),
+                    {}, false};
+        }
+        if (standard.NumberOfLinks != 1) {
+            return {close_open_handle(
+                        handle, make_result(DurableFileStatus::Unsupported)),
+                    {}, false};
+        }
+        WindowsDurableReadChannel channel(handle);
+        return read_bounded_close(channel, max_bytes);
+    }
+
+    DurableFileResult create_journal(std::string_view bytes) override {
+        if (!bound()) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto path = child_path(directory_, journal_name);
+        const auto handle = ::CreateFileW(
+            path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred,
+                            ::GetLastError()));
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return close_open_handle(
+                handle,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred,
+                            ::GetLastError()));
+        }
+        if (standard.NumberOfLinks != 1) {
+            return close_open_handle(
+                handle,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        WindowsDurableFileChannel channel(handle);
+        const auto persisted = write_flush_close(channel, bytes);
+        if (!persisted.succeeded() &&
+            !persisted.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    persisted.diagnostic};
+        }
+        return persisted;
+    }
+
+    DurableFileResult append_journal(std::string_view bytes) override {
+        if (!bound()) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto path = child_path(directory_, journal_name);
+        const auto handle = ::CreateFileW(
+            path.c_str(), FILE_APPEND_DATA | FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return close_open_handle(
+                handle,
+                make_windows_result(DurableFileStatus::FailedBeforeEffect,
+                                    ::GetLastError()));
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return close_open_handle(
+                handle, make_result(DurableFileStatus::Unsupported));
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return close_open_handle(
+                handle,
+                make_windows_result(DurableFileStatus::FailedBeforeEffect,
+                                    ::GetLastError()));
+        }
+        if (standard.NumberOfLinks != 1) {
+            return close_open_handle(
+                handle, make_result(DurableFileStatus::Unsupported));
+        }
+        WindowsDurableFileChannel channel(handle);
+        return write_flush_close(channel, bytes);
+    }
+
+    DurableFileResult truncate_journal(std::size_t bytes) override {
+        if (!bound()) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto path = child_path(directory_, journal_name);
+        const auto handle = ::CreateFileW(
+            path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return close_open_handle(
+                handle,
+                make_windows_result(DurableFileStatus::FailedBeforeEffect,
+                                    ::GetLastError()));
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return close_open_handle(
+                handle, make_result(DurableFileStatus::Unsupported));
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return close_open_handle(
+                handle,
+                make_windows_result(DurableFileStatus::FailedBeforeEffect,
+                                    ::GetLastError()));
+        }
+        if (standard.NumberOfLinks != 1) {
+            return close_open_handle(
+                handle, make_result(DurableFileStatus::Unsupported));
+        }
+        WindowsDurableFileChannel channel(handle);
+        return truncate_flush_close(channel, bytes);
+    }
+
+    DurableFileResult replace_journal(std::string_view bytes) override {
+        if (!bound()) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto stage_path = child_path(directory_, journal_stage_name);
+        const auto target_path = child_path(directory_, journal_name);
+        const auto handle = ::CreateFileW(
+            stage_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred,
+                            ::GetLastError()));
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return close_open_handle(
+                handle,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred,
+                            ::GetLastError()));
+        }
+        if (standard.NumberOfLinks != 1) {
+            return close_open_handle(
+                handle,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        FILE_ID_INFO staged_identity {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileIdInfo, &staged_identity,
+                sizeof(staged_identity))) {
+            const auto error = ::GetLastError();
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred, error));
+        }
+        const auto cleared = clear_verified_stage(handle);
+        if (!cleared.succeeded()) {
+            return close_open_handle(handle, cleared);
+        }
+        WindowsDurableFileChannel channel(handle);
+        const auto staged = write_flush_close(channel, bytes);
+        if (!staged.succeeded() && !staged.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    staged.diagnostic};
+        }
+        if (!staged.succeeded()) {
+            return staged;
+        }
+        if (!::MoveFileExW(stage_path.c_str(), target_path.c_str(),
+                           MOVEFILE_REPLACE_EXISTING |
+                               MOVEFILE_WRITE_THROUGH)) {
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, ::GetLastError());
+        }
+        return verify_replaced_target(target_path, staged_identity, bytes);
+    }
+
+    DurableFileResult replace_root(std::string_view bytes) override {
+        if (!bound()) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto stage_path = child_path(directory_, root_stage_name);
+        const auto target_path = child_path(directory_, root_name);
+        const auto handle = ::CreateFileW(
+            stage_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        FILE_ATTRIBUTE_TAG_INFO attributes {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileAttributeTagInfo, &attributes,
+                sizeof(attributes))) {
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred,
+                            ::GetLastError()));
+        }
+        if ((attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+            (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            return close_open_handle(
+                handle,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        FILE_STANDARD_INFO standard {};
+        if (!::GetFileInformationByHandleEx(handle, FileStandardInfo,
+                                            &standard, sizeof(standard))) {
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred,
+                            ::GetLastError()));
+        }
+        if (standard.NumberOfLinks != 1) {
+            return close_open_handle(
+                handle,
+                make_result(DurableFileStatus::EffectMayHaveOccurred));
+        }
+        FILE_ID_INFO staged_identity {};
+        if (!::GetFileInformationByHandleEx(
+                handle, FileIdInfo, &staged_identity,
+                sizeof(staged_identity))) {
+            const auto error = ::GetLastError();
+            return close_open_handle(
+                handle, make_windows_result(
+                            DurableFileStatus::EffectMayHaveOccurred, error));
+        }
+        const auto cleared = clear_verified_stage(handle);
+        if (!cleared.succeeded()) {
+            return close_open_handle(handle, cleared);
+        }
+        WindowsDurableFileChannel channel(handle);
+        const auto staged = write_flush_close(channel, bytes);
+        if (!staged.succeeded() && !staged.effect_may_have_occurred()) {
+            return {DurableFileStatus::EffectMayHaveOccurred,
+                    staged.diagnostic};
+        }
+        if (!staged.succeeded()) {
+            return staged;
+        }
+        if (!::MoveFileExW(stage_path.c_str(), target_path.c_str(),
+                           MOVEFILE_REPLACE_EXISTING |
+                               MOVEFILE_WRITE_THROUGH)) {
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, ::GetLastError());
+        }
+        return verify_replaced_target(target_path, staged_identity, bytes);
+    }
+
+    DurableFileResult unlock_authority() override {
+        if (lock_handle_ == INVALID_HANDLE_VALUE) {
+            return make_result(DurableFileStatus::Unsupported);
+        }
+        const auto handle = std::exchange(lock_handle_, INVALID_HANDLE_VALUE);
+        OVERLAPPED unlock_overlapped {};
+        const auto unlock_result = UnlockFileEx(
+            handle, 0, MAXDWORD, MAXDWORD, &unlock_overlapped);
+        const auto unlock_error =
+            unlock_result ? ERROR_SUCCESS : ::GetLastError();
+        const auto close_result = CloseHandle(handle);
+        const auto close_error =
+            close_result ? ERROR_SUCCESS : ::GetLastError();
+        if (!unlock_result && !close_result) {
+            return make_result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        if (!unlock_result) {
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, unlock_error);
+        }
+        if (!close_result) {
+            return make_windows_result(
+                DurableFileStatus::EffectMayHaveOccurred, close_error);
+        }
+        return make_result(DurableFileStatus::Succeeded);
+    }
+
+private:
+    bool bound() const noexcept {
+        return directory_handle_ != INVALID_HANDLE_VALUE &&
+               !directory_.empty();
+    }
+
+    std::filesystem::path directory_;
+    HANDLE directory_handle_ = INVALID_HANDLE_VALUE;
+    HANDLE lock_handle_ = INVALID_HANDLE_VALUE;
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    DurableFileResult seed_stage_collision_for_test(
+        const std::filesystem::path &path) noexcept {
+        if (preflight_test_fault_ !=
+            DurablePreflightTestFault::StageCreateCollisionExhaustion) {
+            return make_result(DurableFileStatus::Succeeded);
+        }
+        const auto handle = ::CreateFileW(
+            path.c_str(), GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        if (handle == INVALID_HANDLE_VALUE) {
+            return open_error_result(::GetLastError());
+        }
+        WindowsDurableFileChannel channel(handle);
+        return write_flush_close(channel, "caller-owned-stage-collision");
+    }
+
+    DurableFileResult apply_created_identity_test_fault(
+        DurablePreflightTestFault phase,
+        DurableFileResult captured) noexcept {
+        if (captured.succeeded() && preflight_test_fault_ == phase &&
+            !preflight_test_fault_taken_) {
+            preflight_test_fault_taken_ = true;
+            return make_result(DurableFileStatus::FailedBeforeEffect);
+        }
+        return captured;
+    }
+    std::optional<DurablePreflightTestFault> preflight_test_fault_;
+    bool preflight_test_fault_taken_ = false;
+#endif
+};
+
+} // namespace
+
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter(const std::filesystem::path &directory) {
+    const auto directory_handle = ::CreateFileW(
+        directory.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    if (directory_handle == INVALID_HANDLE_VALUE) {
+        return std::make_unique<WindowsDurableFileAdapter>(
+            std::filesystem::path{}, INVALID_HANDLE_VALUE);
+    }
+    FILE_ATTRIBUTE_TAG_INFO attributes {};
+    if (!::GetFileInformationByHandleEx(
+            directory_handle, FileAttributeTagInfo, &attributes,
+            sizeof(attributes)) ||
+        (attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+        (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+        close_best_effort(directory_handle);
+        return std::make_unique<WindowsDurableFileAdapter>(
+            std::filesystem::path{}, INVALID_HANDLE_VALUE);
+    }
+    auto bound_directory = final_directory_path(directory_handle);
+    if (!bound_directory.has_value()) {
+        close_best_effort(directory_handle);
+        return std::make_unique<WindowsDurableFileAdapter>(
+            std::filesystem::path{}, INVALID_HANDLE_VALUE);
+    }
+    return std::make_unique<WindowsDurableFileAdapter>(
+        std::move(*bound_directory), directory_handle);
+}
+
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+std::unique_ptr<DurableFileAdapter>
+make_platform_durable_file_adapter_for_test(
+    const std::filesystem::path &directory, DurablePreflightTestFault fault) {
+    const auto directory_handle = ::CreateFileW(
+        directory.c_str(), FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    if (directory_handle == INVALID_HANDLE_VALUE) {
+        return std::make_unique<WindowsDurableFileAdapter>(
+            std::filesystem::path{}, INVALID_HANDLE_VALUE, fault);
+    }
+    FILE_ATTRIBUTE_TAG_INFO attributes {};
+    if (!::GetFileInformationByHandleEx(
+            directory_handle, FileAttributeTagInfo, &attributes,
+            sizeof(attributes)) ||
+        (attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 ||
+        (attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+        close_best_effort(directory_handle);
+        return std::make_unique<WindowsDurableFileAdapter>(
+            std::filesystem::path{}, INVALID_HANDLE_VALUE, fault);
+    }
+    auto bound_directory = final_directory_path(directory_handle);
+    if (!bound_directory.has_value()) {
+        close_best_effort(directory_handle);
+        return std::make_unique<WindowsDurableFileAdapter>(
+            std::filesystem::path{}, INVALID_HANDLE_VALUE, fault);
+    }
+    return std::make_unique<WindowsDurableFileAdapter>(
+        std::move(*bound_directory), directory_handle, fault);
+}
+#endif
+
+} // namespace lemon::residency::detail

--- a/test/residency/recovery/durable_journal_private_authority_gate.cpp
+++ b/test/residency/recovery/durable_journal_private_authority_gate.cpp
@@ -1,0 +1,122 @@
+#include "lemon/residency/durable_journal.h"
+#include "platform/durable_file_adapter.h"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+using lemon::residency::AuthorityRootCandidate;
+using lemon::residency::DurableJournal;
+using lemon::residency::ExactSchemaExportCandidate;
+using lemon::residency::JournalHistory;
+using lemon::residency::ParsedJournalRecord;
+using lemon::residency::PublishedJournal;
+
+struct ForgedAdapter {};
+
+static_assert(std::is_move_constructible_v<PublishedJournal>);
+static_assert(!std::is_copy_constructible_v<PublishedJournal>);
+static_assert(!std::is_default_constructible_v<PublishedJournal>);
+static_assert(!std::is_constructible_v<PublishedJournal, std::string>);
+static_assert(!std::is_constructible_v<PublishedJournal,
+                                       ExactSchemaExportCandidate>);
+static_assert(!std::is_constructible_v<PublishedJournal,
+                                       const ParsedJournalRecord &>);
+static_assert(!std::is_constructible_v<PublishedJournal, JournalHistory &&>);
+static_assert(!std::is_constructible_v<PublishedJournal,
+                                       const AuthorityRootCandidate &>);
+static_assert(!std::is_constructible_v<PublishedJournal,
+                                       std::shared_ptr<ForgedAdapter>>);
+static_assert(!std::is_default_constructible_v<DurableJournal>);
+static_assert(!std::is_copy_constructible_v<DurableJournal>);
+
+} // namespace
+
+namespace lemon::residency {
+
+class PublishedJournalAccess {
+    template <typename T>
+    static auto can_private_construct(int)
+        -> decltype(T(std::unique_ptr<typename T::Impl>{}), std::true_type{});
+    template <typename>
+    static auto can_private_construct(...) -> std::false_type;
+
+public:
+    static constexpr bool can_forge =
+        decltype(can_private_construct<PublishedJournal>(0))::value;
+};
+
+class DurableJournalTestAccess {
+    template <typename T>
+    static auto can_private_construct(int)
+        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
+                      std::declval<JournalLimits>()),
+                    std::true_type{});
+    template <typename>
+    static auto can_private_construct(...) -> std::false_type;
+
+public:
+    static constexpr bool can_forge =
+        decltype(can_private_construct<DurableJournal>(0))::value;
+};
+
+static_assert(!PublishedJournalAccess::can_forge);
+static_assert(!DurableJournalTestAccess::can_forge);
+
+namespace detail {
+
+enum class DurablePreflightTestFault { MacroOffNameCollision };
+inline constexpr int make_platform_durable_file_adapter_for_test = 0;
+inline constexpr int make_durable_journal_for_test = 0;
+
+class DurableJournalAccess {
+    template <typename T>
+    static auto can_private_construct(int)
+        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
+                      std::declval<JournalLimits>()),
+                    std::true_type{});
+    template <typename>
+    static auto can_private_construct(...) -> std::false_type;
+
+public:
+    static constexpr bool can_forge =
+        decltype(can_private_construct<DurableJournal>(0))::value;
+};
+
+class DurableJournalTestAccess {
+    template <typename T>
+    static auto can_private_construct(int)
+        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
+                      std::declval<JournalLimits>()),
+                    std::true_type{});
+    template <typename>
+    static auto can_private_construct(...) -> std::false_type;
+
+public:
+    static constexpr bool can_forge =
+        decltype(can_private_construct<DurableJournal>(0))::value;
+};
+
+class DurableJournalTestFactory {
+    template <typename T>
+    static auto can_private_construct(int)
+        -> decltype(T(std::declval<std::unique_ptr<::ForgedAdapter>>(),
+                      std::declval<JournalLimits>()),
+                    std::true_type{});
+    template <typename>
+    static auto can_private_construct(...) -> std::false_type;
+
+public:
+    static constexpr bool can_forge =
+        decltype(can_private_construct<DurableJournal>(0))::value;
+};
+
+static_assert(!DurableJournalAccess::can_forge);
+static_assert(!DurableJournalTestAccess::can_forge);
+static_assert(!DurableJournalTestFactory::can_forge);
+
+} // namespace detail
+} // namespace lemon::residency

--- a/test/residency/recovery/durable_journal_public_seam.cpp
+++ b/test/residency/recovery/durable_journal_public_seam.cpp
@@ -1,0 +1,6252 @@
+#include "journal_persistence_test_support.h"
+
+#include "platform/durable_file_adapter.h"
+
+#include "lemon/residency/durable_journal.h"
+#include "lemon/residency/journal.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <initializer_list>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace {
+
+using namespace lemon::residency;
+using namespace lemon::residency::testing;
+
+constexpr std::string_view genesis_wire =
+    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"dae75ca123b7b872994ff29f8661049c9c28a1798b76fcd0015271739c5adf63","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":null,"quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":null,"resident_id":"resident/alpha","resident_state":"prepared","schema":{"major":1,"minor":0},"sequence":1})";
+
+constexpr std::string_view successor_wire =
+    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"ec749a93f0e1a98911b9b91d1823f706d5ce16d1f477690b3c5e07b59fd98147","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":"dae75ca123b7b872994ff29f8661049c9c28a1798b76fcd0015271739c5adf63","quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":null,"resident_id":"resident/alpha","resident_state":"provisional","schema":{"major":1,"minor":0},"sequence":2})";
+
+constexpr std::string_view wrong_predecessor_wire =
+    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"dacce12645761d37967d12704a1eef45ea8634c12b6d77d01f4d1e69cd7606b0","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":"f51528eb4d96e562a5a09c5ac314af4bd5a0821106053f0775e76407eba98ff6","quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":null,"resident_id":"resident/alpha","resident_state":"provisional","schema":{"major":1,"minor":0},"sequence":2})";
+
+constexpr std::string_view illegal_transition_wire =
+    R"({"action_lease_claim_ids":["lease/a"],"checksum_sha256":"3db5747617ca25795e6a961271308b9897e0ccaf825adfb92682181589b064dc","claim_closure":[{"completeness":"bounded","entries":[{"amount":4096,"constraint_id":"gpu/gtt","unit":"bytes"}],"family":"consumable_capacity"},{"completeness":"known_zero","entries":[],"family":"safety_floor"},{"completeness":"bounded","entries":[{"amount":2,"constraint_id":"model-type/llm","unit":"count"}],"family":"cardinality_pool"},{"completeness":"not_applicable","entries":[],"family":"compatibility_exclusivity"}],"daemon_epoch":"epoch/7","journal_id":"journal/main","operation":{"family":"resource_lifecycle","kind":"admission","operation_id":"op/1","plan_id":"plan/1"},"ownership_claim_ids":["owner/a"],"predecessor_checksum_sha256":"dae75ca123b7b872994ff29f8661049c9c28a1798b76fcd0015271739c5adf63","quarantine_origin":null,"recovery_claim_ids":["recovery/a"],"recovery_disposition":"verified_intact","resident_id":"resident/alpha","resident_state":"active","schema":{"major":1,"minor":0},"sequence":2})";
+
+void require(bool condition, std::string_view message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+std::string frame(const ParsedJournalRecord &record) {
+    return std::string(record.canonical_bytes()) + '\n';
+}
+
+JournalLimits generous_limits() {
+    return JournalLimits{1024 * 1024, 128, 32, 1024 * 1024};
+}
+
+JournalRecordDraft draft_for(std::string journal_id, std::string resident_id,
+                             ResidentState state) {
+    JournalRecordDraft draft;
+    draft.journal_id = std::move(journal_id);
+    draft.resident_id = std::move(resident_id);
+    draft.daemon_epoch = "epoch/7";
+    draft.operation = OperationIdentity{"op/1", std::string("plan/1"),
+                                        OperationFamily::ResourceLifecycle,
+                                        OperationKind::Admission};
+    draft.claim_closure = {
+        ClaimFamilyClosure{ClaimFamily::ConsumableCapacity,
+                           ClaimCompleteness::Bounded,
+                           {ClaimAmount{"gpu/gtt", ClaimUnit::Bytes, 4096}}},
+        ClaimFamilyClosure{
+            ClaimFamily::SafetyFloor, ClaimCompleteness::KnownZero, {}},
+        ClaimFamilyClosure{
+            ClaimFamily::CardinalityPool,
+            ClaimCompleteness::Bounded,
+            {ClaimAmount{"model-type/llm", ClaimUnit::Count, 2}}},
+        ClaimFamilyClosure{ClaimFamily::CompatibilityExclusivity,
+                           ClaimCompleteness::NotApplicable,
+                           {}},
+    };
+    draft.resident_state = state;
+    switch (state) {
+    case ResidentState::Prepared:
+    case ResidentState::Provisional:
+        break;
+    case ResidentState::Active:
+    case ResidentState::Suspended:
+        draft.recovery_disposition = RecoveryDisposition::VerifiedIntact;
+        break;
+    case ResidentState::Quarantined:
+        draft.recovery_disposition = RecoveryDisposition::Quarantined;
+        draft.quarantine_origin = RecoveryOrigin{
+            RecoveryOriginKind::RuntimeRealization,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"};
+        break;
+    case ResidentState::Released:
+        draft.recovery_disposition = RecoveryDisposition::VerifiedReleased;
+        break;
+    }
+    draft.action_lease_claim_ids = {"lease/a"};
+    draft.ownership_claim_ids = {"owner/a"};
+    draft.recovery_claim_ids = {"recovery/a"};
+    return draft;
+}
+
+class AllowingOriginVerifier final : public RecoveryOriginVerifier {
+public:
+    bool verify(const RecoveryOriginVerification &) const noexcept override {
+        return true;
+    }
+};
+
+class RejectIfCalledVerifier final : public RecoveryOriginVerifier {
+public:
+    bool verify(const RecoveryOriginVerification &) const noexcept override {
+        called.store(true);
+        return false;
+    }
+
+    mutable std::atomic<bool> called{false};
+};
+
+struct VerifierLifetimeState {
+    std::atomic<std::size_t> calls{0};
+    std::atomic<bool> alive{false};
+};
+
+class LifetimeAllowingVerifier final : public RecoveryOriginVerifier {
+public:
+    explicit LifetimeAllowingVerifier(
+        std::shared_ptr<VerifierLifetimeState> state)
+        : state_(std::move(state)) {
+        state_->alive.store(true);
+    }
+
+    ~LifetimeAllowingVerifier() override { state_->alive.store(false); }
+
+    bool verify(const RecoveryOriginVerification &) const noexcept override {
+        state_->calls.fetch_add(1);
+        return true;
+    }
+
+private:
+    std::shared_ptr<VerifierLifetimeState> state_;
+};
+
+struct Chain {
+    ParsedJournalRecord genesis;
+    ParsedJournalRecord successor;
+    ParsedJournalRecord fork;
+    ParsedJournalRecord third;
+    AuthorityRootCandidate genesis_root;
+    AuthorityRootCandidate successor_root;
+    AuthorityRootCandidate fork_root;
+    AuthorityRootCandidate third_root;
+};
+
+ParsedJournalRecord make_quarantine_tail(const Chain &chain);
+
+ParsedJournalRecord take_record(ParsedJournalRecordResult result,
+                                std::string_view label) {
+    require(result.accepted() && result.candidate.has_value(), label);
+    return std::move(*result.candidate);
+}
+
+JournalHistory take_history(JournalHistoryResult result,
+                            std::string_view label) {
+    require(result.accepted() && result.history.has_value(), label);
+    return std::move(*result.history);
+}
+
+AuthorityRootCandidate take_root(AuthorityRootCandidateResult result,
+                                 std::string_view label) {
+    require(result.accepted() && result.candidate.has_value(), label);
+    return std::move(*result.candidate);
+}
+
+Chain make_chain(std::string journal_id = "journal/main") {
+    auto genesis =
+        take_record(seal_genesis(draft_for(journal_id, "resident/alpha",
+                                           ResidentState::Prepared)),
+                    "genesis fixture was rejected");
+    auto genesis_history =
+        take_history(begin_history(genesis), "genesis history was rejected");
+    auto genesis_root =
+        take_root(seal_authority_root_candidate(genesis_history),
+                  "genesis root fixture was rejected");
+
+    auto successor = take_record(
+        seal_successor(genesis_history, draft_for(journal_id, "resident/alpha",
+                                                  ResidentState::Provisional)),
+        "successor fixture was rejected");
+    if (journal_id == "journal/main") {
+        require(genesis.canonical_bytes() == genesis_wire &&
+                    successor.canonical_bytes() == successor_wire,
+                "TASK-019 canonical fixtures drifted");
+    }
+    auto fork = take_record(
+        seal_successor(genesis_history, draft_for(journal_id, "resident/alpha",
+                                                  ResidentState::Released)),
+        "fork fixture was rejected");
+
+    auto successor_history =
+        take_history(advance_history(std::move(genesis_history), successor),
+                     "successor history fixture was rejected");
+    auto successor_root = take_root(
+        seal_authority_root_candidate(successor_history, &genesis_root),
+        "successor root fixture was rejected");
+
+    auto fork_history =
+        take_history(begin_history(genesis), "fork genesis was rejected");
+    fork_history = take_history(advance_history(std::move(fork_history), fork),
+                                "fork history fixture was rejected");
+    auto fork_root =
+        take_root(seal_authority_root_candidate(fork_history, &genesis_root),
+                  "fork root fixture was rejected");
+
+    auto third =
+        take_record(seal_successor(successor_history,
+                                   draft_for(journal_id, "resident/alpha",
+                                             ResidentState::Active)),
+                    "third fixture was rejected");
+    auto third_history =
+        take_history(advance_history(std::move(successor_history), third),
+                     "third history fixture was rejected");
+    auto third_root =
+        take_root(seal_authority_root_candidate(third_history, &successor_root),
+                  "third root fixture was rejected");
+
+    return Chain{std::move(genesis),      std::move(successor),
+                 std::move(fork),         std::move(third),
+                 std::move(genesis_root), std::move(successor_root),
+                 std::move(fork_root),    std::move(third_root)};
+}
+
+std::string replace_once(std::string value, std::string_view needle,
+                         std::string_view replacement) {
+    const auto offset = value.find(needle);
+    require(offset != std::string::npos,
+            "root-adversary fixture token was absent");
+    value.replace(offset, needle.size(), replacement);
+    return value;
+}
+
+template <typename Map>
+bool same_optional_value(const Map &left, const Map &right,
+                         std::string_view key) {
+    const auto left_value = left.find(std::string(key));
+    const auto right_value = right.find(std::string(key));
+    if ((left_value == left.end()) != (right_value == right.end())) {
+        return false;
+    }
+    return left_value == left.end() ||
+           left_value->second == right_value->second;
+}
+
+bool fixed_file_unchanged(const NamespaceSnapshot &before,
+                          const NamespaceSnapshot &after,
+                          std::string_view name) {
+    return same_optional_value(before.live_file_bytes, after.live_file_bytes,
+                               name) &&
+           same_optional_value(before.durable_file_bytes,
+                               after.durable_file_bytes, name) &&
+           same_optional_value(before.entry_kinds, after.entry_kinds, name) &&
+           before.relative_paths.count(std::string(name)) ==
+               after.relative_paths.count(std::string(name)) &&
+           before.durable_paths.count(std::string(name)) ==
+               after.durable_paths.count(std::string(name)) &&
+           before.durable_content_available.count(std::string(name)) ==
+               after.durable_content_available.count(std::string(name));
+}
+
+bool authority_files_unchanged(const NamespaceSnapshot &before,
+                               const NamespaceSnapshot &after) {
+    for (const auto name :
+         {"journal.jsonl", "authority-root.json", ".journal.jsonl.stage",
+          ".authority-root.json.stage"}) {
+        if (!fixed_file_unchanged(before, after, name)) {
+            return false;
+        }
+    }
+    return before.journal_bytes == after.journal_bytes &&
+           before.authority_root_bytes == after.authority_root_bytes;
+}
+
+bool stage_files_unchanged(const NamespaceSnapshot &before,
+                           const NamespaceSnapshot &after) {
+    for (const auto name :
+         {".journal.jsonl.stage", ".authority-root.json.stage"}) {
+        if (!fixed_file_unchanged(before, after, name)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool is_stage_operation(FaultOperation operation) {
+    switch (operation) {
+    case FaultOperation::RootStageCreate:
+    case FaultOperation::RootStageWrite:
+    case FaultOperation::RootStageFlush:
+    case FaultOperation::RootStageClose:
+    case FaultOperation::RootReplace:
+    case FaultOperation::NamespaceDurability:
+    case FaultOperation::CompactionStageCreate:
+    case FaultOperation::CompactionWrite:
+    case FaultOperation::CompactionFlush:
+    case FaultOperation::CompactionClose:
+    case FaultOperation::CompactionReplace:
+    case FaultOperation::CompactionNamespaceDurability:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool has_stage_operation(const NamespaceSnapshot &snapshot) {
+    return std::any_of(snapshot.observations.begin(),
+                       snapshot.observations.end(),
+                       [](const OperationObservation &observation) {
+                           return is_stage_operation(observation.operation);
+                       });
+}
+
+ParsedJournalRecord make_second_resident(const Chain &chain,
+                                         std::string journal_id) {
+    auto history = take_history(begin_history(chain.genesis),
+                                "second-resident genesis failed");
+    return take_record(
+        seal_successor(history,
+                       draft_for(std::move(journal_id), "resident/beta",
+                                 ResidentState::Prepared)),
+        "second-resident fixture was rejected");
+}
+
+AuthorityRootCandidate root_after(const Chain &chain,
+                                  const ParsedJournalRecord &record) {
+    auto history =
+        take_history(begin_history(chain.genesis), "root-after genesis failed");
+    history = take_history(advance_history(std::move(history), record),
+                           "root-after successor failed");
+    return take_root(
+        seal_authority_root_candidate(history, &chain.genesis_root),
+        "root-after seal failed");
+}
+
+void require_result(DurableJournalResult &result, DurableJournalStatus expected,
+                    std::string_view label) {
+    require(result.status == expected, label);
+    require(result.published() == (expected == DurableJournalStatus::Published),
+            "result success predicate disagreed with status");
+    require(result.journal.has_value() ==
+                (expected == DurableJournalStatus::Published),
+            "authority handle availability disagreed with status");
+    if (result.journal.has_value()) {
+        require(result.journal->available(),
+                "returned authority handle was unavailable");
+    }
+}
+
+void require_storage_released_after_return(JournalTestStorage &storage,
+                                           std::string_view label) {
+    const auto snapshot = storage.snapshot();
+    const auto acquired = static_cast<std::size_t>(std::count_if(
+        snapshot.observations.begin(), snapshot.observations.end(),
+        [](const OperationObservation &observation) {
+            return observation.operation ==
+                       FaultOperation::AuthorityLockAcquire &&
+                   observation.lock_held;
+        }));
+    require(snapshot.open_handles.empty(), label);
+    if (acquired != 0) {
+        require(storage.attempt_count(FaultOperation::AuthorityLockClose) ==
+                    acquired,
+                "acquired authority lock was not closed exactly once");
+    }
+}
+
+void require_public_shape() {
+    static_assert(!std::is_default_constructible_v<TrustedReplayFloor>);
+    static_assert(!std::is_default_constructible_v<DurableJournal>);
+    static_assert(!std::is_copy_constructible_v<DurableJournal>);
+    static_assert(!std::is_copy_assignable_v<DurableJournal>);
+    static_assert(std::is_nothrow_move_constructible_v<DurableJournal>);
+    static_assert(std::is_nothrow_move_assignable_v<DurableJournal>);
+    static_assert(!std::is_default_constructible_v<PublishedJournal>);
+    static_assert(!std::is_copy_constructible_v<PublishedJournal>);
+    static_assert(!std::is_copy_assignable_v<PublishedJournal>);
+    static_assert(std::is_move_constructible_v<PublishedJournal>);
+    static_assert(std::is_move_assignable_v<PublishedJournal>);
+    static_assert(
+        !std::is_constructible_v<PublishedJournal, ParsedJournalRecord>);
+    static_assert(!std::is_constructible_v<PublishedJournal, JournalHistory>);
+    static_assert(
+        !std::is_constructible_v<PublishedJournal, AuthorityRootCandidate>);
+    static_assert(
+        !std::is_constructible_v<PublishedJournal, ExactSchemaExportCandidate>);
+    static_assert(
+        !std::is_convertible_v<ParsedJournalRecord, PublishedJournal>);
+    static_assert(!std::is_convertible_v<JournalHistory, PublishedJournal>);
+    static_assert(
+        !std::is_convertible_v<AuthorityRootCandidate, PublishedJournal>);
+    static_assert(
+        !std::is_convertible_v<ExactSchemaExportCandidate, PublishedJournal>);
+
+    const auto limits = generous_limits();
+    require(
+        limits.max_committed_bytes != 0 && limits.max_committed_records != 0 &&
+            limits.max_resident_heads != 0 && limits.max_crash_tail_bytes != 0,
+        "test limits were not explicit");
+
+    const std::set<DurableJournalStatus> statuses{
+        DurableJournalStatus::Published,
+        DurableJournalStatus::ConflictBeforeWrite,
+        DurableJournalStatus::UnsupportedStorage,
+        DurableJournalStatus::CorruptOrRollback,
+        DurableJournalStatus::LimitExceeded,
+        DurableJournalStatus::RecoveryRequired,
+    };
+    require(statuses.size() == 6, "stable durable-journal outcomes collapsed");
+    require(durable_journal_data_filename == "journal.jsonl" &&
+                durable_journal_root_filename == "authority-root.json" &&
+                durable_journal_lock_filename == "authority.lock",
+            "fixed public authority filenames drifted");
+    const std::set<ExactSchemaExportStatus> export_statuses{
+        ExactSchemaExportStatus::ExportedCandidate,
+        ExactSchemaExportStatus::QuiescenceRequired,
+        ExactSchemaExportStatus::ConflictBeforeRead,
+        ExactSchemaExportStatus::RecoveryRequired,
+        ExactSchemaExportStatus::UnsupportedStorage,
+        ExactSchemaExportStatus::CorruptOrRollback,
+        ExactSchemaExportStatus::SchemaMismatch,
+        ExactSchemaExportStatus::LimitExceeded,
+    };
+    require(export_statuses.size() == 8,
+            "stable exact-schema export outcomes collapsed");
+}
+
+void require_shared_io_helpers() {
+    const std::string bytes = "partial-write-contract";
+    const auto partial = probe_write_all(bytes, {FaultAction::ShortWrite});
+    require(partial.result == HelperResultKind::Succeeded &&
+                partial.bytes == bytes && partial.attempts > 1,
+            "write_all did not complete an exact partial write");
+
+    const auto interrupted = probe_write_all(
+        bytes, {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce,
+                FaultAction::ShortWrite});
+    require(interrupted.result == HelperResultKind::Succeeded &&
+                interrupted.bytes == bytes && interrupted.attempts > 3,
+            "write_all did not retry interrupted partial progress");
+    const auto interrupted_after_progress = probe_write_all(
+        bytes, {FaultAction::ShortWrite, FaultAction::InterruptedOnce,
+                FaultAction::ShortWrite});
+    require(interrupted_after_progress.result == HelperResultKind::Succeeded &&
+                interrupted_after_progress.bytes == bytes &&
+                interrupted_after_progress.attempts > 3,
+            "write_all reset or duplicated progress after interruption");
+
+    for (const auto action :
+         {FaultAction::ZeroProgress, FaultAction::OverreportedWrite,
+          FaultAction::Error}) {
+        const auto rejected = probe_write_all(bytes, {action});
+        require(rejected.result == HelperResultKind::FailedBeforeEffect &&
+                    rejected.attempts == 1,
+                "write_all did not fail closed on invalid progress");
+    }
+    const auto partial_prefix = bytes.substr(0, bytes.size() / 2);
+    for (const auto action : {FaultAction::Error, FaultAction::ZeroProgress,
+                              FaultAction::OverreportedWrite}) {
+        const auto rejected_after_progress =
+            probe_write_all(bytes, {FaultAction::ShortWrite, action});
+        require(rejected_after_progress.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    rejected_after_progress.bytes == partial_prefix &&
+                    rejected_after_progress.attempts == 2,
+                "write_all forgot partial progress before terminal failure");
+    }
+    const auto effect_may =
+        probe_write_all(bytes, {FaultAction::EffectThenError});
+    require(effect_may.result == HelperResultKind::EffectMayHaveOccurred &&
+                effect_may.bytes == bytes && effect_may.attempts == 1,
+            "write_all lost a possibly-effectful failure");
+
+    const auto flushed = probe_flush_retry(
+        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
+    require(flushed.result == HelperResultKind::Succeeded &&
+                flushed.attempts == 3,
+            "flush helper did not retry all interruptions");
+
+    const auto truncated = probe_truncate_retry(
+        bytes, 7, {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
+    require(truncated.result == HelperResultKind::Succeeded &&
+                truncated.bytes == bytes.substr(0, 7) &&
+                truncated.attempts == 3,
+            "truncate helper did not retry to the exact boundary");
+
+    for (const auto &[action, expected] :
+         {std::pair{FaultAction::Error, HelperResultKind::FailedBeforeEffect},
+          std::pair{FaultAction::EffectThenError,
+                    HelperResultKind::EffectMayHaveOccurred}}) {
+        const auto terminal_flush = probe_flush_retry({action});
+        require(terminal_flush.result == expected &&
+                    terminal_flush.attempts == 1,
+                "flush helper retried a non-interrupted failure");
+        const auto terminal_truncate = probe_truncate_retry(bytes, 7, {action});
+        const auto expected_bytes =
+            action == FaultAction::EffectThenError ? bytes.substr(0, 7) : bytes;
+        require(terminal_truncate.result == expected &&
+                    terminal_truncate.bytes == expected_bytes &&
+                    terminal_truncate.attempts == 1,
+                "truncate helper retried or lost a terminal outcome");
+    }
+
+    for (const auto &[action, expected] :
+         {std::pair{FaultAction::InterruptedOnce,
+                    HelperResultKind::Interrupted},
+          std::pair{FaultAction::EffectThenError,
+                    HelperResultKind::EffectMayHaveOccurred},
+          std::pair{FaultAction::Error,
+                    HelperResultKind::FailedBeforeEffect}}) {
+        const auto closed = probe_close_once({action});
+        require(closed.result == expected && closed.attempts == 1,
+                "close_once retried or collapsed a failed close");
+    }
+
+    const auto write_success = probe_write_flush_close(bytes, {}, {}, {});
+    require(write_success.result == HelperResultKind::Succeeded &&
+                write_success.bytes == bytes &&
+                write_success.write_attempts == 1 &&
+                write_success.flush_attempts == 1 &&
+                write_success.truncate_attempts == 0 &&
+                write_success.close_attempts == 1,
+            "write-flush-close changed the all-success path");
+
+    const auto write_retried = probe_write_flush_close(
+        bytes,
+        {FaultAction::InterruptedOnce, FaultAction::ShortWrite,
+         FaultAction::InterruptedOnce},
+        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce}, {});
+    require(write_retried.result == HelperResultKind::Succeeded &&
+                write_retried.bytes == bytes &&
+                write_retried.write_attempts > 3 &&
+                write_retried.flush_attempts == 3 &&
+                write_retried.close_attempts == 1,
+            "write-flush-close did not reuse retrying primitives exactly");
+
+    const auto possibly_written =
+        probe_write_flush_close(bytes, {FaultAction::EffectThenError}, {}, {});
+    require(possibly_written.result ==
+                    HelperResultKind::EffectMayHaveOccurred &&
+                possibly_written.bytes == bytes &&
+                possibly_written.write_attempts == 1 &&
+                possibly_written.close_attempts == 1,
+            "write-flush-close erased a possibly-effectful write");
+
+    for (const auto flush_action :
+         {FaultAction::Error, FaultAction::EffectThenError}) {
+        const auto failed_flush =
+            probe_write_flush_close(bytes, {}, {flush_action}, {});
+        require(failed_flush.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    failed_flush.bytes == bytes &&
+                    failed_flush.write_attempts == 1 &&
+                    failed_flush.flush_attempts == 1 &&
+                    failed_flush.close_attempts == 1,
+                "write-flush-close forgot a confirmed write before flush "
+                "failure");
+    }
+    for (const auto close_action :
+         {FaultAction::Error, FaultAction::InterruptedOnce,
+          FaultAction::EffectThenError}) {
+        const auto failed_close =
+            probe_write_flush_close(bytes, {}, {}, {close_action});
+        require(failed_close.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    failed_close.bytes == bytes &&
+                    failed_close.write_attempts == 1 &&
+                    failed_close.flush_attempts == 1 &&
+                    failed_close.close_attempts == 1,
+                "write-flush-close retried close or forgot prior progress");
+    }
+    for (const auto close_action : {FaultAction::Error}) {
+        const auto failed_before = probe_write_flush_close(
+            bytes, {FaultAction::Error}, {}, {close_action});
+        require(failed_before.result == HelperResultKind::FailedBeforeEffect &&
+                    failed_before.bytes.empty() &&
+                    failed_before.write_attempts == 1 &&
+                    failed_before.close_attempts == 1,
+                "write-flush-close collapsed two pre-effect failures");
+    }
+    const auto close_effect_after_write_failure = probe_write_flush_close(
+        bytes, {FaultAction::Error}, {}, {FaultAction::EffectThenError});
+    require(close_effect_after_write_failure.result ==
+                    HelperResultKind::FailedBeforeEffect &&
+                close_effect_after_write_failure.bytes.empty() &&
+                close_effect_after_write_failure.close_attempts == 1,
+            "write-flush-close changed a pre-effect write failure during "
+            "checked close");
+
+    const auto truncate_success =
+        probe_truncate_flush_close(bytes, 7, {}, {}, {});
+    require(truncate_success.result == HelperResultKind::Succeeded &&
+                truncate_success.bytes == bytes.substr(0, 7) &&
+                truncate_success.write_attempts == 0 &&
+                truncate_success.truncate_attempts == 1 &&
+                truncate_success.flush_attempts == 1 &&
+                truncate_success.close_attempts == 1,
+            "truncate-flush-close changed the all-success path");
+
+    const auto truncate_retried = probe_truncate_flush_close(
+        bytes, 7, {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce},
+        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce}, {});
+    require(truncate_retried.result == HelperResultKind::Succeeded &&
+                truncate_retried.bytes == bytes.substr(0, 7) &&
+                truncate_retried.truncate_attempts == 3 &&
+                truncate_retried.flush_attempts == 3 &&
+                truncate_retried.close_attempts == 1,
+            "truncate-flush-close did not reuse retrying primitives exactly");
+
+    const auto possibly_truncated = probe_truncate_flush_close(
+        bytes, 7, {FaultAction::EffectThenError}, {}, {});
+    require(possibly_truncated.result ==
+                    HelperResultKind::EffectMayHaveOccurred &&
+                possibly_truncated.bytes == bytes.substr(0, 7) &&
+                possibly_truncated.truncate_attempts == 1 &&
+                possibly_truncated.close_attempts == 1,
+            "truncate-flush-close erased a possibly-effectful truncate");
+
+    for (const auto flush_action :
+         {FaultAction::Error, FaultAction::EffectThenError}) {
+        const auto failed_flush =
+            probe_truncate_flush_close(bytes, 7, {}, {flush_action}, {});
+        require(failed_flush.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    failed_flush.bytes == bytes.substr(0, 7) &&
+                    failed_flush.truncate_attempts == 1 &&
+                    failed_flush.flush_attempts == 1 &&
+                    failed_flush.close_attempts == 1,
+                "truncate-flush-close forgot a confirmed truncate before "
+                "flush failure");
+    }
+    for (const auto close_action :
+         {FaultAction::Error, FaultAction::InterruptedOnce,
+          FaultAction::EffectThenError}) {
+        const auto failed_close =
+            probe_truncate_flush_close(bytes, 7, {}, {}, {close_action});
+        require(failed_close.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    failed_close.bytes == bytes.substr(0, 7) &&
+                    failed_close.truncate_attempts == 1 &&
+                    failed_close.flush_attempts == 1 &&
+                    failed_close.close_attempts == 1,
+                "truncate-flush-close retried close or forgot prior effect");
+    }
+    for (const auto close_action : {FaultAction::Error}) {
+        const auto failed_before = probe_truncate_flush_close(
+            bytes, 7, {FaultAction::Error}, {}, {close_action});
+        require(failed_before.result == HelperResultKind::FailedBeforeEffect &&
+                    failed_before.bytes == bytes &&
+                    failed_before.truncate_attempts == 1 &&
+                    failed_before.close_attempts == 1,
+                "truncate-flush-close collapsed two pre-effect failures");
+    }
+    const auto close_effect_after_truncate_failure = probe_truncate_flush_close(
+        bytes, 7, {FaultAction::Error}, {}, {FaultAction::EffectThenError});
+    require(close_effect_after_truncate_failure.result ==
+                    HelperResultKind::FailedBeforeEffect &&
+                close_effect_after_truncate_failure.bytes == bytes &&
+                close_effect_after_truncate_failure.close_attempts == 1,
+            "truncate-flush-close changed a pre-effect truncate failure "
+            "during checked close");
+
+    const auto requests_stay_within_remaining_sentinel =
+        [](const ReadHelperProbeResult &probe, std::size_t max_bytes) {
+            if (probe.requested_bytes.size() != probe.returned_bytes.size()) {
+                return false;
+            }
+            auto retained = std::size_t{0};
+            for (std::size_t index = 0; index < probe.requested_bytes.size();
+                 ++index) {
+                if (retained > max_bytes + 1 ||
+                    probe.requested_bytes[index] > max_bytes + 1 - retained ||
+                    probe.returned_bytes[index] >
+                        probe.requested_bytes[index]) {
+                    return false;
+                }
+                retained += probe.returned_bytes[index];
+            }
+            return retained <= max_bytes + 1;
+        };
+
+    const auto empty_read = probe_read_bounded_close({}, 7, {}, {});
+    require(empty_read.result == HelperResultKind::Succeeded &&
+                empty_read.bytes.empty() && !empty_read.truncated &&
+                empty_read.read_attempts == 1 &&
+                empty_read.close_attempts == 1 &&
+                requests_stay_within_remaining_sentinel(empty_read, 7),
+            "bounded read did not preserve explicit empty EOF");
+
+    const std::string exact_cap_bytes = "1234567";
+    const auto exact_cap = probe_read_bounded_close(exact_cap_bytes, 7, {}, {});
+    require(exact_cap.result == HelperResultKind::Succeeded &&
+                exact_cap.bytes == exact_cap_bytes && !exact_cap.truncated &&
+                exact_cap.read_attempts >= 2 &&
+                !exact_cap.returned_bytes.empty() &&
+                exact_cap.returned_bytes.back() == 0 &&
+                exact_cap.close_attempts == 1 &&
+                requests_stay_within_remaining_sentinel(exact_cap, 7),
+            "bounded read did not confirm exact-cap EOF with a zero read");
+
+    constexpr auto bounded_read_chunk_bytes = std::size_t{64 * 1024};
+    const std::string large_exact_cap_bytes(
+        bounded_read_chunk_bytes * 2 + 17, 'q');
+    const auto large_exact_cap = probe_read_bounded_close(
+        large_exact_cap_bytes, large_exact_cap_bytes.size(), {}, {});
+    require(large_exact_cap.result == HelperResultKind::Succeeded &&
+                large_exact_cap.bytes == large_exact_cap_bytes &&
+                !large_exact_cap.truncated &&
+                large_exact_cap.read_attempts >= 4 &&
+                std::all_of(large_exact_cap.requested_bytes.begin(),
+                            large_exact_cap.requested_bytes.end(),
+                            [&](std::size_t requested) {
+                                return requested <= bounded_read_chunk_bytes;
+                            }) &&
+                large_exact_cap.close_attempts == 1 &&
+                requests_stay_within_remaining_sentinel(
+                    large_exact_cap, large_exact_cap_bytes.size()),
+            "bounded read requested an eager max-sized native allocation");
+
+    for (const auto &over_cap_bytes :
+         {std::string("12345678"), std::string(64, 'z')}) {
+        const auto over_cap =
+            probe_read_bounded_close(over_cap_bytes, 7, {}, {});
+        require(over_cap.result == HelperResultKind::Succeeded &&
+                    over_cap.bytes == over_cap_bytes.substr(0, 7) &&
+                    over_cap.truncated && over_cap.close_attempts == 1 &&
+                    requests_stay_within_remaining_sentinel(over_cap, 7),
+                "bounded read did not cap and classify extra input");
+    }
+
+    const std::string chunked_bytes = "abcdef";
+    const auto chunked = probe_read_bounded_close(chunked_bytes, 10,
+                                                  {FaultAction::ShortWrite,
+                                                   FaultAction::InterruptedOnce,
+                                                   FaultAction::ShortWrite},
+                                                  {});
+    require(chunked.result == HelperResultKind::Succeeded &&
+                chunked.bytes == chunked_bytes && !chunked.truncated &&
+                chunked.read_attempts >= 4 && chunked.close_attempts == 1 &&
+                !chunked.returned_bytes.empty() &&
+                chunked.returned_bytes.back() == 0 &&
+                requests_stay_within_remaining_sentinel(chunked, 10),
+            "bounded read duplicated, skipped, or reset bytes across an "
+            "interruption or skipped zero-count EOF confirmation");
+
+    for (const auto action :
+         {FaultAction::Error, FaultAction::EffectThenError}) {
+        const auto failed_after_progress = probe_read_bounded_close(
+            chunked_bytes, 10, {FaultAction::ShortWrite, action}, {});
+        const auto expected_partial =
+            action == FaultAction::EffectThenError ? chunked_bytes : "abc";
+        require(failed_after_progress.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    failed_after_progress.bytes == expected_partial &&
+                    !failed_after_progress.truncated &&
+                    failed_after_progress.read_attempts == 2 &&
+                    failed_after_progress.close_attempts == 1 &&
+                    requests_stay_within_remaining_sentinel(
+                        failed_after_progress, 10),
+                "bounded read forgot partial progress before terminal read "
+                "failure");
+    }
+
+    const auto zero_progress = probe_read_bounded_close(
+        chunked_bytes, 10, {FaultAction::ZeroProgress}, {});
+    require(zero_progress.result == HelperResultKind::FailedBeforeEffect &&
+                zero_progress.bytes.empty() &&
+                zero_progress.read_attempts == 1 &&
+                zero_progress.close_attempts == 1,
+            "bounded read accepted successful non-EOF zero progress");
+
+    const auto overreported = probe_read_bounded_close(
+        chunked_bytes, 10, {FaultAction::OverreportedWrite}, {});
+    require(overreported.result == HelperResultKind::FailedBeforeEffect &&
+                overreported.bytes.empty() &&
+                overreported.returned_bytes.size() == 1 &&
+                overreported.requested_bytes.size() == 1 &&
+                overreported.returned_bytes.front() >
+                    overreported.requested_bytes.front() &&
+                overreported.close_attempts == 1,
+            "bounded read accepted a chunk larger than its request");
+
+    for (const auto close_action :
+         {FaultAction::Error, FaultAction::InterruptedOnce,
+          FaultAction::EffectThenError}) {
+        const auto close_after_success =
+            probe_read_bounded_close(chunked_bytes, 10, {}, {close_action});
+        require(close_after_success.result ==
+                        HelperResultKind::EffectMayHaveOccurred &&
+                    close_after_success.bytes == chunked_bytes &&
+                    close_after_success.close_attempts == 1,
+                "bounded read retried close or forgot observed bytes");
+    }
+
+    const auto read_and_close_failed = probe_read_bounded_close(
+        chunked_bytes, 10, {FaultAction::Error}, {FaultAction::Error});
+    require(read_and_close_failed.result ==
+                    HelperResultKind::FailedBeforeEffect &&
+                read_and_close_failed.bytes.empty() &&
+                read_and_close_failed.read_attempts == 1 &&
+                read_and_close_failed.close_attempts == 1,
+            "bounded read collapsed two pre-effect failures");
+    const auto effectful_close_after_read_failure =
+        probe_read_bounded_close(chunked_bytes, 10, {FaultAction::Error},
+                                 {FaultAction::EffectThenError});
+    require(effectful_close_after_read_failure.result ==
+                    HelperResultKind::EffectMayHaveOccurred &&
+                effectful_close_after_read_failure.bytes.empty() &&
+                effectful_close_after_read_failure.close_attempts == 1,
+            "possibly-effectful read close did not dominate a read failure");
+}
+
+PublishedJournal create(JournalTestStorage &storage, const Chain &chain,
+                        JournalLimits limits = generous_limits()) {
+    auto journal = storage.make_journal(limits);
+    auto result =
+        journal.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(result, DurableJournalStatus::Published,
+                   "fresh create was not published");
+    require(result.journal->root_bytes() ==
+                chain.genesis_root.canonical_bytes(),
+            "fresh create returned the wrong root");
+    require(result.journal->journal_id() == chain.genesis.journal_id(),
+            "fresh create returned the wrong journal identity");
+    require(result.journal->tip_sequence() == 1,
+            "fresh create returned the wrong sequence");
+    require_storage_released_after_return(
+        storage, "fresh create returned with a live authority handle");
+    return std::move(*result.journal);
+}
+
+PublishedJournal recover(JournalTestStorage &storage, std::string_view floor,
+                         JournalLimits limits = generous_limits(),
+                         const RecoveryOriginVerifier *verifier = nullptr) {
+    auto journal = storage.make_journal(limits);
+    auto result = journal.recover_existing(
+        TrustedReplayFloor::exact_root(std::string(floor)), verifier);
+    require_result(result, DurableJournalStatus::Published,
+                   "valid recovery was rejected");
+    require_storage_released_after_return(
+        storage, "recovery returned with a live authority handle");
+    return std::move(*result.journal);
+}
+
+void require_exact_initial_publication() {
+    const auto chain = make_chain();
+    auto storage = JournalTestStorage::fresh();
+    auto authority = create(storage, chain);
+    const auto snapshot = storage.snapshot();
+    require(snapshot.journal_bytes == frame(chain.genesis),
+            "fresh journal frame bytes drifted");
+    require(snapshot.authority_root_bytes ==
+                chain.genesis_root.canonical_bytes(),
+            "fresh authority-root bytes drifted");
+    require(!snapshot.authority_root_bytes.empty() &&
+                snapshot.authority_root_bytes.back() != '\n',
+            "authority root gained a trailing line terminator");
+    require(snapshot.all_authority_io_under_lock,
+            "authority publication performed I/O outside the full lock");
+    require(snapshot.lock_file_present && snapshot.lock_file_stable,
+            "authority lock was removed, staged, or replaced");
+    require(snapshot.open_handles.empty() && authority.available(),
+            "fresh publication leaked a handle or consumed authority");
+
+    auto initialized_storage = JournalTestStorage::fresh();
+    const auto initialized_before = initialized_storage.snapshot();
+    auto wrong_floor = initialized_storage.make_journal(generous_limits());
+    auto wrong =
+        wrong_floor.create_new(TrustedReplayFloor::exact_root(std::string(
+                                   chain.genesis_root.canonical_bytes())),
+                               chain.genesis);
+    require_result(wrong, DurableJournalStatus::CorruptOrRollback,
+                   "initialized floor authorized create_new");
+    require(initialized_storage.snapshot() == initialized_before,
+            "initialized-floor create_new changed fresh storage");
+
+    storage.reset_observations();
+    const auto duplicate_before = storage.snapshot();
+    auto second = storage.make_journal(generous_limits());
+    auto duplicate =
+        second.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(duplicate, DurableJournalStatus::ConflictBeforeWrite,
+                   "nonfresh namespace did not conflict before write");
+    require(
+        same_persistent_state(storage.snapshot(), duplicate_before) &&
+            storage.attempt_count(FaultOperation::FixedNamespaceInspect) == 1 &&
+            storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+            storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
+            storage.attempt_count(FaultOperation::InitialJournalCreate) == 0 &&
+            storage.attempt_count(FaultOperation::JournalWrite) == 0 &&
+            storage.attempt_count(FaultOperation::RootStageCreate) == 0 &&
+            storage.attempt_count(FaultOperation::RootReplace) == 0 &&
+            !storage.snapshot().authority_mutation_attempted &&
+            storage.snapshot().all_authority_io_under_lock &&
+            storage.snapshot().open_handles.empty() &&
+            storage.attempt_count(FaultOperation::AuthorityLockClose) == 1,
+        "nonfresh create changed storage");
+}
+
+void require_durable_journal_moves() {
+    const auto chain = make_chain();
+    auto constructed_storage = JournalTestStorage::fresh();
+    auto constructed_source =
+        constructed_storage.make_journal(generous_limits());
+    DurableJournal constructed(std::move(constructed_source));
+    auto constructed_result = constructed.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(constructed_result, DurableJournalStatus::Published,
+                   "move-constructed DurableJournal was not operational");
+
+    auto assigned_storage = JournalTestStorage::fresh();
+    auto assigned_source = assigned_storage.make_journal(generous_limits());
+    auto displaced_storage = JournalTestStorage::fresh();
+    auto assigned = displaced_storage.make_journal(generous_limits());
+    assigned = std::move(assigned_source);
+    auto assigned_result =
+        assigned.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(assigned_result, DurableJournalStatus::Published,
+                   "move-assigned DurableJournal was not operational");
+}
+
+void require_explicit_floor_states() {
+    const auto chain = make_chain();
+    for (const auto &floor_bytes : {std::string{}, std::string("{")}) {
+        auto fresh = JournalTestStorage::fresh();
+        const auto fresh_before = fresh.snapshot();
+        auto fresh_journal = fresh.make_journal(generous_limits());
+        auto create_result = fresh_journal.create_new(
+            TrustedReplayFloor::exact_root(floor_bytes), chain.genesis);
+        require_result(create_result, DurableJournalStatus::CorruptOrRollback,
+                       "invalid exact floor authorized fresh create");
+        require(same_persistent_state(fresh.snapshot(), fresh_before) &&
+                    !fresh.snapshot().authority_mutation_attempted,
+                "invalid exact floor mutated fresh storage");
+        require_storage_released_after_return(
+            fresh, "invalid create floor retained an authority handle");
+
+        auto existing = JournalTestStorage::seeded(
+            frame(chain.genesis),
+            std::string(chain.genesis_root.canonical_bytes()));
+        const auto existing_before = existing.snapshot();
+        auto existing_journal = existing.make_journal(generous_limits());
+        auto recover_result = existing_journal.recover_existing(
+            TrustedReplayFloor::exact_root(floor_bytes));
+        require_result(recover_result, DurableJournalStatus::CorruptOrRollback,
+                       "invalid exact floor authorized recovery");
+        require(same_persistent_state(existing.snapshot(), existing_before) &&
+                    !existing.snapshot().authority_mutation_attempted,
+                "invalid exact floor mutated existing storage");
+        require_storage_released_after_return(
+            existing, "invalid recovery floor retained an authority handle");
+    }
+}
+
+void require_fresh_namespace_asymmetry() {
+    const auto chain = make_chain();
+    const std::vector<std::pair<FixedAuthorityChild, std::string>> blockers{
+        {FixedAuthorityChild::Root,
+         std::string(chain.genesis_root.canonical_bytes())},
+        {FixedAuthorityChild::Journal, frame(chain.genesis)},
+        {FixedAuthorityChild::RootStage, "root-stage"},
+        {FixedAuthorityChild::JournalStage, "journal-stage"},
+        {FixedAuthorityChild::Root, ""},
+        {FixedAuthorityChild::Journal, ""},
+    };
+    for (const auto &[child, bytes] : blockers) {
+        auto storage = JournalTestStorage::fresh();
+        storage.overwrite_fixed_child_bytes(child, bytes);
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "incomplete authority namespace was overwritten");
+        const auto after = storage.snapshot();
+        require(authority_files_unchanged(before, after) &&
+                    !after.authority_mutation_attempted &&
+                    after.all_authority_io_under_lock &&
+                    after.open_handles.empty() &&
+                    storage.attempt_count(
+                        FaultOperation::FixedNamespaceInspect) == 1 &&
+                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+                    storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                    storage.attempt_count(
+                        FaultOperation::InitialJournalCreate) == 0 &&
+                    storage.attempt_count(FaultOperation::RootStageCreate) == 0,
+                "blocked create changed incomplete authority storage");
+        require_storage_released_after_return(
+            storage, "incomplete create retained an authority handle");
+    }
+
+    for (const auto &[stage, bytes] :
+         {std::pair{FixedAuthorityChild::RootStage,
+                    std::string("root-stage-with-complete-authority")},
+          std::pair{FixedAuthorityChild::JournalStage,
+                    std::string("journal-stage-with-complete-authority")}}) {
+        auto storage = JournalTestStorage::seeded(
+            frame(chain.genesis),
+            std::string(chain.genesis_root.canonical_bytes()));
+        storage.overwrite_fixed_child_bytes(stage, bytes);
+        storage.reset_observations();
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "stage residue did not override complete-create "
+                       "conflict classification");
+        const auto after = storage.snapshot();
+        require(same_persistent_state(after, before) &&
+                    authority_files_unchanged(before, after) &&
+                    !after.authority_mutation_attempted &&
+                    after.all_authority_io_under_lock &&
+                    after.open_handles.empty() &&
+                    storage.attempt_count(
+                        FaultOperation::FixedNamespaceInspect) == 1 &&
+                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+                    storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                    storage.attempt_count(
+                        FaultOperation::InitialJournalCreate) == 0 &&
+                    storage.attempt_count(FaultOperation::RootStageCreate) == 0,
+                "complete authority with a stage was changed or treated as "
+                "a duplicate");
+        require_storage_released_after_return(
+            storage, "complete-with-stage create retained a handle");
+    }
+
+    auto lock_only = JournalTestStorage::fresh();
+    lock_only.overwrite_fixed_child_bytes(FixedAuthorityChild::Lock, {});
+    static_cast<void>(create(lock_only, chain));
+
+    auto sentinel = JournalTestStorage::fresh();
+    sentinel.seed_untrusted_file("sentinel.bin", "outside-authority");
+    static_cast<void>(create(sentinel, chain));
+    require(sentinel.snapshot().live_file_bytes.at("sentinel.bin") ==
+                    "outside-authority" &&
+                sentinel.snapshot().durable_file_bytes.at("sentinel.bin") ==
+                    "outside-authority",
+            "fresh create changed unrelated sentinel bytes");
+}
+
+void require_unique_authority_moves() {
+    const auto chain = make_chain();
+    auto constructed_storage = JournalTestStorage::fresh();
+    auto constructed_source = create(constructed_storage, chain);
+    PublishedJournal constructed(std::move(constructed_source));
+    require(!constructed_source.available() && constructed.available(),
+            "move construction duplicated or lost authority");
+    constructed_storage.reset_observations();
+    const auto constructed_before = constructed_storage.snapshot();
+    auto moved_from_construction_journal =
+        constructed_storage.make_journal(generous_limits());
+    auto moved_from_construction =
+        moved_from_construction_journal.append_and_publish(
+            std::move(constructed_source), chain.successor);
+    require_result(moved_from_construction,
+                   DurableJournalStatus::CorruptOrRollback,
+                   "move-constructed source retained write authority");
+    require(!constructed_source.available() && constructed.available() &&
+                constructed_storage.snapshot() == constructed_before,
+            "move-constructed source reached authority storage");
+    auto constructed_journal =
+        constructed_storage.make_journal(generous_limits());
+    auto constructed_published = constructed_journal.append_and_publish(
+        std::move(constructed), chain.successor);
+    require_result(constructed_published, DurableJournalStatus::Published,
+                   "move-constructed destination could not publish");
+    require(!constructed.available() &&
+                constructed_published.journal->available(),
+            "move-constructed destination duplicated authority");
+
+    auto compact_storage = JournalTestStorage::fresh();
+    auto compact_source = create(compact_storage, chain);
+    PublishedJournal compact_destination(std::move(compact_source));
+    compact_storage.reset_observations();
+    const auto compact_before = compact_storage.snapshot();
+    auto moved_from_compaction_journal =
+        compact_storage.make_journal(generous_limits());
+    auto moved_from_compaction = moved_from_compaction_journal.compact_physical(
+        std::move(compact_source));
+    require_result(moved_from_compaction,
+                   DurableJournalStatus::CorruptOrRollback,
+                   "move-constructed source retained compaction authority");
+    require(!compact_source.available() && compact_destination.available() &&
+                compact_storage.snapshot() == compact_before,
+            "moved-from compaction reached authority storage");
+    auto compact_destination_journal =
+        compact_storage.make_journal(generous_limits());
+    auto compact_destination_published =
+        compact_destination_journal.append_and_publish(
+            std::move(compact_destination), chain.successor);
+    require_result(compact_destination_published,
+                   DurableJournalStatus::Published,
+                   "compaction move destination could not publish");
+
+    auto assigned_storage = JournalTestStorage::fresh();
+    auto assigned_source = create(assigned_storage, chain);
+    auto displaced_storage = JournalTestStorage::seeded(
+        frame(chain.genesis),
+        std::string(chain.genesis_root.canonical_bytes()));
+    auto assigned =
+        recover(displaced_storage, chain.genesis_root.canonical_bytes());
+    assigned = std::move(assigned_source);
+    require(!assigned_source.available() && assigned.available(),
+            "move assignment duplicated or lost authority");
+    assigned_storage.reset_observations();
+    const auto assigned_before = assigned_storage.snapshot();
+    auto moved_from_assignment_journal =
+        assigned_storage.make_journal(generous_limits());
+    auto moved_from_assignment =
+        moved_from_assignment_journal.append_and_publish(
+            std::move(assigned_source), chain.successor);
+    require_result(moved_from_assignment,
+                   DurableJournalStatus::CorruptOrRollback,
+                   "move-assigned source retained write authority");
+    require(!assigned_source.available() && assigned.available() &&
+                assigned_storage.snapshot() == assigned_before,
+            "move-assigned source reached authority storage");
+
+    auto journal = assigned_storage.make_journal(generous_limits());
+    auto published =
+        journal.append_and_publish(std::move(assigned), chain.successor);
+    require_result(published, DurableJournalStatus::Published,
+                   "move-assigned destination could not publish");
+    require(!assigned.available() && published.journal->available(),
+            "move-assigned destination duplicated authority");
+
+    auto export_storage = JournalTestStorage::fresh();
+    auto export_source = create(export_storage, chain);
+    auto export_displaced_storage = JournalTestStorage::seeded(
+        frame(chain.genesis),
+        std::string(chain.genesis_root.canonical_bytes()));
+    auto export_destination =
+        recover(export_displaced_storage, chain.genesis_root.canonical_bytes());
+    export_destination = std::move(export_source);
+    export_storage.reset_observations();
+    const auto export_before = export_storage.snapshot();
+    auto moved_from_export_journal =
+        export_storage.make_journal(generous_limits());
+    auto moved_from_export =
+        moved_from_export_journal.export_exact_schema_candidate(
+            export_source, supported_journal_schema,
+            JournalQuiescence::Confirmed);
+    require(moved_from_export.status ==
+                    ExactSchemaExportStatus::CorruptOrRollback &&
+                !moved_from_export.exported() &&
+                !moved_from_export.candidate.has_value() &&
+                !export_source.available() && export_destination.available() &&
+                export_storage.snapshot() == export_before,
+            "moved-from export reached authority storage");
+    auto export_destination_journal =
+        export_storage.make_journal(generous_limits());
+    auto export_destination_published =
+        export_destination_journal.append_and_publish(
+            std::move(export_destination), chain.successor);
+    require_result(export_destination_published,
+                   DurableJournalStatus::Published,
+                   "export move destination could not publish");
+}
+
+void require_fixed_paths() {
+    const std::vector<std::string> journal_ids{
+        "../escape",
+        "/absolute",
+        "C:\\root\\journal",
+        "\\\\?\\C:\\device",
+        "CON",
+        "con",
+        "A",
+        "a",
+        "%2e%2e%2fescape",
+        "..\\escape",
+        "aux.txt",
+        "PRN",
+        "COM1",
+        "LPT1",
+        "authority-root.json",
+        "authority.lock",
+        "JOURNAL.JSONL",
+        "\\\\server\\share",
+    };
+    std::optional<std::set<std::string>> expected_paths;
+    for (const auto &journal_id : journal_ids) {
+        const auto chain = make_chain(journal_id);
+        auto storage = JournalTestStorage::fresh();
+        static_cast<void>(create(storage, chain));
+        storage.restart();
+        const auto restarted = storage.snapshot();
+        const auto paths = restarted.relative_paths;
+        require(paths.count("journal.jsonl") == 1 &&
+                    paths.count("authority-root.json") == 1 &&
+                    paths.count("authority.lock") == 1,
+                "fixed authority filenames were absent");
+        require(std::all_of(paths.begin(), paths.end(),
+                            [](const std::string &path) {
+                                return path.find('/') == std::string::npos &&
+                                       path.find('\\') == std::string::npos &&
+                                       path != "." && path != "..";
+                            }),
+                "journal identity influenced a storage path");
+        require(restarted.lock_file_present && restarted.lock_file_stable,
+                "authority lock did not survive unlock and restart unchanged");
+        if (!expected_paths.has_value()) {
+            expected_paths = paths;
+        } else {
+            require(paths == *expected_paths,
+                    "case, encoding, or platform identity changed fixed paths");
+        }
+    }
+}
+
+void require_identifier_boundaries_precede_persistence() {
+    std::vector<std::string> invalid_ids;
+    invalid_ids.emplace_back("journal/\xc3\xa9");
+    invalid_ids.emplace_back("journal/e\xcc\x81");
+    auto embedded_nul = std::string("journal/a");
+    embedded_nul.push_back('\0');
+    embedded_nul.push_back('b');
+    invalid_ids.push_back(std::move(embedded_nul));
+
+    auto untouched = JournalTestStorage::fresh();
+    const auto before = untouched.snapshot();
+    for (auto &journal_id : invalid_ids) {
+        auto rejected = seal_genesis(draft_for(
+            std::move(journal_id), "resident/alpha", ResidentState::Prepared));
+        require(!rejected.accepted() && !rejected.candidate.has_value() &&
+                    rejected.status == JournalStatus::InvalidIdentifier,
+                "non-codec identifier crossed the TASK-019 boundary");
+    }
+    require(untouched.snapshot() == before,
+            "identifier rejection reached persistence");
+}
+
+void require_replay_and_floors() {
+    const auto chain = make_chain();
+    const auto one_frame = frame(chain.genesis);
+    const auto two_frames = one_frame + frame(chain.successor);
+    const auto three_frames = two_frames + frame(chain.third);
+
+    auto exact = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    auto exact_authority =
+        recover(exact, chain.successor_root.canonical_bytes());
+    require(exact_authority.root_bytes() ==
+                chain.successor_root.canonical_bytes(),
+            "exact floor recovered a different root");
+    require(exact.snapshot().root_read_before_journal_read &&
+                exact.snapshot().all_authority_io_under_lock,
+            "recovery did not read root first under the full lock");
+
+    auto descendant = JournalTestStorage::seeded(
+        three_frames, std::string(chain.third_root.canonical_bytes()));
+    auto descendant_authority =
+        recover(descendant, chain.genesis_root.canonical_bytes());
+    require(descendant_authority.root_bytes() ==
+                chain.third_root.canonical_bytes(),
+            "proven descendant floor did not recover the stored root");
+
+    auto regressed = JournalTestStorage::seeded(
+        one_frame, std::string(chain.genesis_root.canonical_bytes()));
+    auto regressed_journal = regressed.make_journal(generous_limits());
+    auto regressed_result =
+        regressed_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.successor_root.canonical_bytes())));
+    require_result(regressed_result, DurableJournalStatus::CorruptOrRollback,
+                   "regressed root passed a newer independent floor");
+    require_storage_released_after_return(
+        regressed, "regressed recovery retained an authority handle");
+
+    auto consistency_only = JournalTestStorage::seeded(
+        one_frame, std::string(chain.genesis_root.canonical_bytes()));
+    auto consistency_authority =
+        recover(consistency_only, chain.genesis_root.canonical_bytes());
+    require(consistency_authority.root_bytes() ==
+                chain.genesis_root.canonical_bytes(),
+            "coherently rolled-back storage and floor lost consistency-only "
+            "recovery");
+
+    auto divergent = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    auto divergent_journal = divergent.make_journal(generous_limits());
+    auto divergent_result =
+        divergent_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.fork_root.canonical_bytes())));
+    require_result(divergent_result, DurableJournalStatus::CorruptOrRollback,
+                   "same-generation fork passed the independent floor");
+    require_storage_released_after_return(
+        divergent, "divergent recovery retained an authority handle");
+
+    auto absent_floor = exact.make_journal(generous_limits());
+    auto absent_result =
+        absent_floor.recover_existing(TrustedReplayFloor::uninitialized());
+    require_result(absent_result, DurableJournalStatus::CorruptOrRollback,
+                   "uninitialized floor authorized existing storage");
+    require_storage_released_after_return(
+        exact, "uninitialized-floor recovery retained an authority handle");
+
+    auto local_rollback = JournalTestStorage::seeded(
+        one_frame, std::string(chain.genesis_root.canonical_bytes()));
+    local_rollback.seed_untrusted_file(
+        "local-floor.json", std::string(chain.genesis_root.canonical_bytes()));
+    auto local_journal = local_rollback.make_journal(generous_limits());
+    auto local_result =
+        local_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.successor_root.canonical_bytes())));
+    require_result(local_result, DurableJournalStatus::CorruptOrRollback,
+                   "local rollback sidecar replaced the independent floor");
+    require_storage_released_after_return(
+        local_rollback, "rollback rejection retained an authority handle");
+
+    auto root_ahead = JournalTestStorage::seeded(
+        one_frame, std::string(chain.successor_root.canonical_bytes()));
+    auto root_ahead_journal = root_ahead.make_journal(generous_limits());
+    auto root_ahead_result =
+        root_ahead_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+    require_result(root_ahead_result, DurableJournalStatus::CorruptOrRollback,
+                   "root ahead of durable journal was authorized");
+    require_storage_released_after_return(
+        root_ahead, "root-ahead rejection retained an authority handle");
+
+    auto missing_root = JournalTestStorage::seeded(one_frame, std::nullopt);
+    auto missing_root_journal = missing_root.make_journal(generous_limits());
+    auto missing_root_result =
+        missing_root_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+    require_result(missing_root_result, DurableJournalStatus::CorruptOrRollback,
+                   "journal bytes without a root implied genesis");
+    require_storage_released_after_return(
+        missing_root, "missing-root rejection retained an authority handle");
+
+    auto committed_truncation = JournalTestStorage::seeded(
+        two_frames.substr(0, two_frames.size() - 1),
+        std::string(chain.successor_root.canonical_bytes()));
+    auto truncation_journal =
+        committed_truncation.make_journal(generous_limits());
+    auto truncation_result =
+        truncation_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+    require_result(truncation_result, DurableJournalStatus::CorruptOrRollback,
+                   "missing committed LF terminator was authorized");
+    require_storage_released_after_return(
+        committed_truncation,
+        "committed-truncation rejection retained an authority handle");
+}
+
+void require_surviving_stage_recovery() {
+    const auto chain = make_chain();
+    const auto old_bytes = frame(chain.genesis);
+    const auto successor_bytes = old_bytes + frame(chain.successor);
+    const auto seed_stages = [](JournalTestStorage &storage) {
+        storage.overwrite_fixed_child_bytes(FixedAuthorityChild::RootStage,
+                                            "surviving-root-stage");
+        storage.overwrite_fixed_child_bytes(FixedAuthorityChild::JournalStage,
+                                            "surviving-journal-stage");
+    };
+
+    for (const auto &[journal_bytes, root_bytes, expected_journal,
+                      expected_root] :
+         {std::tuple{
+              old_bytes, std::string(chain.genesis_root.canonical_bytes()),
+              old_bytes, std::string(chain.genesis_root.canonical_bytes())},
+          std::tuple{successor_bytes,
+                     std::string(chain.genesis_root.canonical_bytes()),
+                     old_bytes,
+                     std::string(chain.genesis_root.canonical_bytes())},
+          std::tuple{successor_bytes,
+                     std::string(chain.successor_root.canonical_bytes()),
+                     successor_bytes,
+                     std::string(chain.successor_root.canonical_bytes())}}) {
+        auto storage = JournalTestStorage::seeded(journal_bytes, root_bytes);
+        seed_stages(storage);
+        const auto before = storage.snapshot();
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        const auto after = storage.snapshot();
+        require(authority.root_bytes() == expected_root &&
+                    after.journal_bytes == expected_journal &&
+                    stage_files_unchanged(before, after) &&
+                    !has_stage_operation(after) && after.journal_durable &&
+                    after.authority_root_durable &&
+                    after.all_authority_io_under_lock,
+                "safe surviving stages influenced or changed recovery");
+    }
+
+    auto append_storage = JournalTestStorage::seeded(
+        old_bytes, std::string(chain.genesis_root.canonical_bytes()));
+    seed_stages(append_storage);
+    const auto append_before = append_storage.snapshot();
+    auto append_authority =
+        recover(append_storage, chain.genesis_root.canonical_bytes());
+    auto append_journal = append_storage.make_journal(generous_limits());
+    auto appended = append_journal.append_and_publish(
+        std::move(append_authority), chain.successor);
+    require_result(appended, DurableJournalStatus::Published,
+                   "root publication could not replace a safe root stage");
+    const auto append_after = append_storage.snapshot();
+    require(
+        append_after.relative_paths.count(".authority-root.json.stage") == 0 &&
+            append_after.durable_paths.count(".authority-root.json.stage") ==
+                0 &&
+            fixed_file_unchanged(append_before, append_after,
+                                 ".journal.jsonl.stage") &&
+            append_after.journal_bytes == successor_bytes &&
+            append_after.authority_root_bytes ==
+                chain.successor_root.canonical_bytes() &&
+            append_after.all_authority_io_under_lock,
+        "root publication broadly cleaned or trusted surviving stages");
+
+    auto compact_storage = JournalTestStorage::seeded(
+        successor_bytes, std::string(chain.successor_root.canonical_bytes()));
+    seed_stages(compact_storage);
+    const auto compact_before = compact_storage.snapshot();
+    auto compact_authority =
+        recover(compact_storage, chain.genesis_root.canonical_bytes());
+    auto compact_journal = compact_storage.make_journal(generous_limits());
+    auto compacted =
+        compact_journal.compact_physical(std::move(compact_authority));
+    require_result(compacted, DurableJournalStatus::Published,
+                   "compaction could not replace a safe journal stage");
+    const auto compact_after = compact_storage.snapshot();
+    require(compact_after.relative_paths.count(".journal.jsonl.stage") == 0 &&
+                compact_after.durable_paths.count(".journal.jsonl.stage") ==
+                    0 &&
+                fixed_file_unchanged(compact_before, compact_after,
+                                     ".authority-root.json.stage") &&
+                compact_after.journal_bytes == successor_bytes &&
+                compact_after.authority_root_bytes ==
+                    chain.successor_root.canonical_bytes() &&
+                compact_after.all_authority_io_under_lock,
+            "compaction broadly cleaned or trusted surviving stages");
+
+    auto root_ahead = JournalTestStorage::seeded(
+        old_bytes, std::string(chain.successor_root.canonical_bytes()));
+    seed_stages(root_ahead);
+    const auto before = root_ahead.snapshot();
+    auto journal = root_ahead.make_journal(generous_limits());
+    auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+        std::string(chain.genesis_root.canonical_bytes())));
+    require_result(result, DurableJournalStatus::CorruptOrRollback,
+                   "root-ahead crash state was authorized by stages");
+    require(same_persistent_state(root_ahead.snapshot(), before) &&
+                !root_ahead.snapshot().authority_mutation_attempted,
+            "root-ahead rejection changed crash-state evidence");
+    require_storage_released_after_return(
+        root_ahead, "staged root-ahead rejection retained a handle");
+}
+
+void require_root_parser_is_task019() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    const auto exact_root = std::string(chain.genesis_root.canonical_bytes());
+    std::vector<std::string> adversaries{
+        exact_root + "\n",
+        exact_root + " ",
+        std::string("\xef\xbb\xbf") + exact_root,
+        "{",
+        std::string(max_journal_input_bytes + 1, 'x'),
+        replace_once(exact_root, "{", "{\"unknown\":0,"),
+        replace_once(exact_root, "{", "{\"schema\":{\"major\":1,\"minor\":0},"),
+        replace_once(exact_root, "\"major\":1", "\"major\":2"),
+        replace_once(exact_root, "\"generation\":1", "\"generation\":2"),
+        replace_once(exact_root, "\"tip_sequence\":1", "\"tip_sequence\":2"),
+        replace_once(exact_root, "\"journal_id\":\"journal/main\"",
+                     "\"journal_id\":\"journal/other\""),
+        replace_once(
+            exact_root, chain.genesis_root.checksum_sha256(),
+            "0000000000000000000000000000000000000000000000000000000000000000"),
+    };
+    for (const auto &root : adversaries) {
+        auto storage = JournalTestStorage::seeded(committed, root);
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.recover_existing(
+            TrustedReplayFloor::exact_root(exact_root));
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "alternate authority-root encoding was accepted");
+        require(same_persistent_state(storage.snapshot(), before) &&
+                    !storage.snapshot().authority_mutation_attempted,
+                "invalid authority root triggered repair or mutation");
+        require_storage_released_after_return(
+            storage, "invalid root rejection retained an authority handle");
+    }
+}
+
+void require_committed_origin_verification() {
+    const auto chain = make_chain();
+    AllowingOriginVerifier allowing;
+    const auto quarantine = make_quarantine_tail(chain);
+    auto history =
+        take_history(begin_history(chain.genesis), "origin genesis failed");
+    history =
+        take_history(advance_history(std::move(history), quarantine, &allowing),
+                     "origin quarantine history failed");
+    const auto root =
+        take_root(seal_authority_root_candidate(history, &chain.genesis_root),
+                  "origin quarantine root failed");
+    const auto bytes = frame(chain.genesis) + frame(quarantine);
+
+    RejectIfCalledVerifier rejecting;
+    for (const RecoveryOriginVerifier *verifier :
+         {static_cast<const RecoveryOriginVerifier *>(nullptr),
+          static_cast<const RecoveryOriginVerifier *>(&rejecting)}) {
+        auto storage = JournalTestStorage::seeded(
+            bytes, std::string(root.canonical_bytes()));
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result =
+            journal.recover_existing(TrustedReplayFloor::exact_root(std::string(
+                                         chain.genesis_root.canonical_bytes())),
+                                     verifier);
+        require_result(
+            result, DurableJournalStatus::CorruptOrRollback,
+            "unavailable origin verification authorized committed history");
+        require(same_persistent_state(storage.snapshot(), before) &&
+                    !storage.snapshot().authority_mutation_attempted,
+                "origin-verification failure changed committed storage");
+        require_storage_released_after_return(
+            storage,
+            "origin-verification rejection retained an authority handle");
+    }
+    require(rejecting.called.load(),
+            "rejecting verifier was not called for committed authority");
+
+    auto accepted =
+        JournalTestStorage::seeded(bytes, std::string(root.canonical_bytes()));
+    auto authority = recover(accepted, chain.genesis_root.canonical_bytes(),
+                             generous_limits(), &allowing);
+    require(authority.root_bytes() == root.canonical_bytes(),
+            "available origin verifier did not authorize committed history");
+}
+
+ParsedJournalRecord make_quarantine_tail(const Chain &chain) {
+    AllowingOriginVerifier verifier;
+    auto history = take_history(begin_history(chain.genesis),
+                                "quarantine-tail genesis failed");
+    return take_record(
+        seal_successor(history,
+                       draft_for(std::string(chain.genesis.journal_id()),
+                                 "resident/alpha", ResidentState::Quarantined),
+                       &verifier),
+        "quarantine tail fixture was rejected");
+}
+
+struct QuarantinedGenesis {
+    ParsedJournalRecord record;
+    AuthorityRootCandidate root;
+};
+
+QuarantinedGenesis make_quarantined_genesis() {
+    AllowingOriginVerifier verifier;
+    auto record = take_record(
+        seal_genesis(draft_for("journal/quarantine", "resident/quarantine",
+                               ResidentState::Quarantined),
+                     &verifier),
+        "quarantined genesis fixture was rejected");
+    auto history = take_history(begin_history(record, &verifier),
+                                "quarantined genesis history was rejected");
+    auto root = take_root(seal_authority_root_candidate(history),
+                          "quarantined genesis root was rejected");
+    return {std::move(record), std::move(root)};
+}
+
+void require_origin_verifier_publication_and_lifetime() {
+    const auto chain = make_chain();
+    const auto quarantined_genesis = make_quarantined_genesis();
+
+    RejectIfCalledVerifier create_rejecting;
+    for (const RecoveryOriginVerifier *verifier :
+         {static_cast<const RecoveryOriginVerifier *>(nullptr),
+          static_cast<const RecoveryOriginVerifier *>(&create_rejecting)}) {
+        auto storage = JournalTestStorage::fresh();
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         quarantined_genesis.record, verifier);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "unverified quarantined genesis was published");
+        require(same_persistent_state(storage.snapshot(), before) &&
+                    !storage.snapshot().authority_mutation_attempted,
+                "rejected quarantined genesis changed authority storage");
+        require_storage_released_after_return(
+            storage, "quarantined create rejection retained a handle");
+    }
+    require(create_rejecting.called.load(),
+            "create_new did not invoke the rejecting origin verifier");
+
+    AllowingOriginVerifier allowing;
+    auto created_storage = JournalTestStorage::fresh();
+    auto create_journal = created_storage.make_journal(generous_limits());
+    auto created =
+        create_journal.create_new(TrustedReplayFloor::uninitialized(),
+                                  quarantined_genesis.record, &allowing);
+    require_result(created, DurableJournalStatus::Published,
+                   "verified quarantined genesis was not published");
+    created_storage.restart();
+    auto missing_recovery =
+        created_storage.make_journal(generous_limits())
+            .recover_existing(TrustedReplayFloor::exact_root(
+                std::string(quarantined_genesis.root.canonical_bytes())));
+    require_result(missing_recovery, DurableJournalStatus::CorruptOrRollback,
+                   "quarantined genesis recovery skipped reverification");
+    require_storage_released_after_return(
+        created_storage,
+        "quarantined recovery rejection retained an authority handle");
+    static_cast<void>(recover(created_storage,
+                              quarantined_genesis.root.canonical_bytes(),
+                              generous_limits(), &allowing));
+
+    const auto prove_existing_quarantine_does_not_borrow =
+        [](JournalTestStorage &storage,
+           std::optional<PublishedJournal> authority,
+           const std::shared_ptr<VerifierLifetimeState> &state,
+           std::size_t validated_calls, std::string_view label) {
+            require(authority.has_value() && authority->available() &&
+                        !state->alive.load() && validated_calls != 0,
+                    label);
+            auto compact_journal = storage.make_journal(generous_limits());
+            auto compacted =
+                compact_journal.compact_physical(std::move(*authority));
+            require_result(compacted, DurableJournalStatus::Published, label);
+            auto export_journal = storage.make_journal(generous_limits());
+            auto exported = export_journal.export_exact_schema_candidate(
+                *compacted.journal, supported_journal_schema,
+                JournalQuiescence::Confirmed);
+            require(exported.exported() && exported.candidate.has_value() &&
+                        state->calls.load() == validated_calls,
+                    label);
+        };
+
+    auto create_lifetime_storage = JournalTestStorage::fresh();
+    auto create_lifetime_state = std::make_shared<VerifierLifetimeState>();
+    std::optional<PublishedJournal> create_lifetime_authority;
+    std::size_t create_lifetime_calls = 0;
+    {
+        LifetimeAllowingVerifier verifier(create_lifetime_state);
+        auto journal = create_lifetime_storage.make_journal(generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         quarantined_genesis.record, &verifier);
+        require_result(result, DurableJournalStatus::Published,
+                       "scoped verifier create was rejected");
+        create_lifetime_authority.emplace(std::move(*result.journal));
+        create_lifetime_calls = create_lifetime_state->calls.load();
+    }
+    prove_existing_quarantine_does_not_borrow(
+        create_lifetime_storage, std::move(create_lifetime_authority),
+        create_lifetime_state, create_lifetime_calls,
+        "create token retained a borrowed origin verifier");
+
+    auto recover_lifetime_storage = JournalTestStorage::seeded(
+        frame(quarantined_genesis.record),
+        std::string(quarantined_genesis.root.canonical_bytes()));
+    auto recover_lifetime_state = std::make_shared<VerifierLifetimeState>();
+    std::optional<PublishedJournal> recover_lifetime_authority;
+    std::size_t recover_lifetime_calls = 0;
+    {
+        LifetimeAllowingVerifier verifier(recover_lifetime_state);
+        auto journal = recover_lifetime_storage.make_journal(generous_limits());
+        auto result = journal.recover_existing(
+            TrustedReplayFloor::exact_root(
+                std::string(quarantined_genesis.root.canonical_bytes())),
+            &verifier);
+        require_result(result, DurableJournalStatus::Published,
+                       "scoped verifier recovery was rejected");
+        recover_lifetime_authority.emplace(std::move(*result.journal));
+        recover_lifetime_calls = recover_lifetime_state->calls.load();
+    }
+    prove_existing_quarantine_does_not_borrow(
+        recover_lifetime_storage, std::move(recover_lifetime_authority),
+        recover_lifetime_state, recover_lifetime_calls,
+        "recovery token retained a borrowed origin verifier");
+
+    const auto quarantine = make_quarantine_tail(chain);
+    RejectIfCalledVerifier append_rejecting;
+    for (const RecoveryOriginVerifier *verifier :
+         {static_cast<const RecoveryOriginVerifier *>(nullptr),
+          static_cast<const RecoveryOriginVerifier *>(&append_rejecting)}) {
+        auto storage = JournalTestStorage::seeded(
+            frame(chain.genesis),
+            std::string(chain.genesis_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.append_and_publish(std::move(authority),
+                                                 quarantine, verifier);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "unverified quarantined append was published");
+        require(!authority.available() &&
+                    same_persistent_state(storage.snapshot(), before) &&
+                    !storage.snapshot().authority_mutation_attempted,
+                "rejected quarantined append changed authority storage");
+        require_storage_released_after_return(
+            storage, "quarantined append rejection retained a handle");
+    }
+    require(append_rejecting.called.load(),
+            "append did not invoke the rejecting origin verifier");
+
+    auto lifetime_storage = JournalTestStorage::seeded(
+        frame(chain.genesis),
+        std::string(chain.genesis_root.canonical_bytes()));
+    auto lifetime_authority =
+        recover(lifetime_storage, chain.genesis_root.canonical_bytes());
+    auto lifetime_state = std::make_shared<VerifierLifetimeState>();
+    std::optional<PublishedJournal> verified_authority;
+    std::size_t verified_calls = 0;
+    {
+        LifetimeAllowingVerifier lifetime_verifier(lifetime_state);
+        auto journal = lifetime_storage.make_journal(generous_limits());
+        auto result = journal.append_and_publish(
+            std::move(lifetime_authority), quarantine, &lifetime_verifier);
+        require_result(result, DurableJournalStatus::Published,
+                       "verified quarantined append was rejected");
+        verified_authority.emplace(std::move(*result.journal));
+        verified_calls = lifetime_state->calls.load();
+    }
+    require(!lifetime_state->alive.load() && verified_calls != 0,
+            "verifier lifetime fixture did not expire after validation");
+
+    auto compact_journal = lifetime_storage.make_journal(generous_limits());
+    auto compacted =
+        compact_journal.compact_physical(std::move(*verified_authority));
+    require_result(compacted, DurableJournalStatus::Published,
+                   "compaction retained a borrowed verifier dependency");
+    auto export_journal = lifetime_storage.make_journal(generous_limits());
+    auto exported = export_journal.export_exact_schema_candidate(
+        *compacted.journal, supported_journal_schema,
+        JournalQuiescence::Confirmed);
+    require(exported.exported() && exported.candidate.has_value() &&
+                lifetime_state->calls.load() == verified_calls,
+            "compaction or export called a destroyed verifier");
+
+    lifetime_storage.restart();
+    auto recovery_without_verifier =
+        lifetime_storage.make_journal(generous_limits())
+            .recover_existing(TrustedReplayFloor::exact_root(
+                std::string(chain.genesis_root.canonical_bytes())));
+    require_result(recovery_without_verifier,
+                   DurableJournalStatus::CorruptOrRollback,
+                   "quarantined append recovery skipped reverification");
+    require_storage_released_after_return(
+        lifetime_storage,
+        "unverified quarantine recovery retained an authority handle");
+    static_cast<void>(recover(lifetime_storage,
+                              chain.genesis_root.canonical_bytes(),
+                              generous_limits(), &allowing));
+}
+
+void require_tail_classification_and_repair() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    const auto quarantine = make_quarantine_tail(chain);
+    const std::vector<std::string> tolerated_tails{
+        frame(chain.successor),
+        frame(chain.fork),
+        frame(chain.successor) + frame(chain.third),
+        frame(quarantine),
+        frame(chain.successor).substr(0, frame(chain.successor).size() / 2),
+        std::string("garbage\0tail", 12),
+        std::string(max_journal_input_bytes + 1, 'x'),
+        "\r\n\n",
+    };
+
+    for (const auto &tail : tolerated_tails) {
+        auto limits = generous_limits();
+        limits.max_crash_tail_bytes = tail.size();
+        auto storage = JournalTestStorage::seeded(
+            committed + tail,
+            std::string(chain.genesis_root.canonical_bytes()));
+        const auto before = storage.snapshot();
+        RejectIfCalledVerifier verifier;
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes(),
+                                 limits, &verifier);
+        require(authority.root_bytes() == chain.genesis_root.canonical_bytes(),
+                "tail recovery synthesized a root");
+        require(!verifier.called.load(),
+                "replay parsed past the stored authority root");
+        const auto after = storage.snapshot();
+        require(after.journal_bytes == committed &&
+                    after.authority_root_bytes ==
+                        chain.genesis_root.canonical_bytes() &&
+                    after.stage_files_absent &&
+                    after.durable_stage_files_absent &&
+                    !has_stage_operation(after) &&
+                    after.all_authority_io_under_lock,
+                "tail was not durably repaired before authority returned");
+        require(
+            after.journal_durable && after.journal_closed,
+            "tail repair returned before file durability and checked close");
+        require(before.journal_bytes != after.journal_bytes,
+                "tail-repair fixture did not mutate storage");
+    }
+
+    const auto second_resident =
+        make_second_resident(chain, std::string(chain.genesis.journal_id()));
+    for (auto limits : {[] {
+                            auto selected = generous_limits();
+                            selected.max_committed_records = 1;
+                            return selected;
+                        }(),
+                        [] {
+                            auto selected = generous_limits();
+                            selected.max_resident_heads = 1;
+                            return selected;
+                        }()}) {
+        const auto &tail_record = limits.max_committed_records == 1
+                                      ? chain.successor
+                                      : second_resident;
+        const auto tail = frame(tail_record);
+        limits.max_crash_tail_bytes = tail.size();
+        auto storage = JournalTestStorage::seeded(
+            committed + tail,
+            std::string(chain.genesis_root.canonical_bytes()));
+        RejectIfCalledVerifier verifier;
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes(),
+                                 limits, &verifier);
+        require(
+            authority.root_bytes() == chain.genesis_root.canonical_bytes() &&
+                storage.snapshot().journal_bytes == committed &&
+                storage.snapshot().journal_durable &&
+                storage.snapshot().journal_closed && !verifier.called.load(),
+            "valid crash tail was counted against the authorized prefix");
+    }
+
+    const std::vector<std::string> malformed_committed{
+        std::string("\xef\xbb\xbf") + std::string(genesis_wire) + '\n',
+        std::string(genesis_wire) + "\r\n",
+        std::string("\n") + std::string(genesis_wire) + '\n',
+        std::string(genesis_wire),
+    };
+    for (const auto &journal_bytes : malformed_committed) {
+        auto storage = JournalTestStorage::seeded(
+            journal_bytes, std::string(chain.genesis_root.canonical_bytes()));
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "invalid committed LF framing was authorized");
+        require(same_persistent_state(storage.snapshot(), before),
+                "invalid committed LF framing triggered repair or mutation");
+        require(!storage.snapshot().authority_mutation_attempted,
+                "invalid committed LF framing attempted authority mutation");
+        require_storage_released_after_return(
+            storage,
+            "invalid committed LF framing retained an authority handle");
+    }
+}
+
+DurableJournalStatus recovery_status(JournalTestStorage &storage,
+                                     std::string_view floor,
+                                     JournalLimits limits) {
+    auto journal = storage.make_journal(limits);
+    auto result = journal.recover_existing(
+        TrustedReplayFloor::exact_root(std::string(floor)));
+    require(!result.journal.has_value() ||
+                result.status == DurableJournalStatus::Published,
+            "failed recovery carried authority");
+    require_storage_released_after_return(
+        storage, "recovery result retained an authority handle");
+    return result.status;
+}
+
+void require_explicit_limits() {
+    const auto chain = make_chain();
+    const auto one_frame = frame(chain.genesis);
+    const auto two_frames = one_frame + frame(chain.successor);
+
+    for (std::size_t field = 0; field < 4; ++field) {
+        auto limits = generous_limits();
+        if (field == 0) {
+            limits.max_committed_bytes = 0;
+        } else if (field == 1) {
+            limits.max_committed_records = 0;
+        } else if (field == 2) {
+            limits.max_resident_heads = 0;
+        } else {
+            limits.max_crash_tail_bytes = 0;
+        }
+        auto storage = JournalTestStorage::fresh();
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(limits);
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::LimitExceeded,
+                       "zero journal limit did not fail closed");
+        require(storage.snapshot() == before, "zero limit mutated storage");
+
+        auto existing = JournalTestStorage::seeded(
+            one_frame, std::string(chain.genesis_root.canonical_bytes()));
+        const auto existing_before = existing.snapshot();
+        require(recovery_status(existing, chain.genesis_root.canonical_bytes(),
+                                limits) == DurableJournalStatus::LimitExceeded,
+                "zero journal limit was accepted during recovery");
+        require(existing.snapshot() == existing_before,
+                "zero recovery limit changed committed storage");
+    }
+
+    auto byte_exact_limits = generous_limits();
+    byte_exact_limits.max_committed_bytes = two_frames.size();
+    auto byte_exact = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    require(recovery_status(byte_exact, chain.genesis_root.canonical_bytes(),
+                            byte_exact_limits) ==
+                DurableJournalStatus::Published,
+            "inclusive committed-byte limit was rejected");
+    auto byte_over = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    byte_exact_limits.max_committed_bytes = two_frames.size() - 1;
+    const auto byte_over_before = byte_over.snapshot();
+    require(recovery_status(byte_over, chain.genesis_root.canonical_bytes(),
+                            byte_exact_limits) ==
+                DurableJournalStatus::LimitExceeded,
+            "committed-byte limit +1 was accepted");
+    require(same_persistent_state(byte_over.snapshot(), byte_over_before) &&
+                !byte_over.snapshot().authority_mutation_attempted,
+            "committed-byte limit failure changed storage");
+
+    auto record_limits = generous_limits();
+    record_limits.max_committed_records = 2;
+    auto record_exact = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    require(recovery_status(record_exact, chain.genesis_root.canonical_bytes(),
+                            record_limits) == DurableJournalStatus::Published,
+            "inclusive committed-record limit was rejected");
+    auto record_over = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    record_limits.max_committed_records = 1;
+    const auto record_over_before = record_over.snapshot();
+    require(recovery_status(record_over, chain.genesis_root.canonical_bytes(),
+                            record_limits) ==
+                DurableJournalStatus::LimitExceeded,
+            "committed-record limit +1 was accepted");
+    require(same_persistent_state(record_over.snapshot(), record_over_before) &&
+                !record_over.snapshot().authority_mutation_attempted,
+            "committed-record limit failure changed storage");
+
+    const auto beta = make_second_resident(chain, "journal/main");
+    const auto beta_root = root_after(chain, beta);
+    const auto beta_bytes = one_frame + frame(beta);
+    auto head_limits = generous_limits();
+    head_limits.max_resident_heads = 1;
+    auto same_resident = JournalTestStorage::seeded(
+        two_frames, std::string(chain.successor_root.canonical_bytes()));
+    require(recovery_status(same_resident, chain.genesis_root.canonical_bytes(),
+                            head_limits) == DurableJournalStatus::Published,
+            "record count was mistaken for resident-head count");
+    head_limits.max_resident_heads = 2;
+    auto head_exact = JournalTestStorage::seeded(
+        beta_bytes, std::string(beta_root.canonical_bytes()));
+    require(recovery_status(head_exact, chain.genesis_root.canonical_bytes(),
+                            head_limits) == DurableJournalStatus::Published,
+            "inclusive resident-head limit was rejected");
+    auto head_over = JournalTestStorage::seeded(
+        beta_bytes, std::string(beta_root.canonical_bytes()));
+    head_limits.max_resident_heads = 1;
+    const auto head_over_before = head_over.snapshot();
+    require(recovery_status(head_over, chain.genesis_root.canonical_bytes(),
+                            head_limits) == DurableJournalStatus::LimitExceeded,
+            "resident-head limit +1 was accepted");
+    require(same_persistent_state(head_over.snapshot(), head_over_before) &&
+                !head_over.snapshot().authority_mutation_attempted,
+            "resident-head limit failure changed storage");
+
+    const auto tail = frame(chain.successor);
+    auto tail_limits = generous_limits();
+    tail_limits.max_crash_tail_bytes = tail.size();
+    auto tail_exact = JournalTestStorage::seeded(
+        one_frame + tail, std::string(chain.genesis_root.canonical_bytes()));
+    require(recovery_status(tail_exact, chain.genesis_root.canonical_bytes(),
+                            tail_limits) == DurableJournalStatus::Published,
+            "inclusive crash-tail limit was rejected");
+    auto tail_over = JournalTestStorage::seeded(
+        one_frame + tail, std::string(chain.genesis_root.canonical_bytes()));
+    tail_limits.max_crash_tail_bytes = tail.size() - 1;
+    const auto tail_over_before = tail_over.snapshot();
+    require(recovery_status(tail_over, chain.genesis_root.canonical_bytes(),
+                            tail_limits) == DurableJournalStatus::LimitExceeded,
+            "crash-tail limit +1 was accepted");
+    require(same_persistent_state(tail_over.snapshot(), tail_over_before) &&
+                !tail_over.snapshot().authority_mutation_attempted,
+            "crash-tail limit failure changed storage");
+
+    for (const auto limits :
+         {JournalLimits{std::numeric_limits<std::size_t>::max(), 128, 32, 1},
+          JournalLimits{1, 128, 32, std::numeric_limits<std::size_t>::max()},
+          JournalLimits{std::numeric_limits<std::size_t>::max() - 1, 128, 32,
+                        1},
+          JournalLimits{1, 128, 32,
+                        std::numeric_limits<std::size_t>::max() - 1},
+          JournalLimits{std::numeric_limits<std::size_t>::max(), 128, 32,
+                        std::numeric_limits<std::size_t>::max()}}) {
+        auto overflow = JournalTestStorage::seeded(
+            one_frame, std::string(chain.genesis_root.canonical_bytes()));
+        overflow.reset_observations();
+        const auto before = overflow.snapshot();
+        require(recovery_status(overflow, chain.genesis_root.canonical_bytes(),
+                                limits) == DurableJournalStatus::LimitExceeded,
+                "overflowing bounded-read arithmetic did not fail closed");
+        require(same_persistent_state(overflow.snapshot(), before) &&
+                    overflow.attempt_count(FaultOperation::RootOpen) == 0 &&
+                    overflow.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                    !overflow.snapshot().authority_mutation_attempted,
+                "overflowing bounds reached storage I/O or mutation");
+    }
+
+    auto nonzero_small = generous_limits();
+    nonzero_small.max_committed_bytes = one_frame.size() - 1;
+    auto small_create = JournalTestStorage::fresh();
+    const auto small_before = small_create.snapshot();
+    auto small_journal = small_create.make_journal(nonzero_small);
+    auto small_result = small_journal.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(small_result, DurableJournalStatus::LimitExceeded,
+                   "nonzero undersized create limit reached publication");
+    require(small_create.snapshot() == small_before,
+            "undersized create limit performed storage I/O");
+
+    const auto require_append_limit = [&](JournalLimits limits,
+                                          const ParsedJournalRecord &candidate,
+                                          std::string_view label) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame, std::string(chain.genesis_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(limits);
+        auto result =
+            journal.append_and_publish(std::move(authority), candidate);
+        require_result(result, DurableJournalStatus::LimitExceeded, label);
+        require(!authority.available() && storage.snapshot() == before &&
+                    !storage.snapshot().authority_mutation_attempted &&
+                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+                    storage.attempt_count(FaultOperation::JournalOpen) == 0,
+                "append limit failure was not write-free");
+    };
+    auto append_bytes = generous_limits();
+    append_bytes.max_committed_bytes = one_frame.size();
+    require_append_limit(append_bytes, chain.successor,
+                         "append exceeded committed-byte limit");
+    auto append_records = generous_limits();
+    append_records.max_committed_records = 1;
+    require_append_limit(append_records, chain.successor,
+                         "append exceeded committed-record limit");
+    auto append_heads = generous_limits();
+    append_heads.max_resident_heads = 1;
+    require_append_limit(append_heads, beta,
+                         "append exceeded resident-head limit");
+
+    const std::vector<std::tuple<std::string, std::string, JournalLimits>>
+        token_limit_cases{
+            {two_frames, std::string(chain.successor_root.canonical_bytes()),
+             JournalLimits{two_frames.size() - 1, 128, 32,
+                           generous_limits().max_crash_tail_bytes}},
+            {two_frames, std::string(chain.successor_root.canonical_bytes()),
+             JournalLimits{generous_limits().max_committed_bytes, 1, 32,
+                           generous_limits().max_crash_tail_bytes}},
+            {beta_bytes, std::string(beta_root.canonical_bytes()),
+             JournalLimits{generous_limits().max_committed_bytes, 128, 1,
+                           generous_limits().max_crash_tail_bytes}},
+        };
+    for (const auto &[bytes, root, limits] : token_limit_cases) {
+        auto compact_storage = JournalTestStorage::seeded(bytes, root);
+        auto compact_authority =
+            recover(compact_storage, chain.genesis_root.canonical_bytes());
+        compact_storage.reset_observations();
+        const auto compact_before = compact_storage.snapshot();
+        auto compact_journal = compact_storage.make_journal(limits);
+        auto compact_result =
+            compact_journal.compact_physical(std::move(compact_authority));
+        require_result(compact_result, DurableJournalStatus::LimitExceeded,
+                       "token limit did not refuse compaction");
+        require(!compact_authority.available() &&
+                    compact_storage.snapshot() == compact_before,
+                "compaction limit reached storage I/O or mutation");
+
+        auto export_storage = JournalTestStorage::seeded(bytes, root);
+        auto export_authority =
+            recover(export_storage, chain.genesis_root.canonical_bytes());
+        export_storage.reset_observations();
+        const auto export_before = export_storage.snapshot();
+        auto export_journal = export_storage.make_journal(limits);
+        auto export_result = export_journal.export_exact_schema_candidate(
+            export_authority, supported_journal_schema,
+            JournalQuiescence::Confirmed);
+        require(export_result.status ==
+                        ExactSchemaExportStatus::LimitExceeded &&
+                    !export_result.exported() &&
+                    !export_result.candidate.has_value() &&
+                    export_authority.available(),
+                "token limit returned an export candidate");
+        require(export_storage.snapshot() == export_before,
+                "export limit reached storage I/O or mutation");
+    }
+}
+
+const std::vector<FaultOperation> pre_authority_operations{
+    FaultOperation::AuthorityLockOpen,
+    FaultOperation::AuthorityLockAcquire,
+    FaultOperation::AuthorityIdentityRead,
+    FaultOperation::PreflightProbe,
+    FaultOperation::PreflightFlushCreate,
+    FaultOperation::PreflightFlushWrite,
+    FaultOperation::PreflightFlushFileFlush,
+    FaultOperation::PreflightFlushClose,
+    FaultOperation::PreflightTruncate,
+    FaultOperation::PreflightTruncateFlush,
+    FaultOperation::PreflightTruncateClose,
+    FaultOperation::PreflightReplaceStageCreate,
+    FaultOperation::PreflightReplaceStageWrite,
+    FaultOperation::PreflightReplaceStageFlush,
+    FaultOperation::PreflightReplaceStageClose,
+    FaultOperation::PreflightReplace,
+    FaultOperation::PreflightNamespaceDurability,
+    FaultOperation::PreflightCleanup,
+    FaultOperation::FixedNamespaceInspect,
+};
+
+const std::vector<FaultOperation> publication_operations = [] {
+    auto operations = pre_authority_operations;
+    operations.insert(operations.end(), {
+                                            FaultOperation::RootOpen,
+                                            FaultOperation::RootRead,
+                                            FaultOperation::RootClose,
+                                            FaultOperation::JournalOpen,
+                                            FaultOperation::JournalRead,
+                                            FaultOperation::JournalReadClose,
+                                            FaultOperation::JournalAppendOpen,
+                                            FaultOperation::JournalWrite,
+                                            FaultOperation::JournalFlush,
+                                            FaultOperation::JournalClose,
+                                            FaultOperation::RootStageCreate,
+                                            FaultOperation::RootStageWrite,
+                                            FaultOperation::RootStageFlush,
+                                            FaultOperation::RootStageClose,
+                                            FaultOperation::RootReplace,
+                                            FaultOperation::NamespaceDurability,
+                                            FaultOperation::AuthorityUnlock,
+                                            FaultOperation::AuthorityLockClose,
+                                        });
+    return operations;
+}();
+
+const std::vector<FaultOperation> creation_operations = [] {
+    auto operations = pre_authority_operations;
+    operations.insert(operations.end(),
+                      {
+                          FaultOperation::RootOpen,
+                          FaultOperation::InitialJournalCreate,
+                          FaultOperation::JournalWrite,
+                          FaultOperation::JournalFlush,
+                          FaultOperation::JournalClose,
+                          FaultOperation::RootStageCreate,
+                          FaultOperation::RootStageWrite,
+                          FaultOperation::RootStageFlush,
+                          FaultOperation::RootStageClose,
+                          FaultOperation::RootReplace,
+                          FaultOperation::NamespaceDurability,
+                          FaultOperation::AuthorityUnlock,
+                          FaultOperation::AuthorityLockClose,
+                      });
+    return operations;
+}();
+
+bool preflight_may_have_effect(FaultOperation operation,
+                               FaultPosition position, FaultAction action) {
+    const auto found = std::find(pre_authority_operations.begin(),
+                                 pre_authority_operations.end(), operation);
+    const auto first = std::find(pre_authority_operations.begin(),
+                                 pre_authority_operations.end(),
+                                 FaultOperation::PreflightProbe);
+    return found >= first && found != pre_authority_operations.end() &&
+           (position == FaultPosition::After ||
+            action == FaultAction::EffectThenError);
+}
+
+void require_operations_in_order(
+    const NamespaceSnapshot &snapshot,
+    std::initializer_list<FaultOperation> operations,
+    std::string_view failure_message) {
+    std::size_t cursor = 0;
+    for (const auto operation : operations) {
+        const auto found = std::find_if(
+            snapshot.observations.begin() + static_cast<std::ptrdiff_t>(cursor),
+            snapshot.observations.end(),
+            [&](const OperationObservation &observation) {
+                return observation.operation == operation &&
+                       observation.lock_held;
+            });
+        require(found != snapshot.observations.end(), failure_message);
+        cursor = static_cast<std::size_t>(
+                     std::distance(snapshot.observations.begin(), found)) +
+                 1;
+    }
+}
+
+void require_durability_ordering() {
+    const auto chain = make_chain();
+
+    auto create_storage = JournalTestStorage::fresh();
+    static_cast<void>(create(create_storage, chain));
+    const auto create_snapshot = create_storage.snapshot();
+    require_operations_in_order(
+        create_snapshot,
+        {FaultOperation::InitialJournalCreate, FaultOperation::JournalWrite,
+         FaultOperation::JournalFlush, FaultOperation::JournalClose,
+         FaultOperation::RootStageCreate, FaultOperation::RootStageWrite,
+         FaultOperation::RootStageFlush, FaultOperation::RootStageClose,
+         FaultOperation::RootReplace, FaultOperation::NamespaceDurability},
+        "create did not durably publish journal before root");
+
+    auto append_storage = JournalTestStorage::seeded(
+        frame(chain.genesis),
+        std::string(chain.genesis_root.canonical_bytes()));
+    auto append_authority =
+        recover(append_storage, chain.genesis_root.canonical_bytes());
+    append_storage.reset_observations();
+    auto append_journal = append_storage.make_journal(generous_limits());
+    auto append_result = append_journal.append_and_publish(
+        std::move(append_authority), chain.successor);
+    require_result(append_result, DurableJournalStatus::Published,
+                   "ordering append was rejected");
+    const auto append_snapshot = append_storage.snapshot();
+    require_operations_in_order(
+        append_snapshot,
+        {FaultOperation::RootOpen, FaultOperation::RootRead,
+         FaultOperation::RootClose, FaultOperation::JournalOpen,
+         FaultOperation::JournalRead, FaultOperation::JournalReadClose,
+         FaultOperation::JournalAppendOpen, FaultOperation::JournalWrite,
+         FaultOperation::JournalFlush, FaultOperation::JournalClose,
+         FaultOperation::RootStageCreate, FaultOperation::RootStageWrite,
+         FaultOperation::RootStageFlush, FaultOperation::RootStageClose,
+         FaultOperation::RootReplace, FaultOperation::NamespaceDurability},
+        "append did not durably publish journal before root");
+
+    auto tail_storage = JournalTestStorage::seeded(
+        frame(chain.genesis) + frame(chain.successor).substr(0, 7),
+        std::string(chain.genesis_root.canonical_bytes()));
+    tail_storage.reset_observations();
+    auto tail_journal = tail_storage.make_journal(generous_limits());
+    auto tail_result =
+        tail_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+    require_result(tail_result, DurableJournalStatus::Published,
+                   "ordering tail repair was rejected");
+    const auto tail_snapshot = tail_storage.snapshot();
+    require_operations_in_order(
+        tail_snapshot,
+        {FaultOperation::RootOpen, FaultOperation::RootRead,
+         FaultOperation::RootClose, FaultOperation::JournalOpen,
+         FaultOperation::JournalRead, FaultOperation::JournalReadClose,
+         FaultOperation::TailRepairOpen, FaultOperation::TailRepairTruncate,
+         FaultOperation::TailRepairFlush, FaultOperation::TailRepairClose},
+        "tail repair did not truncate, flush, and close in place");
+    require(!has_stage_operation(tail_snapshot) &&
+                tail_snapshot.stage_files_absent &&
+                tail_snapshot.durable_stage_files_absent &&
+                tail_snapshot.all_authority_io_under_lock,
+            "tail repair used replacement or namespace durability");
+
+    const auto committed = frame(chain.genesis) + frame(chain.successor);
+    auto compact_storage = JournalTestStorage::seeded(
+        committed, std::string(chain.successor_root.canonical_bytes()));
+    auto compact_authority =
+        recover(compact_storage, chain.successor_root.canonical_bytes());
+    compact_storage.reset_observations();
+    auto compact_journal = compact_storage.make_journal(generous_limits());
+    auto compact_result =
+        compact_journal.compact_physical(std::move(compact_authority));
+    require_result(compact_result, DurableJournalStatus::Published,
+                   "ordering compaction was rejected");
+    const auto compact_snapshot = compact_storage.snapshot();
+    require_operations_in_order(
+        compact_snapshot,
+        {FaultOperation::CompactionStageCreate, FaultOperation::CompactionWrite,
+         FaultOperation::CompactionFlush, FaultOperation::CompactionClose,
+         FaultOperation::CompactionReplace,
+         FaultOperation::CompactionNamespaceDurability},
+        "compaction did not flush and close its stage before replacement");
+}
+
+void require_stage_replacement_swap_is_fail_closed() {
+    const auto chain = make_chain();
+    const auto genesis_root =
+        std::string(chain.genesis_root.canonical_bytes());
+    const auto successor_root =
+        std::string(chain.successor_root.canonical_bytes());
+
+    for (const bool corrupt_content : {false, true}) {
+        auto storage =
+            JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
+        auto authority = recover(storage, genesis_root);
+        storage.reset_observations();
+        storage.pause_after(FaultOperation::RootStageClose);
+        std::optional<DurableJournalResult> result;
+        std::thread publisher([&] {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(journal.append_and_publish(std::move(authority),
+                                                       chain.successor));
+        });
+        require(storage.wait_until_paused(5000),
+                "root replacement did not pause after stage close");
+        const auto swapped_root =
+            corrupt_content ? std::string("swapped-root-stage")
+                            : successor_root;
+        storage.replace_fixed_child_file(FixedAuthorityChild::RootStage,
+                                         swapped_root);
+        storage.release_pause();
+        publisher.join();
+        require(result.has_value(),
+                "root replacement did not return after stage swap");
+        require_result(*result, DurableJournalStatus::RecoveryRequired,
+                       "root stage swap returned publication authority");
+        require(!authority.available() && !result->journal.has_value() &&
+                    storage.snapshot().journal_bytes ==
+                        frame(chain.genesis) + frame(chain.successor) &&
+                    storage.snapshot().authority_root_bytes == swapped_root &&
+                    storage.snapshot().all_authority_io_under_lock,
+                "root stage swap escaped fail-closed publication");
+        require_storage_released_after_return(
+            storage, "root stage swap retained an authority handle");
+
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.recover_existing(
+            TrustedReplayFloor::exact_root(genesis_root));
+        if (corrupt_content) {
+            require_result(recovered, DurableJournalStatus::CorruptOrRollback,
+                           "corrupt swapped root remained authoritative");
+            require_storage_released_after_return(
+                storage, "corrupt swapped-root recovery retained a handle");
+        } else {
+            require_result(recovered, DurableJournalStatus::Published,
+                           "identity-only root swap was not recoverable");
+            auto continuation = storage.make_journal(generous_limits());
+            auto continued = continuation.append_and_publish(
+                std::move(*recovered.journal), chain.third);
+            require_result(continued, DurableJournalStatus::Published,
+                           "identity-only root swap could not continue");
+        }
+    }
+
+    for (const bool corrupt_content : {false, true}) {
+        auto storage =
+            JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
+        auto authority = recover(storage, genesis_root);
+        storage.reset_observations();
+        storage.pause_after(FaultOperation::CompactionClose);
+        std::optional<DurableJournalResult> result;
+        std::thread compactor([&] {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(
+                journal.compact_physical(std::move(authority)));
+        });
+        require(storage.wait_until_paused(5000),
+                "journal replacement did not pause after stage close");
+        const auto swapped_journal =
+            corrupt_content ? std::string("swapped-journal-stage")
+                            : frame(chain.genesis);
+        storage.replace_fixed_child_file(FixedAuthorityChild::JournalStage,
+                                         swapped_journal);
+        storage.release_pause();
+        compactor.join();
+        require(result.has_value(),
+                "journal replacement did not return after stage swap");
+        require_result(*result, DurableJournalStatus::RecoveryRequired,
+                       "journal stage swap returned publication authority");
+        require(!authority.available() && !result->journal.has_value() &&
+                    storage.snapshot().journal_bytes == swapped_journal &&
+                    storage.snapshot().authority_root_bytes == genesis_root &&
+                    storage.snapshot().all_authority_io_under_lock,
+                "journal stage swap escaped fail-closed publication");
+        require_storage_released_after_return(
+            storage, "journal stage swap retained an authority handle");
+
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.recover_existing(
+            TrustedReplayFloor::exact_root(genesis_root));
+        if (corrupt_content) {
+            require_result(recovered, DurableJournalStatus::CorruptOrRollback,
+                           "corrupt swapped journal remained authoritative");
+            require_storage_released_after_return(
+                storage,
+                "corrupt swapped-journal recovery retained a handle");
+        } else {
+            require_result(recovered, DurableJournalStatus::Published,
+                           "identity-only journal swap was not recoverable");
+            auto continuation = storage.make_journal(generous_limits());
+            auto continued = continuation.append_and_publish(
+                std::move(*recovered.journal), chain.successor);
+            require_result(continued, DurableJournalStatus::Published,
+                           "identity-only journal swap could not continue");
+        }
+    }
+}
+
+void require_paused_read_replacement_is_fail_closed() {
+    const auto chain = make_chain();
+    const auto genesis_root =
+        std::string(chain.genesis_root.canonical_bytes());
+    auto storage =
+        JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
+    storage.pause_after(FaultOperation::JournalRead);
+    std::optional<DurableJournalResult> result;
+    bool threw = false;
+    std::thread recoverer([&] {
+        try {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(journal.recover_existing(
+                TrustedReplayFloor::exact_root(genesis_root)));
+        } catch (...) {
+            threw = true;
+        }
+    });
+    require(storage.wait_until_paused(5000),
+            "recovery did not pause during its journal read");
+    storage.replace_fixed_child_file(FixedAuthorityChild::Journal, "x");
+    storage.release_pause();
+    recoverer.join();
+    require(!threw, "paused journal read used stale mutable storage");
+    require(result.has_value(), "paused journal read did not return");
+    require_result(*result, DurableJournalStatus::RecoveryRequired,
+                   "journal replacement during a read did not fail closed");
+    require_storage_released_after_return(
+        storage, "paused journal read retained an authority handle");
+}
+
+void require_paused_read_holds_authority_lock() {
+    const auto chain = make_chain();
+    const auto genesis_root =
+        std::string(chain.genesis_root.canonical_bytes());
+    auto storage =
+        JournalTestStorage::seeded(frame(chain.genesis), genesis_root);
+    storage.pause_after(FaultOperation::JournalRead);
+    std::optional<DurableJournalResult> holder_result;
+    std::optional<DurableJournalResult> waiter_result;
+    std::thread holder([&] {
+        auto journal = storage.make_journal(generous_limits());
+        holder_result.emplace(journal.recover_existing(
+            TrustedReplayFloor::exact_root(genesis_root)));
+    });
+    require(storage.wait_until_paused(5000),
+            "lock holder did not pause during its journal read");
+    std::thread waiter([&] {
+        auto journal = storage.make_journal(generous_limits());
+        waiter_result.emplace(journal.recover_existing(
+            TrustedReplayFloor::exact_root(genesis_root)));
+    });
+    const auto waiter_blocked = storage.wait_until_lock_waiter(5000);
+    storage.release_pause();
+    holder.join();
+    waiter.join();
+    require(waiter_blocked,
+            "journal read did not retain the stable authority lock");
+    require(holder_result.has_value() && waiter_result.has_value(),
+            "serialized journal readers did not return");
+    require_result(*holder_result, DurableJournalStatus::Published,
+                   "paused journal reader lost publication authority");
+    require_result(*waiter_result, DurableJournalStatus::Published,
+                   "waiting journal reader lost publication authority");
+    require_storage_released_after_return(
+        storage, "serialized journal readers retained an authority handle");
+}
+
+void require_paused_write_observes_completed_effect() {
+    const auto chain = make_chain();
+    const auto genesis_journal = frame(chain.genesis);
+    const auto successor_frame = frame(chain.successor);
+    const auto genesis_root =
+        std::string(chain.genesis_root.canonical_bytes());
+    auto storage = JournalTestStorage::seeded(genesis_journal, genesis_root);
+    auto authority = recover(storage, genesis_root);
+    storage.reset_observations();
+    storage.pause_after(FaultOperation::JournalWrite);
+    std::optional<DurableJournalResult> result;
+    std::thread publisher([&] {
+        auto journal = storage.make_journal(generous_limits());
+        result.emplace(
+            journal.append_and_publish(std::move(authority), chain.successor));
+    });
+    const auto paused = storage.wait_until_paused(5000);
+    if (!paused) {
+        storage.release_pause();
+        publisher.join();
+        require(false, "journal write did not pause after observation");
+    }
+    const auto observed = storage.snapshot();
+    const auto write = std::find_if(
+        observed.observations.begin(), observed.observations.end(),
+        [](const OperationObservation &observation) {
+            return observation.operation == FaultOperation::JournalWrite;
+        });
+    require(write != observed.observations.end() && write->lock_held &&
+                write->mutation_attempted &&
+                write->requested_bytes == successor_frame.size() &&
+                write->transferred_bytes == successor_frame.size() &&
+                observed.journal_bytes == genesis_journal + successor_frame &&
+                observed.authority_root_bytes == genesis_root,
+            "journal write pause preceded its successful observation");
+    storage.release_pause();
+    publisher.join();
+    require(result.has_value(), "paused journal write did not return");
+    require_result(*result, DurableJournalStatus::Published,
+                   "paused journal write did not finish publication");
+    require_storage_released_after_return(
+        storage, "paused journal write retained an authority handle");
+}
+
+void require_fake_adapter_destructor_closes_open_lock() {
+    auto storage = JournalTestStorage::fresh();
+    require(storage.destroy_adapter_with_open_lock(false) &&
+                storage.snapshot().open_handles.empty(),
+            "fake adapter destructor leaked an open lock handle");
+
+    require(storage.destroy_adapter_with_open_lock(true) &&
+                storage.snapshot().open_handles.size() == 1,
+            "simulated crash incorrectly closed the fake lock handle");
+    storage.restart();
+    require(storage.snapshot().open_handles.empty(),
+            "restart retained a simulated-crash lock handle");
+}
+
+void require_final_under_lock_revalidation() {
+    const auto chain = make_chain();
+    const auto genesis_journal = frame(chain.genesis);
+    const auto successor_journal = genesis_journal + frame(chain.successor);
+    const auto genesis_root =
+        std::string(chain.genesis_root.canonical_bytes());
+    const auto successor_root =
+        std::string(chain.successor_root.canonical_bytes());
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
+        std::optional<DurableJournalResult> result;
+        std::thread creator([&] {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(journal.create_new(
+                TrustedReplayFloor::uninitialized(), chain.genesis));
+        });
+        require(storage.wait_until_paused(5000),
+                "create did not pause for final authority validation");
+        storage.replace_fixed_child_file(FixedAuthorityChild::Journal,
+                                         "post-create-journal-swap");
+        storage.release_pause();
+        creator.join();
+        require(result.has_value(), "paused create did not return");
+        require_result(*result, DurableJournalStatus::RecoveryRequired,
+                       "create minted authority after a final journal swap");
+        require(!result->journal.has_value() &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityIdentityRead) == 2,
+                "create skipped its final composite authority validation");
+        require_storage_released_after_return(
+            storage, "final create validation retained an authority handle");
+        storage.replace_fixed_child_file(FixedAuthorityChild::Journal,
+                                         genesis_journal);
+        static_cast<void>(recover(storage, genesis_root));
+    }
+
+    {
+        auto storage = JournalTestStorage::seeded(
+            genesis_journal, genesis_root, PlatformContract::Linux);
+        storage.reset_observations();
+        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
+        std::optional<DurableJournalResult> result;
+        std::thread recoverer([&] {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(journal.recover_existing(
+                TrustedReplayFloor::exact_root(genesis_root)));
+        });
+        require(storage.wait_until_paused(5000),
+                "recovery did not pause for final authority validation");
+        const auto old_lock_identity = storage.lock_identity();
+        require(old_lock_identity != 0 && storage.try_unlink_lock_file() &&
+                    storage.try_recreate_lock_file() &&
+                    storage.lock_identity() != old_lock_identity,
+                "recovery final validation fixture did not replace the lock");
+        storage.release_pause();
+        recoverer.join();
+        require(result.has_value(), "paused recovery did not return");
+        require_result(*result, DurableJournalStatus::RecoveryRequired,
+                       "recovery minted authority after final lock replacement");
+        require(!result->journal.has_value() &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityIdentityRead) == 2,
+                "recovery skipped its final composite authority validation");
+        require_storage_released_after_return(
+            storage,
+            "final recovery validation retained an authority handle");
+        static_cast<void>(recover(storage, genesis_root));
+    }
+
+    {
+        auto storage =
+            JournalTestStorage::seeded(genesis_journal, genesis_root);
+        auto authority = recover(storage, genesis_root);
+        storage.reset_observations();
+        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
+        std::optional<DurableJournalResult> result;
+        std::thread publisher([&] {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(journal.append_and_publish(std::move(authority),
+                                                       chain.successor));
+        });
+        require(storage.wait_until_paused(5000),
+                "append did not pause for final authority validation");
+        storage.replace_fixed_child_file(FixedAuthorityChild::Root,
+                                         "post-append-root-swap");
+        storage.release_pause();
+        publisher.join();
+        require(result.has_value(), "paused append did not return");
+        require_result(*result, DurableJournalStatus::RecoveryRequired,
+                       "append minted authority after a final root swap");
+        require(!authority.available() && !result->journal.has_value() &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityIdentityRead) == 2,
+                "append skipped its final composite authority validation");
+        require_storage_released_after_return(
+            storage, "final append validation retained an authority handle");
+        storage.replace_fixed_child_file(FixedAuthorityChild::Root,
+                                         successor_root);
+        static_cast<void>(recover(storage, successor_root));
+    }
+
+    {
+        auto storage =
+            JournalTestStorage::seeded(successor_journal, successor_root);
+        auto authority = recover(storage, successor_root);
+        storage.reset_observations();
+        storage.pause_after_nth(FaultOperation::AuthorityIdentityRead, 2);
+        std::optional<DurableJournalResult> result;
+        std::thread compactor([&] {
+            auto journal = storage.make_journal(generous_limits());
+            result.emplace(journal.compact_physical(std::move(authority)));
+        });
+        require(storage.wait_until_paused(5000),
+                "compaction did not pause for final authority validation");
+        storage.replace_fixed_child_file(FixedAuthorityChild::JournalStage,
+                                         successor_journal);
+        storage.release_pause();
+        compactor.join();
+        require(result.has_value(), "paused compaction did not return");
+        require_result(
+            *result, DurableJournalStatus::RecoveryRequired,
+            "compaction minted authority after final stage replacement");
+        require(!authority.available() && !result->journal.has_value() &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityIdentityRead) == 2,
+                "compaction skipped its final composite authority validation");
+        require_storage_released_after_return(
+            storage,
+            "final compaction validation retained an authority handle");
+        auto recovered = recover(storage, successor_root);
+        auto cleanup = storage.make_journal(generous_limits());
+        auto cleaned = cleanup.compact_physical(std::move(recovered));
+        require_result(cleaned, DurableJournalStatus::Published,
+                       "stage-drift recovery could not continue");
+        require(storage.snapshot().stage_files_absent,
+                "stage-drift continuation did not consume its stage");
+    }
+}
+
+void require_preflight_and_bounded_read_trace() {
+    const auto chain = make_chain();
+    const auto limits = generous_limits();
+    auto storage = JournalTestStorage::seeded(
+        frame(chain.genesis),
+        std::string(chain.genesis_root.canonical_bytes()));
+    storage.reset_observations();
+    auto journal = storage.make_journal(limits);
+    auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+        std::string(chain.genesis_root.canonical_bytes())));
+    require_result(result, DurableJournalStatus::Published,
+                   "trace recovery was rejected");
+    const auto snapshot = storage.snapshot();
+
+    const std::vector<FaultOperation> ordered_preflight{
+        FaultOperation::PreflightProbe,
+        FaultOperation::PreflightFlushCreate,
+        FaultOperation::PreflightFlushWrite,
+        FaultOperation::PreflightFlushFileFlush,
+        FaultOperation::PreflightFlushClose,
+        FaultOperation::PreflightTruncate,
+        FaultOperation::PreflightTruncateFlush,
+        FaultOperation::PreflightTruncateClose,
+        FaultOperation::PreflightReplaceStageCreate,
+        FaultOperation::PreflightReplaceStageWrite,
+        FaultOperation::PreflightReplaceStageFlush,
+        FaultOperation::PreflightReplaceStageClose,
+        FaultOperation::PreflightReplace,
+        FaultOperation::PreflightNamespaceDurability,
+        FaultOperation::PreflightCleanup,
+    };
+    std::size_t cursor = 0;
+    for (const auto operation : ordered_preflight) {
+        const auto found = std::find_if(
+            snapshot.observations.begin() + static_cast<std::ptrdiff_t>(cursor),
+            snapshot.observations.end(),
+            [&](const OperationObservation &observation) {
+                return observation.operation == operation &&
+                       observation.lock_held;
+            });
+        require(found != snapshot.observations.end(),
+                "preflight primitive was absent or out of order");
+        cursor = static_cast<std::size_t>(
+                     std::distance(snapshot.observations.begin(), found)) +
+                 1;
+    }
+    const auto first_authority_open = std::find_if(
+        snapshot.observations.begin(), snapshot.observations.end(),
+        [](const OperationObservation &observation) {
+            return observation.operation == FaultOperation::RootOpen ||
+                   observation.operation == FaultOperation::JournalOpen;
+        });
+    const auto fixed_namespace_inspection =
+        std::find_if(snapshot.observations.begin(), snapshot.observations.end(),
+                     [](const OperationObservation &observation) {
+                         return observation.operation ==
+                                FaultOperation::FixedNamespaceInspect;
+                     });
+    require(first_authority_open != snapshot.observations.end() &&
+                fixed_namespace_inspection != snapshot.observations.end() &&
+                fixed_namespace_inspection->lock_held &&
+                cursor <= static_cast<std::size_t>(
+                              std::distance(snapshot.observations.begin(),
+                                            fixed_namespace_inspection)) &&
+                fixed_namespace_inspection < first_authority_open,
+            "fixed namespace was not inspected after preflight and before "
+            "authority I/O");
+
+    const auto identity =
+        std::find_if(snapshot.observations.begin(), snapshot.observations.end(),
+                     [](const OperationObservation &observation) {
+                         return observation.operation ==
+                                FaultOperation::AuthorityIdentityRead;
+                     });
+    const auto first_preflight = std::find_if(
+        snapshot.observations.begin(), snapshot.observations.end(),
+        [](const OperationObservation &observation) {
+            return observation.operation == FaultOperation::PreflightProbe;
+        });
+    require(identity != snapshot.observations.end() && identity->lock_held &&
+                first_preflight != snapshot.observations.end() &&
+                identity < first_preflight,
+            "authority identity was not validated under lock before "
+            "preflight");
+
+    const auto root_read = std::find_if(
+        snapshot.observations.begin(), snapshot.observations.end(),
+        [](const OperationObservation &observation) {
+            return observation.operation == FaultOperation::RootRead;
+        });
+    const auto journal_read = std::find_if(
+        snapshot.observations.begin(), snapshot.observations.end(),
+        [](const OperationObservation &observation) {
+            return observation.operation == FaultOperation::JournalRead;
+        });
+    require(root_read != snapshot.observations.end() &&
+                journal_read != snapshot.observations.end() &&
+                root_read < journal_read &&
+                root_read->requested_bytes <= max_journal_input_bytes + 1 &&
+                root_read->requested_bytes >=
+                    chain.genesis_root.canonical_bytes().size() &&
+                journal_read->requested_bytes <=
+                    limits.max_committed_bytes + limits.max_crash_tail_bytes +
+                        1 &&
+                journal_read->requested_bytes >= frame(chain.genesis).size(),
+            "recovery did not use bounded root-first reads");
+    require(
+        storage.attempt_count(FaultOperation::RootClose) == 2 &&
+            storage.attempt_count(FaultOperation::JournalReadClose) == 2 &&
+            storage.attempt_count(FaultOperation::PreflightFlushClose) == 1 &&
+            storage.attempt_count(FaultOperation::PreflightTruncateClose) ==
+                1 &&
+            storage.attempt_count(FaultOperation::PreflightReplaceStageClose) ==
+                1 &&
+            storage.attempt_count(FaultOperation::AuthorityLockClose) == 1 &&
+            snapshot.open_handles.empty() &&
+            !snapshot.authority_mutation_attempted,
+        "bounded recovery did not checked-close each read handle once");
+}
+
+bool creation_may_have_mutated(FaultOperation operation, FaultPosition position,
+                               FaultAction action) {
+    if (preflight_may_have_effect(operation, position, action)) {
+        return true;
+    }
+    if (operation == FaultOperation::InitialJournalCreate) {
+        return position == FaultPosition::After ||
+               action == FaultAction::EffectThenError;
+    }
+    const auto found = std::find(creation_operations.begin(),
+                                 creation_operations.end(), operation);
+    const auto create =
+        std::find(creation_operations.begin(), creation_operations.end(),
+                  FaultOperation::InitialJournalCreate);
+    return found > create;
+}
+
+void require_create_faults() {
+    const auto chain = make_chain();
+    bool observed_journal_close_residue = false;
+    bool observed_root_stage_close_residue = false;
+    for (const auto operation : creation_operations) {
+        for (const auto position :
+             {FaultPosition::Before, FaultPosition::After}) {
+            for (const auto action : {FaultAction::Error, FaultAction::Crash,
+                                      FaultAction::EffectThenError}) {
+                auto storage = JournalTestStorage::fresh();
+                const auto initial = storage.snapshot();
+                storage.arm_fault(operation, position, action);
+                auto journal = storage.make_journal(generous_limits());
+                auto result = journal.create_new(
+                    TrustedReplayFloor::uninitialized(), chain.genesis);
+                const auto expected =
+                    creation_may_have_mutated(operation, position, action)
+                        ? DurableJournalStatus::RecoveryRequired
+                        : DurableJournalStatus::UnsupportedStorage;
+                const auto operation_position =
+                    std::find(creation_operations.begin(),
+                              creation_operations.end(), operation);
+                const auto create_position =
+                    std::find(creation_operations.begin(),
+                              creation_operations.end(),
+                              FaultOperation::InitialJournalCreate);
+                const bool retained_process_fence =
+                    preflight_may_have_effect(operation, position, action) ||
+                    operation_position > create_position ||
+                    (operation_position == create_position &&
+                     (position == FaultPosition::After ||
+                      action == FaultAction::EffectThenError));
+                require_result(
+                    result, expected,
+                    "create fault returned the wrong stable outcome");
+                const auto after_failure = storage.snapshot();
+                if (action != FaultAction::Crash) {
+                    const bool boundary_effect_happened =
+                        position == FaultPosition::After ||
+                        action == FaultAction::EffectThenError;
+                    const auto expected_preflight_close =
+                        [&](FaultOperation open_operation) {
+                            const auto fault =
+                                std::find(creation_operations.begin(),
+                                          creation_operations.end(), operation);
+                            const auto open = std::find(
+                                creation_operations.begin(),
+                                creation_operations.end(), open_operation);
+                            return static_cast<std::size_t>(
+                                fault > open ||
+                                (fault == open && boundary_effect_happened));
+                        };
+                    const auto expected_lock_close = static_cast<std::size_t>(
+                        operation != FaultOperation::AuthorityLockOpen ||
+                        boundary_effect_happened);
+                    require(
+                        after_failure.open_handles.empty() &&
+                            storage.attempt_count(
+                                FaultOperation::AuthorityLockClose) ==
+                                expected_lock_close &&
+                            storage.attempt_count(
+                                FaultOperation::PreflightFlushClose) ==
+                                expected_preflight_close(
+                                    FaultOperation::PreflightFlushCreate) &&
+                            storage.attempt_count(
+                                FaultOperation::PreflightTruncateClose) ==
+                                expected_preflight_close(
+                                    FaultOperation::PreflightTruncate) &&
+                            storage.attempt_count(
+                                FaultOperation::PreflightReplaceStageClose) ==
+                                expected_preflight_close(
+                                    FaultOperation::
+                                        PreflightReplaceStageCreate) &&
+                            storage.attempt_count(
+                                FaultOperation::JournalClose) ==
+                                expected_preflight_close(
+                                    FaultOperation::InitialJournalCreate) &&
+                            storage.attempt_count(
+                                FaultOperation::RootStageClose) ==
+                                expected_preflight_close(
+                                    FaultOperation::RootStageCreate),
+                        "create fault leaked or retried a handle before "
+                        "restart");
+                }
+                if (expected == DurableJournalStatus::UnsupportedStorage) {
+                    require(authority_files_unchanged(initial, after_failure) &&
+                                !after_failure.authority_mutation_attempted,
+                            "pre-authority failure changed authority files");
+                }
+                const auto established_lock_identity = storage.lock_identity();
+                storage.restart();
+                const auto snapshot = storage.snapshot();
+                require(snapshot.authority_root_bytes.empty() ||
+                            snapshot.authority_root_bytes ==
+                                chain.genesis_root.canonical_bytes(),
+                        "failed create exposed a synthesized root");
+                require(snapshot.all_authority_io_under_lock,
+                        "failed create performed authority I/O outside the "
+                        "full lock");
+                if (snapshot.authority_root_bytes ==
+                    chain.genesis_root.canonical_bytes()) {
+                    storage.reset_observations();
+                    auto recovered =
+                        recover(storage, chain.genesis_root.canonical_bytes());
+                    require(recovered.root_bytes() ==
+                                    chain.genesis_root.canonical_bytes() &&
+                                storage.snapshot().journal_bytes ==
+                                    frame(chain.genesis) &&
+                                storage.snapshot().journal_durable &&
+                                storage.snapshot().journal_closed &&
+                                storage.snapshot().stage_files_absent &&
+                                storage.snapshot().durable_stage_files_absent,
+                            "visible genesis root was not exactly recoverable");
+                } else {
+                    const auto has_residue =
+                        snapshot.relative_paths.count("journal.jsonl") != 0 ||
+                        snapshot.relative_paths.count(".journal.jsonl.stage") !=
+                            0 ||
+                        snapshot.relative_paths.count(
+                            ".authority-root.json.stage") != 0 ||
+                        snapshot.durable_file_bytes.count("journal.jsonl") !=
+                            0 ||
+                        snapshot.durable_file_bytes.count(
+                            ".journal.jsonl.stage") != 0 ||
+                        snapshot.durable_file_bytes.count(
+                            ".authority-root.json.stage") != 0;
+                    storage.reset_observations();
+                    const auto fenced_before = storage.snapshot();
+                    auto retry = storage.make_journal(generous_limits());
+                    auto retry_result = retry.create_new(
+                        TrustedReplayFloor::uninitialized(), chain.genesis);
+                    if (has_residue) {
+                        observed_journal_close_residue |=
+                            operation == FaultOperation::JournalClose &&
+                            position == FaultPosition::After &&
+                            action == FaultAction::Crash;
+                        observed_root_stage_close_residue |=
+                            operation == FaultOperation::RootStageClose &&
+                            position == FaultPosition::After &&
+                            action == FaultAction::Crash;
+                        require_result(
+                            retry_result,
+                            retained_process_fence
+                                ? DurableJournalStatus::RecoveryRequired
+                                : DurableJournalStatus::CorruptOrRollback,
+                            "rootless authority residue was not rejected");
+                        const auto after_create_rejection = storage.snapshot();
+                        require(
+                            same_persistent_state(after_create_rejection,
+                                                  fenced_before) &&
+                                !after_create_rejection
+                                     .authority_mutation_attempted,
+                            "rootless create rejection changed crash evidence");
+                        require_storage_released_after_return(
+                            storage,
+                            "rootless create rejection retained a handle");
+                        storage.reset_observations();
+                        const auto before_recovery_rejection =
+                            storage.snapshot();
+                        auto recovery = storage.make_journal(generous_limits());
+                        auto recovery_result = recovery.recover_existing(
+                            TrustedReplayFloor::uninitialized());
+                        require_result(
+                            recovery_result,
+                            DurableJournalStatus::CorruptOrRollback,
+                            "rootless authority residue minted recovery");
+                        const auto after_recovery_rejection =
+                            storage.snapshot();
+                        require(
+                            same_persistent_state(after_recovery_rejection,
+                                                  before_recovery_rejection) &&
+                                !after_recovery_rejection
+                                     .authority_mutation_attempted &&
+                                after_recovery_rejection.authority_root_bytes
+                                    .empty(),
+                            "rootless recovery rejection changed crash "
+                            "evidence");
+                        require_storage_released_after_return(
+                            storage,
+                            "rootless recovery rejection retained a handle");
+                    } else {
+                        require_result(
+                            retry_result, DurableJournalStatus::Published,
+                            "provably empty namespace could not retry create");
+                        const auto retried = storage.snapshot();
+                        require((established_lock_identity == 0 ||
+                                 storage.lock_identity() ==
+                                     established_lock_identity) &&
+                                    retried.relative_paths.count(
+                                        ".durability-probe") == 0 &&
+                                    retried.relative_paths.count(
+                                        ".durability-probe.stage") == 0 &&
+                                    retried.open_handles.empty(),
+                                "create retry changed stable lock or retained "
+                                "preflight residue");
+                    }
+                }
+            }
+        }
+    }
+    require(observed_journal_close_residue && observed_root_stage_close_residue,
+            "create fault matrix did not exercise rootless durable residue");
+}
+
+bool publication_may_have_mutated(FaultOperation operation,
+                                  FaultPosition position, FaultAction action) {
+    if (operation == FaultOperation::JournalWrite) {
+        return position == FaultPosition::After ||
+               action == FaultAction::EffectThenError;
+    }
+    const auto found = std::find(publication_operations.begin(),
+                                 publication_operations.end(), operation);
+    const auto write =
+        std::find(publication_operations.begin(), publication_operations.end(),
+                  FaultOperation::JournalWrite);
+    return found > write;
+}
+
+void require_append_and_fault_recovery() {
+    const auto chain = make_chain();
+    auto baseline = JournalTestStorage::fresh();
+    static_cast<void>(create(baseline, chain));
+
+    auto success = baseline.clone();
+    auto success_authority =
+        recover(success, chain.genesis_root.canonical_bytes());
+    auto success_journal = success.make_journal(generous_limits());
+    auto published = success_journal.append_and_publish(
+        std::move(success_authority), chain.successor);
+    require_result(published, DurableJournalStatus::Published,
+                   "valid append was not published");
+    require(published.journal->root_bytes() ==
+                chain.successor_root.canonical_bytes(),
+            "append published the wrong root");
+    require(success.snapshot().journal_bytes ==
+                    frame(chain.genesis) + frame(chain.successor) &&
+                success.snapshot().authority_root_bytes ==
+                    chain.successor_root.canonical_bytes() &&
+                success.snapshot().open_handles.empty(),
+            "append publication bytes drifted");
+    require(success.snapshot().all_authority_io_under_lock,
+            "append publication performed authority I/O outside the full lock");
+
+    for (const auto operation : publication_operations) {
+        for (const auto position :
+             {FaultPosition::Before, FaultPosition::After}) {
+            for (const auto action : {FaultAction::Error, FaultAction::Crash,
+                                      FaultAction::EffectThenError}) {
+                auto storage = baseline.clone();
+                auto authority =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                auto peer =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                storage.reset_observations();
+                storage.arm_fault(operation, position, action);
+                auto journal = storage.make_journal(generous_limits());
+                auto result = journal.append_and_publish(std::move(authority),
+                                                         chain.successor);
+                const bool authority_may_have_mutated =
+                    publication_may_have_mutated(operation, position, action);
+                const auto expected =
+                    (authority_may_have_mutated || preflight_may_have_effect(
+                                                       operation, position,
+                                                       action))
+                        ? DurableJournalStatus::RecoveryRequired
+                        : DurableJournalStatus::UnsupportedStorage;
+                require_result(
+                    result, expected,
+                    "publication fault returned the wrong stable outcome");
+                require(
+                    !authority.available(),
+                    "publication fault left the consumed handle write-capable");
+                if (action != FaultAction::Crash) {
+                    require_storage_released_after_return(
+                        storage,
+                        "publication fault retained an authority handle");
+                }
+                if (authority_may_have_mutated ||
+                    preflight_may_have_effect(operation, position, action)) {
+                    const auto before_fence = storage.snapshot();
+                    storage.reset_observations();
+                    auto fence = storage.make_journal(generous_limits());
+                    auto fenced = fence.append_and_publish(std::move(peer),
+                                                           chain.successor);
+                    require_result(
+                        fenced, DurableJournalStatus::RecoveryRequired,
+                        "possibly-effectful publication did not fence a "
+                        "pre-fault authority token");
+                    const auto after_fence = storage.snapshot();
+                    require(
+                        !peer.available() &&
+                            same_persistent_state(after_fence, before_fence) &&
+                            !after_fence.authority_mutation_attempted,
+                        "publication fence attempt changed authority");
+                    if (action != FaultAction::Crash) {
+                        require_storage_released_after_return(
+                            storage,
+                            "publication fence retained an authority handle");
+                    }
+                }
+                storage.restart();
+                const auto restart_snapshot = storage.snapshot();
+                storage.reset_observations();
+                auto recovered =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                const bool prior = recovered.root_bytes() ==
+                                   chain.genesis_root.canonical_bytes();
+                const bool successor = recovered.root_bytes() ==
+                                       chain.successor_root.canonical_bytes();
+                require(prior || successor,
+                        "publication crash recovered a synthesized root");
+                const auto recovered_snapshot = storage.snapshot();
+                require(
+                    recovered_snapshot.journal_bytes ==
+                            (prior ? frame(chain.genesis)
+                                   : frame(chain.genesis) +
+                                         frame(chain.successor)) &&
+                        recovered_snapshot.authority_root_bytes ==
+                            (prior ? chain.genesis_root.canonical_bytes()
+                                   : chain.successor_root.canonical_bytes()) &&
+                        stage_files_unchanged(restart_snapshot,
+                                              recovered_snapshot) &&
+                        recovered_snapshot.journal_durable,
+                    "recovery returned before exact fault-state repair was "
+                    "durable");
+                auto continuation = storage.make_journal(generous_limits());
+                auto continued = continuation.append_and_publish(
+                    std::move(recovered),
+                    prior ? chain.successor : chain.third);
+                require_result(
+                    continued, DurableJournalStatus::Published,
+                    "recovered authority could not continue appending");
+            }
+        }
+    }
+}
+
+void require_stale_cas_is_write_free() {
+    const auto chain = make_chain();
+    auto storage = JournalTestStorage::fresh();
+    static_cast<void>(create(storage, chain));
+    auto stale = recover(storage, chain.genesis_root.canonical_bytes());
+    auto stale_compaction =
+        recover(storage, chain.genesis_root.canonical_bytes());
+    auto winner = recover(storage, chain.genesis_root.canonical_bytes());
+    auto winning_journal = storage.make_journal(generous_limits());
+    auto published =
+        winning_journal.append_and_publish(std::move(winner), chain.successor);
+    require_result(published, DurableJournalStatus::Published,
+                   "CAS winner did not publish");
+
+    storage.reset_observations();
+    const auto before = storage.snapshot();
+    auto losing_journal = storage.make_journal(generous_limits());
+    auto conflict =
+        losing_journal.append_and_publish(std::move(stale), chain.successor);
+    require_result(conflict, DurableJournalStatus::ConflictBeforeWrite,
+                   "stale expected root did not conflict before write");
+    const auto after = storage.snapshot();
+    require(!stale.available() &&
+                after.authority_root_bytes == before.authority_root_bytes &&
+                after.journal_bytes == before.journal_bytes &&
+                !after.authority_mutation_attempted,
+            "CAS loser attempted an authority mutation");
+    require(after.root_read_before_journal_read &&
+                after.all_authority_io_under_lock,
+            "CAS comparison did not run root-first under the full lock");
+    require_storage_released_after_return(
+        storage, "stale append retained an authority handle");
+
+    storage.reset_observations();
+    const auto compaction_before = storage.snapshot();
+    auto stale_compaction_journal = storage.make_journal(generous_limits());
+    auto compact_conflict =
+        stale_compaction_journal.compact_physical(std::move(stale_compaction));
+    require_result(compact_conflict, DurableJournalStatus::ConflictBeforeWrite,
+                   "stale authority compacted current storage");
+    const auto compaction_after = storage.snapshot();
+    require(!stale_compaction.available() &&
+                same_persistent_state(compaction_after, compaction_before) &&
+                !compaction_after.authority_mutation_attempted &&
+                compaction_after.all_authority_io_under_lock &&
+                storage.attempt_count(FaultOperation::RootRead) > 0 &&
+                storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                storage.attempt_count(FaultOperation::JournalRead) == 0 &&
+                !has_stage_operation(compaction_after),
+            "stale compaction read or staged beyond the root CAS");
+    require_storage_released_after_return(
+        storage, "stale compaction retained an authority handle");
+
+    for (const auto stage : {FixedAuthorityChild::JournalStage,
+                             FixedAuthorityChild::RootStage}) {
+        auto stage_storage = JournalTestStorage::seeded(
+            frame(chain.genesis),
+            std::string(chain.genesis_root.canonical_bytes()));
+        auto stage_authority =
+            recover(stage_storage, chain.genesis_root.canonical_bytes());
+        stage_storage.overwrite_fixed_child_bytes(
+            stage, stage == FixedAuthorityChild::JournalStage
+                       ? "peer-journal-stage"
+                       : "peer-root-stage");
+        stage_storage.reset_observations();
+        const auto stage_before = stage_storage.snapshot();
+        auto stage_journal = stage_storage.make_journal(generous_limits());
+        auto stage_conflict =
+            stage_journal.compact_physical(std::move(stage_authority));
+        const auto stage_after = stage_storage.snapshot();
+        require_result(stage_conflict,
+                       DurableJournalStatus::RecoveryRequired,
+                       "compaction ignored peer stage-presence drift");
+        require(!stage_authority.available() &&
+                    same_persistent_state(stage_after, stage_before) &&
+                    !stage_after.authority_mutation_attempted &&
+                    stage_after.all_authority_io_under_lock &&
+                    stage_storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+                    stage_storage.attempt_count(FaultOperation::JournalOpen) ==
+                        0 &&
+                    !has_stage_operation(stage_after),
+                "stage-drift compaction read or mutated authority");
+        require_storage_released_after_return(
+            stage_storage, "stage-drift compaction retained an authority handle");
+        auto stage_recovered = recover(
+            stage_storage, chain.genesis_root.canonical_bytes());
+        static_cast<void>(stage_recovered);
+    }
+}
+
+void require_history_invalid_append_is_write_free() {
+    const auto chain = make_chain();
+    const auto other = make_chain("journal/other");
+    const auto wrong_predecessor = take_record(
+        parse_record_candidate(wrong_predecessor_wire),
+        "wrong-predecessor fixture was not independently canonical");
+    const auto illegal_transition = take_record(
+        parse_record_candidate(illegal_transition_wire),
+        "illegal-transition fixture was not independently canonical");
+    for (const ParsedJournalRecord *candidate :
+         {&chain.genesis, &chain.third, &other.successor, &wrong_predecessor,
+          &illegal_transition}) {
+        auto storage = JournalTestStorage::seeded(
+            frame(chain.genesis),
+            std::string(chain.genesis_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        const auto before = storage.snapshot();
+        auto journal = storage.make_journal(generous_limits());
+        auto result =
+            journal.append_and_publish(std::move(authority), *candidate);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "history-invalid canonical append was accepted");
+        require(!authority.available() &&
+                    same_persistent_state(storage.snapshot(), before) &&
+                    !storage.snapshot().authority_mutation_attempted &&
+                    storage.attempt_count(FaultOperation::JournalWrite) == 0,
+                "history-invalid append reached authority mutation");
+        require_storage_released_after_return(
+            storage, "history-invalid append retained an authority handle");
+    }
+}
+
+void require_partial_io_and_interrupt_retries() {
+    const auto chain = make_chain();
+    const auto one_frame = frame(chain.genesis);
+
+    const auto append_fault = [&](FaultOperation operation,
+                                  std::vector<FaultAction> actions,
+                                  std::string_view label) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame, std::string(chain.genesis_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        storage.arm_fault_sequence(operation, FaultPosition::Before,
+                                   std::move(actions));
+        auto journal = storage.make_journal(generous_limits());
+        auto published =
+            journal.append_and_publish(std::move(authority), chain.successor);
+        require_result(published, DurableJournalStatus::Published, label);
+        const auto snapshot = storage.snapshot();
+        require(snapshot.journal_bytes == one_frame + frame(chain.successor) &&
+                    snapshot.authority_root_bytes ==
+                        chain.successor_root.canonical_bytes() &&
+                    snapshot.journal_closed && snapshot.open_handles.empty() &&
+                    storage.attempt_count(operation) > 1,
+                "retried publication did not preserve exact closed bytes");
+        require(storage.attempt_count(FaultOperation::JournalClose) == 1 &&
+                    storage.attempt_count(FaultOperation::RootStageClose) == 1,
+                "publication close was retried or omitted");
+    };
+
+    for (const auto operation :
+         {FaultOperation::JournalWrite, FaultOperation::RootStageWrite}) {
+        append_fault(operation, {FaultAction::ShortWrite},
+                     "short publication write did not complete");
+        append_fault(
+            operation,
+            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce},
+            "interrupted publication write did not retry");
+    }
+    for (const auto operation :
+         {FaultOperation::JournalFlush, FaultOperation::RootStageFlush,
+          FaultOperation::NamespaceDurability}) {
+        append_fault(
+            operation,
+            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce},
+            "interrupted publication durability did not retry");
+    }
+
+    auto lock_storage = JournalTestStorage::seeded(
+        one_frame, std::string(chain.genesis_root.canonical_bytes()));
+    lock_storage.arm_fault_sequence(
+        FaultOperation::AuthorityLockAcquire, FaultPosition::Before,
+        {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
+    static_cast<void>(
+        recover(lock_storage, chain.genesis_root.canonical_bytes()));
+    require(lock_storage.attempt_count(FaultOperation::AuthorityLockAcquire) ==
+                3,
+            "interrupted whole-file lock was not retried");
+
+    for (const auto operation : {FaultOperation::TailRepairTruncate,
+                                 FaultOperation::TailRepairFlush}) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame + frame(chain.successor),
+            std::string(chain.genesis_root.canonical_bytes()));
+        storage.arm_fault_sequence(
+            operation, FaultPosition::Before,
+            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
+        static_cast<void>(
+            recover(storage, chain.genesis_root.canonical_bytes()));
+        require(storage.snapshot().journal_bytes == one_frame &&
+                    storage.attempt_count(operation) == 3 &&
+                    storage.attempt_count(FaultOperation::TailRepairClose) == 1,
+                "interrupted tail repair did not retry and close exactly");
+    }
+
+    for (const auto action :
+         {FaultAction::ShortWrite, FaultAction::InterruptedOnce}) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame + frame(chain.successor),
+            std::string(chain.successor_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        storage.arm_fault(FaultOperation::CompactionWrite,
+                          FaultPosition::Before, action);
+        auto journal = storage.make_journal(generous_limits());
+        auto compacted = journal.compact_physical(std::move(authority));
+        require_result(compacted, DurableJournalStatus::Published,
+                       "retryable compaction write did not complete");
+        require(storage.snapshot().journal_bytes ==
+                        one_frame + frame(chain.successor) &&
+                    storage.snapshot().authority_root_bytes ==
+                        chain.successor_root.canonical_bytes() &&
+                    storage.attempt_count(FaultOperation::CompactionWrite) >
+                        1 &&
+                    storage.attempt_count(FaultOperation::CompactionClose) == 1,
+                "compaction retry changed bytes or close discipline");
+    }
+
+    for (const auto operation :
+         {FaultOperation::CompactionFlush,
+          FaultOperation::CompactionNamespaceDurability}) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame + frame(chain.successor),
+            std::string(chain.successor_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        storage.arm_fault_sequence(
+            operation, FaultPosition::Before,
+            {FaultAction::InterruptedOnce, FaultAction::InterruptedOnce});
+        auto journal = storage.make_journal(generous_limits());
+        auto compacted = journal.compact_physical(std::move(authority));
+        require_result(compacted, DurableJournalStatus::Published,
+                       "interrupted compaction durability did not retry");
+        const auto snapshot = storage.snapshot();
+        require(snapshot.journal_bytes == one_frame + frame(chain.successor) &&
+                    snapshot.authority_root_bytes ==
+                        chain.successor_root.canonical_bytes() &&
+                    storage.attempt_count(operation) > 1 &&
+                    storage.attempt_count(FaultOperation::CompactionClose) == 1,
+                "compaction durability retry changed exact closed bytes");
+    }
+
+    const auto require_create_close = [&](FaultOperation operation,
+                                          FaultAction action,
+                                          FaultOperation close_operation) {
+        auto storage = JournalTestStorage::fresh();
+        storage.arm_fault(operation, FaultPosition::Before, action);
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "create close-path fault changed outcome");
+        require(storage.attempt_count(close_operation) == 1 &&
+                    storage.snapshot().open_handles.empty(),
+                "create failure omitted or retried checked close");
+    };
+    require_create_close(FaultOperation::InitialJournalCreate,
+                         FaultAction::EffectThenError,
+                         FaultOperation::JournalClose);
+    require_create_close(FaultOperation::JournalWrite, FaultAction::Error,
+                         FaultOperation::JournalClose);
+    require_create_close(FaultOperation::JournalFlush, FaultAction::Error,
+                         FaultOperation::JournalClose);
+    require_create_close(FaultOperation::JournalClose, FaultAction::Error,
+                         FaultOperation::JournalClose);
+    require_create_close(FaultOperation::RootStageCreate,
+                         FaultAction::EffectThenError,
+                         FaultOperation::RootStageClose);
+    require_create_close(FaultOperation::RootStageWrite, FaultAction::Error,
+                         FaultOperation::RootStageClose);
+    require_create_close(FaultOperation::RootStageFlush, FaultAction::Error,
+                         FaultOperation::RootStageClose);
+    require_create_close(FaultOperation::RootStageClose, FaultAction::Error,
+                         FaultOperation::RootStageClose);
+
+    const auto require_append_close = [&](FaultOperation operation,
+                                          FaultPosition position,
+                                          FaultAction action,
+                                          FaultOperation close_operation,
+                                          DurableJournalStatus expected) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame, std::string(chain.genesis_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        const auto before = storage.snapshot();
+        storage.arm_fault(operation, position, action);
+        auto journal = storage.make_journal(generous_limits());
+        auto result =
+            journal.append_and_publish(std::move(authority), chain.successor);
+        require_result(result, expected,
+                       "publication close-path fault changed outcome");
+        require(!authority.available() &&
+                    storage.attempt_count(close_operation) == 1 &&
+                    storage.snapshot().open_handles.empty(),
+                "publication failure omitted or retried checked close");
+        if (operation == FaultOperation::JournalAppendOpen) {
+            require(
+                same_persistent_state(storage.snapshot(), before) &&
+                    !storage.snapshot().authority_mutation_attempted &&
+                    storage.attempt_count(FaultOperation::JournalWrite) == 0 &&
+                    storage.attempt_count(FaultOperation::RootStageCreate) == 0,
+                "journal-open failure reached publication mutation");
+        }
+    };
+    require_append_close(FaultOperation::JournalAppendOpen,
+                         FaultPosition::Before, FaultAction::EffectThenError,
+                         FaultOperation::JournalClose,
+                         DurableJournalStatus::UnsupportedStorage);
+    require_append_close(FaultOperation::JournalAppendOpen,
+                         FaultPosition::After, FaultAction::Error,
+                         FaultOperation::JournalClose,
+                         DurableJournalStatus::UnsupportedStorage);
+    require_append_close(FaultOperation::JournalWrite, FaultPosition::Before,
+                         FaultAction::Error, FaultOperation::JournalClose,
+                         DurableJournalStatus::UnsupportedStorage);
+    require_append_close(FaultOperation::JournalFlush, FaultPosition::Before,
+                         FaultAction::Error, FaultOperation::JournalClose,
+                         DurableJournalStatus::RecoveryRequired);
+    require_append_close(FaultOperation::JournalClose, FaultPosition::Before,
+                         FaultAction::Error, FaultOperation::JournalClose,
+                         DurableJournalStatus::RecoveryRequired);
+    require_append_close(FaultOperation::RootStageCreate, FaultPosition::Before,
+                         FaultAction::EffectThenError,
+                         FaultOperation::RootStageClose,
+                         DurableJournalStatus::RecoveryRequired);
+    require_append_close(FaultOperation::RootStageWrite, FaultPosition::Before,
+                         FaultAction::Error, FaultOperation::RootStageClose,
+                         DurableJournalStatus::RecoveryRequired);
+    require_append_close(FaultOperation::RootStageFlush, FaultPosition::Before,
+                         FaultAction::Error, FaultOperation::RootStageClose,
+                         DurableJournalStatus::RecoveryRequired);
+    require_append_close(FaultOperation::RootStageClose, FaultPosition::Before,
+                         FaultAction::Error, FaultOperation::RootStageClose,
+                         DurableJournalStatus::RecoveryRequired);
+
+    for (const auto &[position, action] :
+         {std::pair{FaultPosition::Before, FaultAction::EffectThenError},
+          std::pair{FaultPosition::After, FaultAction::Error}}) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame + frame(chain.successor),
+            std::string(chain.genesis_root.canonical_bytes()));
+        storage.reset_observations();
+        const auto before = storage.snapshot();
+        storage.arm_fault(FaultOperation::TailRepairOpen, position, action);
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+        require_result(result, DurableJournalStatus::UnsupportedStorage,
+                       "tail-open close-path fault changed outcome");
+        const auto after = storage.snapshot();
+        require(storage.attempt_count(FaultOperation::TailRepairClose) == 1 &&
+                    storage.attempt_count(FaultOperation::TailRepairTruncate) ==
+                        0 &&
+                    after.open_handles.empty() &&
+                    same_persistent_state(after, before) &&
+                    !after.authority_mutation_attempted,
+                "tail-open failure omitted close or reached truncation");
+    }
+
+    for (const auto &[operation, expected] :
+         {std::pair{FaultOperation::TailRepairTruncate,
+                    DurableJournalStatus::UnsupportedStorage},
+          std::pair{FaultOperation::TailRepairFlush,
+                    DurableJournalStatus::RecoveryRequired},
+          std::pair{FaultOperation::TailRepairClose,
+                    DurableJournalStatus::RecoveryRequired}}) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame + frame(chain.successor),
+            std::string(chain.genesis_root.canonical_bytes()));
+        storage.reset_observations();
+        storage.arm_fault(operation, FaultPosition::Before, FaultAction::Error);
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+        require_result(result, expected,
+                       "tail close-path fault changed outcome");
+        require(storage.attempt_count(FaultOperation::TailRepairClose) == 1 &&
+                    storage.snapshot().open_handles.empty(),
+                "tail repair failure omitted or retried checked close");
+    }
+
+    for (const auto operation :
+         {FaultOperation::CompactionStageCreate,
+          FaultOperation::CompactionWrite, FaultOperation::CompactionFlush,
+          FaultOperation::CompactionClose}) {
+        auto storage = JournalTestStorage::seeded(
+            one_frame + frame(chain.successor),
+            std::string(chain.successor_root.canonical_bytes()));
+        auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+        storage.reset_observations();
+        storage.arm_fault(operation, FaultPosition::Before,
+                          operation == FaultOperation::CompactionStageCreate
+                              ? FaultAction::EffectThenError
+                              : FaultAction::Error);
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.compact_physical(std::move(authority));
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "compaction close-path fault changed outcome");
+        require(storage.attempt_count(FaultOperation::CompactionClose) == 1 &&
+                    storage.snapshot().open_handles.empty(),
+                "compaction failure omitted or retried checked close");
+    }
+}
+
+void require_stable_lock_identity() {
+    const auto chain = make_chain();
+    for (const auto platform :
+         {PlatformContract::Linux, PlatformContract::Windows,
+          PlatformContract::MacOS}) {
+        auto storage = JournalTestStorage::seeded(
+            frame(chain.genesis),
+            std::string(chain.genesis_root.canonical_bytes()), platform);
+        storage.pause_after(FaultOperation::AuthorityLockAcquire);
+
+        std::optional<DurableJournalStatus> holder_status;
+        std::optional<DurableJournalStatus> waiter_status;
+        std::thread holder([&] {
+            auto journal = storage.make_journal(generous_limits());
+            holder_status =
+                journal
+                    .recover_existing(TrustedReplayFloor::exact_root(
+                        std::string(chain.genesis_root.canonical_bytes())))
+                    .status;
+        });
+        require(storage.wait_until_paused(5000),
+                "lock holder did not reach the deterministic pause");
+        const auto old_identity = storage.lock_identity();
+
+        std::thread waiter([&] {
+            auto journal = storage.make_journal(generous_limits());
+            waiter_status =
+                journal
+                    .recover_existing(TrustedReplayFloor::exact_root(
+                        std::string(chain.genesis_root.canonical_bytes())))
+                    .status;
+        });
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (storage.attempt_count(FaultOperation::AuthorityLockOpen) < 2) {
+            require(std::chrono::steady_clock::now() < deadline,
+                    "lock waiter did not open the stable entry");
+            std::this_thread::yield();
+        }
+
+        if (platform == PlatformContract::Windows) {
+            require(!storage.try_unlink_lock_file() &&
+                        !storage.try_recreate_lock_file() &&
+                        !storage.try_replace_lock_with_reparse_point(),
+                    "Windows lock handle allowed delete-sharing replacement");
+        } else {
+            require(storage.try_unlink_lock_file() &&
+                        storage.try_recreate_lock_file() &&
+                        storage.lock_identity() != old_identity,
+                    "POSIX lock replacement did not create a new identity");
+        }
+        storage.release_pause();
+        holder.join();
+        waiter.join();
+
+        if (platform == PlatformContract::Windows) {
+            require(holder_status == DurableJournalStatus::Published &&
+                        waiter_status == DurableJournalStatus::Published &&
+                        storage.lock_identity() == old_identity,
+                    "Windows stable lock did not serialize both readers");
+            auto unlocked = JournalTestStorage::fresh(platform);
+            require(unlocked.try_recreate_lock_file() &&
+                        unlocked.try_replace_lock_with_reparse_point(),
+                    "closed Windows lock lacked replacement positive control");
+        } else {
+            const std::multiset<DurableJournalStatus> statuses{*holder_status,
+                                                               *waiter_status};
+            const std::multiset<DurableJournalStatus> expected{
+                DurableJournalStatus::UnsupportedStorage,
+                DurableJournalStatus::UnsupportedStorage};
+            require(statuses == expected,
+                    "POSIX replaced-lock waiters did not fail closed");
+            const auto failed_waiters = storage.snapshot();
+            require(std::none_of(failed_waiters.observations.begin(),
+                                 failed_waiters.observations.end(),
+                                 [](const OperationObservation &observation) {
+                                     return observation.operation ==
+                                                FaultOperation::RootOpen ||
+                                            observation.operation ==
+                                                FaultOperation::RootRead ||
+                                            observation.operation ==
+                                                FaultOperation::JournalOpen ||
+                                            observation.operation ==
+                                                FaultOperation::JournalRead;
+                                 }) &&
+                        failed_waiters.open_handles.empty() &&
+                        !failed_waiters.authority_mutation_attempted,
+                    "replaced-lock waiter reached authority I/O before "
+                    "failing closed");
+            const auto replacement_identity = storage.lock_identity();
+            storage.reset_observations();
+            auto retry = storage.make_journal(generous_limits());
+            auto retried =
+                retry.recover_existing(TrustedReplayFloor::exact_root(
+                    std::string(chain.genesis_root.canonical_bytes())));
+            require_result(retried, DurableJournalStatus::Published,
+                           "stable replacement identity was not recoverable");
+            const auto retry_snapshot = storage.snapshot();
+            require(
+                std::all_of(
+                    retry_snapshot.observations.begin(),
+                    retry_snapshot.observations.end(),
+                    [&](const OperationObservation &observation) {
+                        if (observation.operation ==
+                                FaultOperation::AuthorityIdentityRead ||
+                            observation.operation == FaultOperation::RootOpen ||
+                            observation.operation == FaultOperation::RootRead ||
+                            observation.operation ==
+                                FaultOperation::JournalOpen ||
+                            observation.operation ==
+                                FaultOperation::JournalRead) {
+                            return observation.lock_held &&
+                                   observation.lock_identity ==
+                                       replacement_identity;
+                        }
+                        return true;
+                    }),
+                "new caller used the stale lock identity for authority I/O");
+        }
+        require(storage.snapshot().open_handles.empty() &&
+                    !storage.snapshot().authority_mutation_attempted,
+                "lock replacement leaked a handle or mutated authority");
+    }
+}
+
+void require_fence_epoch_cas_clear() {
+    const auto chain = make_chain();
+    const auto root = std::string(chain.genesis_root.canonical_bytes());
+    auto storage = JournalTestStorage::seeded(frame(chain.genesis), root);
+    auto during_unlock_peer = recover(storage, root);
+    auto after_unlock_peer = recover(storage, root);
+    storage.overwrite_fixed_child_bytes(
+        FixedAuthorityChild::Journal,
+        frame(chain.genesis) + frame(chain.successor));
+
+    storage.reset_observations();
+    storage.arm_fault(FaultOperation::AuthorityUnlock, FaultPosition::After,
+                      FaultAction::Error);
+    storage.pause_after(FaultOperation::AuthorityUnlock);
+    std::optional<DurableJournalResult> repairing_result;
+    std::thread repairing([&] {
+        auto journal = storage.make_journal(generous_limits());
+        repairing_result.emplace(journal.recover_existing(
+            TrustedReplayFloor::exact_root(root)));
+    });
+    require(storage.wait_until_paused(5000),
+            "tail repair did not pause after the unlock effect");
+
+    storage.reset_observations();
+    const auto during_unlock_before = storage.snapshot();
+    auto during_unlock_journal = storage.make_journal(generous_limits());
+    auto blocked_during_unlock = during_unlock_journal.append_and_publish(
+        std::move(during_unlock_peer), chain.successor);
+    const auto during_unlock_after = storage.snapshot();
+    require_result(blocked_during_unlock,
+                   DurableJournalStatus::RecoveryRequired,
+                   "tail repair exposed an unlock-before-fence window");
+    require(!during_unlock_peer.available() &&
+                storage.attempt_count(FaultOperation::AuthorityLockOpen) == 0 &&
+                same_persistent_state(during_unlock_after,
+                                      during_unlock_before) &&
+                !during_unlock_after.authority_mutation_attempted,
+            "tail-repair provisional fence allowed authority I/O");
+
+    storage.release_pause();
+    repairing.join();
+    require(repairing_result.has_value(),
+            "paused tail repair did not return after unlock");
+    require_result(*repairing_result, DurableJournalStatus::RecoveryRequired,
+                   "effectful unlock failure did not retain its fence");
+
+    storage.reset_observations();
+    const auto fenced_before = storage.snapshot();
+    auto blocked_writer = storage.make_journal(generous_limits());
+    auto blocked = blocked_writer.append_and_publish(
+        std::move(after_unlock_peer), chain.successor);
+    const auto fenced_after = storage.snapshot();
+    require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                   "unlock failure did not retain its provisional fence");
+    require(!after_unlock_peer.available() &&
+                storage.attempt_count(FaultOperation::AuthorityLockOpen) == 0 &&
+                same_persistent_state(fenced_after, fenced_before) &&
+                !fenced_after.authority_mutation_attempted,
+            "retained process fence allowed authority I/O or mutation");
+
+    auto recovered = recover(storage, root);
+    auto continuation = storage.make_journal(generous_limits());
+    auto continued = continuation.append_and_publish(std::move(recovered),
+                                                     chain.successor);
+    require_result(continued, DurableJournalStatus::Published,
+                   "locked recovery did not clear the retained process fence");
+
+    auto epoch_storage =
+        JournalTestStorage::seeded(frame(chain.genesis), root);
+    auto before_resume_peer = recover(epoch_storage, root);
+    auto after_resume_peer = recover(epoch_storage, root);
+    epoch_storage.overwrite_fixed_child_bytes(
+        FixedAuthorityChild::Journal,
+        frame(chain.genesis) + frame(chain.successor));
+
+    epoch_storage.reset_observations();
+    epoch_storage.pause_after(FaultOperation::AuthorityUnlock);
+    std::optional<DurableJournalResult> epoch_clearing_result;
+    std::thread epoch_clearing([&] {
+        auto journal = epoch_storage.make_journal(generous_limits());
+        epoch_clearing_result.emplace(journal.recover_existing(
+            TrustedReplayFloor::exact_root(root)));
+    });
+    require(epoch_storage.wait_until_paused(5000),
+            "epoch-clearing recovery did not pause after unlock");
+
+    epoch_storage.overwrite_fixed_child_bytes(
+        FixedAuthorityChild::Journal,
+        frame(chain.genesis) + frame(chain.successor));
+    epoch_storage.arm_fault(FaultOperation::TailRepairTruncate,
+                            FaultPosition::After, FaultAction::Error);
+    auto replacement_journal = epoch_storage.make_journal(generous_limits());
+    auto replacement = replacement_journal.recover_existing(
+        TrustedReplayFloor::exact_root(root));
+    require_result(replacement, DurableJournalStatus::RecoveryRequired,
+                   "effectful tail repair did not publish a replacement epoch");
+
+    epoch_storage.reset_observations();
+    const auto before_resume = epoch_storage.snapshot();
+    auto before_resume_journal =
+        epoch_storage.make_journal(generous_limits());
+    auto blocked_before_resume = before_resume_journal.append_and_publish(
+        std::move(before_resume_peer), chain.successor);
+    const auto after_blocked_before_resume = epoch_storage.snapshot();
+    require_result(blocked_before_resume, DurableJournalStatus::RecoveryRequired,
+                   "replacement epoch did not fence before older recovery");
+    require(!before_resume_peer.available() &&
+                epoch_storage.attempt_count(
+                    FaultOperation::AuthorityLockOpen) == 0 &&
+                same_persistent_state(after_blocked_before_resume,
+                                      before_resume) &&
+                !after_blocked_before_resume.authority_mutation_attempted,
+            "replacement epoch allowed pre-resume authority I/O");
+
+    epoch_storage.release_pause();
+    epoch_clearing.join();
+    require(epoch_clearing_result.has_value() &&
+                epoch_clearing_result->published(),
+            "older epoch recovery did not complete after successful unlock");
+
+    epoch_storage.reset_observations();
+    const auto after_resume = epoch_storage.snapshot();
+    auto after_resume_journal = epoch_storage.make_journal(generous_limits());
+    auto blocked_after_resume = after_resume_journal.append_and_publish(
+        std::move(after_resume_peer), chain.successor);
+    const auto after_blocked_after_resume = epoch_storage.snapshot();
+    require_result(blocked_after_resume, DurableJournalStatus::RecoveryRequired,
+                   "older recovery erased its replacement epoch");
+    require(!after_resume_peer.available() &&
+                epoch_storage.attempt_count(
+                    FaultOperation::AuthorityLockOpen) == 0 &&
+                same_persistent_state(after_blocked_after_resume,
+                                      after_resume) &&
+                !after_blocked_after_resume.authority_mutation_attempted,
+            "replacement epoch allowed post-resume authority I/O");
+
+    auto epoch_recovered = recover(epoch_storage, root);
+    auto epoch_continuation = epoch_storage.make_journal(generous_limits());
+    auto epoch_continued = epoch_continuation.append_and_publish(
+        std::move(epoch_recovered), chain.successor);
+    require_result(epoch_continued, DurableJournalStatus::Published,
+                   "locked recovery did not clear the replacement epoch");
+}
+
+void require_fake_storage_identity_binding() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    const auto root = std::string(chain.genesis_root.canonical_bytes());
+    auto storage_a = JournalTestStorage::seeded(committed, root);
+    auto storage_b = JournalTestStorage::seeded(committed, root);
+
+    auto initialize_a = recover(storage_a, root);
+    auto initialize_b = recover(storage_b, root);
+    static_cast<void>(initialize_a);
+    static_cast<void>(initialize_b);
+    storage_b.alias_lock_identity_from(storage_a);
+
+    auto append_token = recover(storage_a, root);
+    storage_b.reset_observations();
+    const auto append_before = storage_b.snapshot();
+    auto b_append = storage_b.make_journal(generous_limits());
+    auto append_result =
+        b_append.append_and_publish(std::move(append_token), chain.successor);
+    require_result(append_result, DurableJournalStatus::CorruptOrRollback,
+                   "cross-storage append accepted byte-identical authority");
+    require(!append_token.available() &&
+                same_persistent_state(storage_b.snapshot(), append_before) &&
+                !storage_b.snapshot().authority_mutation_attempted &&
+                storage_b.attempt_count(
+                    FaultOperation::AuthorityIdentityRead) == 1 &&
+                storage_b.attempt_count(FaultOperation::RootOpen) == 0 &&
+                storage_b.attempt_count(FaultOperation::RootRead) == 0 &&
+                storage_b.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                storage_b.attempt_count(FaultOperation::JournalRead) == 0 &&
+                storage_b.snapshot().all_authority_io_under_lock,
+            "cross-storage append read or mutated journal authority");
+    require_storage_released_after_return(
+        storage_b, "cross-storage append retained an authority handle");
+
+    auto compact_token = recover(storage_a, root);
+    storage_b.reset_observations();
+    const auto compact_before = storage_b.snapshot();
+    auto b_compact = storage_b.make_journal(generous_limits());
+    auto compact_result = b_compact.compact_physical(std::move(compact_token));
+    require_result(
+        compact_result, DurableJournalStatus::CorruptOrRollback,
+        "cross-storage compaction accepted byte-identical authority");
+    require(!compact_token.available() &&
+                same_persistent_state(storage_b.snapshot(), compact_before) &&
+                !storage_b.snapshot().authority_mutation_attempted &&
+                storage_b.attempt_count(
+                    FaultOperation::AuthorityIdentityRead) == 1 &&
+                storage_b.attempt_count(FaultOperation::RootOpen) == 0 &&
+                storage_b.attempt_count(FaultOperation::RootRead) == 0 &&
+                storage_b.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                storage_b.attempt_count(FaultOperation::JournalRead) == 0 &&
+                storage_b.snapshot().all_authority_io_under_lock,
+            "cross-storage compaction read or mutated journal authority");
+    require_storage_released_after_return(
+        storage_b, "cross-storage compaction retained an authority handle");
+
+    auto export_token = recover(storage_a, root);
+    storage_b.reset_observations();
+    const auto export_before = storage_b.snapshot();
+    auto b_export = storage_b.make_journal(generous_limits());
+    auto export_result = b_export.export_exact_schema_candidate(
+        export_token, supported_journal_schema, JournalQuiescence::Confirmed);
+    require(
+        export_result.status == ExactSchemaExportStatus::CorruptOrRollback &&
+            !export_result.exported() && !export_result.candidate.has_value() &&
+            export_token.available() &&
+            same_persistent_state(storage_b.snapshot(), export_before) &&
+            !storage_b.snapshot().authority_mutation_attempted &&
+            storage_b.attempt_count(FaultOperation::AuthorityIdentityRead) ==
+                1 &&
+            storage_b.attempt_count(FaultOperation::RootOpen) == 0 &&
+            storage_b.attempt_count(FaultOperation::RootRead) == 0 &&
+            storage_b.attempt_count(FaultOperation::JournalOpen) == 0 &&
+            storage_b.attempt_count(FaultOperation::JournalRead) == 0 &&
+            storage_b.snapshot().all_authority_io_under_lock,
+        "cross-storage export authorized or read byte-identical storage");
+    require_storage_released_after_return(
+        storage_b, "cross-storage export retained an authority handle");
+
+    auto same_storage = storage_a.make_journal(generous_limits());
+    auto published = same_storage.append_and_publish(std::move(export_token),
+                                                     chain.successor);
+    require_result(published, DurableJournalStatus::Published,
+                   "fresh adapter for the same storage rejected its token");
+}
+
+void require_fake_lock_recreation_invalidates_authority() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    const auto root = std::string(chain.genesis_root.canonical_bytes());
+
+    const auto replace_lock = [](JournalTestStorage &storage) {
+        const auto old_identity = storage.lock_identity();
+        require(old_identity != 0 && storage.try_unlink_lock_file() &&
+                    storage.try_recreate_lock_file() &&
+                    storage.lock_identity() != 0 &&
+                    storage.lock_identity() != old_identity,
+                "fake stable lock was not recreated with a new identity");
+        storage.reset_observations();
+    };
+    const auto require_rejection_trace = [](JournalTestStorage &storage,
+                                            const NamespaceSnapshot &before,
+                                            std::string_view label) {
+        const auto after = storage.snapshot();
+        require(same_persistent_state(after, before) &&
+                    !after.authority_mutation_attempted &&
+                    after.all_authority_io_under_lock &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityIdentityRead) == 1 &&
+                    storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+                    storage.attempt_count(FaultOperation::RootRead) == 0 &&
+                    storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                    storage.attempt_count(FaultOperation::JournalRead) == 0,
+                label);
+        require_storage_released_after_return(
+            storage, "recreated-lock rejection retained an authority handle");
+        auto rebound = recover(storage, before.authority_root_bytes);
+        require(rebound.available(),
+                "fresh recovery did not bind the recreated stable lock");
+    };
+
+    auto append_storage = JournalTestStorage::seeded(committed, root);
+    auto append_token = recover(append_storage, root);
+    replace_lock(append_storage);
+    const auto append_before = append_storage.snapshot();
+    auto append_journal = append_storage.make_journal(generous_limits());
+    auto append_result = append_journal.append_and_publish(
+        std::move(append_token), chain.successor);
+    require_result(append_result, DurableJournalStatus::UnsupportedStorage,
+                   "recreated stable lock accepted an old append token");
+    require(!append_token.available(),
+            "recreated-lock append did not consume its token");
+    require_rejection_trace(append_storage, append_before,
+                            "recreated-lock append reached authority I/O");
+
+    auto compact_storage = JournalTestStorage::seeded(committed, root);
+    auto compact_token = recover(compact_storage, root);
+    replace_lock(compact_storage);
+    const auto compact_before = compact_storage.snapshot();
+    auto compact_journal = compact_storage.make_journal(generous_limits());
+    auto compact_result =
+        compact_journal.compact_physical(std::move(compact_token));
+    require_result(compact_result, DurableJournalStatus::UnsupportedStorage,
+                   "recreated stable lock accepted an old compaction token");
+    require(!compact_token.available(),
+            "recreated-lock compaction did not consume its token");
+    require_rejection_trace(compact_storage, compact_before,
+                            "recreated-lock compaction reached authority I/O");
+
+    auto export_storage = JournalTestStorage::seeded(committed, root);
+    auto export_token = recover(export_storage, root);
+    replace_lock(export_storage);
+    const auto export_before = export_storage.snapshot();
+    auto export_journal = export_storage.make_journal(generous_limits());
+    auto export_result = export_journal.export_exact_schema_candidate(
+        export_token, supported_journal_schema, JournalQuiescence::Confirmed);
+    require(
+        export_result.status == ExactSchemaExportStatus::UnsupportedStorage &&
+            !export_result.exported() && !export_result.candidate.has_value() &&
+            export_token.available(),
+        "recreated stable lock accepted or consumed an old export token");
+    require_rejection_trace(export_storage, export_before,
+                            "recreated-lock export reached authority I/O");
+}
+
+void require_directory_lineage_fence_cleanup() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    const auto root = std::string(chain.genesis_root.canonical_bytes());
+    auto storage = JournalTestStorage::seeded(committed, root);
+    auto failing_authority = recover(storage, root);
+    auto stale_authority = recover(storage, root);
+
+    storage.arm_fault(FaultOperation::JournalWrite, FaultPosition::After,
+                      FaultAction::Error);
+    auto failing_journal = storage.make_journal(generous_limits());
+    auto failed = failing_journal.append_and_publish(
+        std::move(failing_authority), chain.successor);
+    require_result(failed, DurableJournalStatus::RecoveryRequired,
+                   "effectful append did not install a lineage fence");
+    require(storage.snapshot().journal_bytes ==
+                committed + frame(chain.successor) &&
+                storage.snapshot().authority_root_bytes == root,
+            "lineage-fence setup did not leave a recoverable tail");
+
+    const auto old_lock_identity = storage.lock_identity();
+    require(old_lock_identity != 0 && storage.try_unlink_lock_file() &&
+                storage.try_recreate_lock_file() &&
+                storage.lock_identity() != old_lock_identity,
+            "lineage-fence setup did not replace the stable lock");
+    auto rebound = recover(storage, root);
+
+    storage.reset_observations();
+    auto stale_journal = storage.make_journal(generous_limits());
+    auto stale = stale_journal.append_and_publish(std::move(stale_authority),
+                                                   chain.successor);
+    require_result(stale, DurableJournalStatus::UnsupportedStorage,
+                   "cleared lineage fence reauthorized an old lock token");
+    require(!stale_authority.available() &&
+                storage.attempt_count(FaultOperation::AuthorityLockOpen) == 1 &&
+                storage.attempt_count(
+                    FaultOperation::AuthorityIdentityRead) == 1 &&
+                storage.attempt_count(FaultOperation::RootOpen) == 0 &&
+                storage.attempt_count(FaultOperation::JournalOpen) == 0,
+            "directory-lineage cleanup retained an obsolete full-identity "
+            "fence");
+
+    auto continuation = storage.make_journal(generous_limits());
+    auto continued = continuation.append_and_publish(std::move(rebound),
+                                                      chain.successor);
+    require_result(continued, DurableJournalStatus::Published,
+                   "directory-lineage recovery did not clear its fence");
+}
+
+void require_fenced_fresh_create_reconciles() {
+    const auto chain = make_chain();
+    auto storage = JournalTestStorage::fresh();
+    storage.arm_fault(FaultOperation::InitialJournalCreate,
+                      FaultPosition::After, FaultAction::Error);
+    auto failed_create = storage.make_journal(generous_limits());
+    auto failed = failed_create.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(failed, DurableJournalStatus::RecoveryRequired,
+                   "effectful create did not install a process fence");
+    storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
+
+    storage.reset_observations();
+    const auto before_failed_inspection = storage.snapshot();
+    storage.arm_fault(FaultOperation::FixedNamespaceInspect,
+                      FaultPosition::Before, FaultAction::Error);
+    auto failed_inspector = storage.make_journal(generous_limits());
+    auto inspection_failure = failed_inspector.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(
+        inspection_failure, DurableJournalStatus::RecoveryRequired,
+        "failed fresh-namespace inspection discarded a retained fence");
+    require(!inspection_failure.journal.has_value() &&
+                same_persistent_state(storage.snapshot(),
+                                      before_failed_inspection) &&
+                !storage.snapshot().authority_mutation_attempted,
+            "failed fresh-namespace inspection changed authority");
+    require_storage_released_after_return(
+        storage, "failed fresh-namespace inspection retained a handle");
+
+    storage.reset_observations();
+    const auto before = storage.snapshot();
+    auto retried_create = storage.make_journal(generous_limits());
+    auto retried = retried_create.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    const auto after = storage.snapshot();
+    require_result(retried, DurableJournalStatus::Published,
+                   "fresh namespace create did not reconcile its fence");
+    require(retried.journal.has_value() && retried.journal->available() &&
+                !same_persistent_state(after, before) &&
+                after.authority_mutation_attempted &&
+                after.journal_bytes == frame(chain.genesis) &&
+                after.authority_root_bytes ==
+                    chain.genesis_root.canonical_bytes() &&
+                after.all_authority_io_under_lock,
+            "fenced create did not verify and publish a fresh namespace");
+    require_storage_released_after_return(
+        storage, "fenced create retained an authority handle");
+}
+
+template <typename Mutation>
+DurableJournalResult create_after_paused_operation(
+    JournalTestStorage &storage, const Chain &chain, FaultOperation operation,
+    Mutation mutation, std::string_view pause_failure,
+    std::size_t occurrence = 1) {
+    storage.pause_after_nth(operation, occurrence);
+    std::optional<DurableJournalResult> result;
+    std::thread creator([&] {
+        auto journal = storage.make_journal(generous_limits());
+        result.emplace(journal.create_new(TrustedReplayFloor::uninitialized(),
+                                          chain.genesis));
+    });
+    if (!storage.wait_until_paused(5000)) {
+        storage.release_pause();
+        creator.join();
+        require(false, pause_failure);
+    }
+    mutation();
+    storage.release_pause();
+    creator.join();
+    require(result.has_value(), "paused create did not return");
+    return std::move(*result);
+}
+
+void require_create_post_failure_clearance_proof() {
+    const auto chain = make_chain();
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto journal = storage.make_journal(generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::UnsupportedStorage,
+                       "proven before-effect create failure stayed fenced");
+        const auto after = storage.snapshot();
+        require(after.journal_bytes.empty() &&
+                    after.authority_root_bytes.empty() &&
+                    after.stage_files_absent &&
+                    !after.authority_mutation_attempted,
+                "before-effect create failure changed authority");
+        auto retry = storage.make_journal(generous_limits());
+        auto retried = retry.create_new(TrustedReplayFloor::uninitialized(),
+                                        chain.genesis);
+        require_result(retried, DurableJournalStatus::Published,
+                       "proven before-effect create failure retained its fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::After, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
+            },
+            "create did not pause after an effect-uncertain failure", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "effect-uncertain create cleared a fresh fence");
+        const auto after = storage.snapshot();
+        require(after.journal_bytes.empty() &&
+                    after.authority_root_bytes.empty() &&
+                    after.stage_files_absent &&
+                    after.authority_mutation_attempted,
+                "effect-uncertain create fixture changed its final namespace");
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear an effect-uncertain fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        auto stale_peer = create(storage, chain);
+        storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
+        storage.remove_fixed_child_file(FixedAuthorityChild::Root);
+        storage.reset_observations();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                storage.arm_fault(FaultOperation::FixedNamespaceInspect,
+                                  FaultPosition::After, FaultAction::Error);
+            },
+            "create did not pause during post-create inspection", 2);
+        require_result(
+            result, DurableJournalStatus::RecoveryRequired,
+            "failed post-create inspection cleared a provisional fence");
+        const auto fenced = storage.snapshot();
+        require(fenced.journal_bytes.empty() &&
+                    fenced.authority_root_bytes.empty() &&
+                    fenced.stage_files_absent &&
+                    !fenced.authority_mutation_attempted,
+                "failed post-create inspection changed authority");
+        storage.reset_observations();
+        const auto before_peer = storage.snapshot();
+        auto peer = storage.make_journal(generous_limits());
+        auto blocked = peer.append_and_publish(std::move(stale_peer),
+                                               chain.successor);
+        require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                       "failed post-create inspection did not retain its fence");
+        const auto after_peer = storage.snapshot();
+        require(!stale_peer.available() &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityLockOpen) == 0 &&
+                    same_persistent_state(after_peer, before_peer) &&
+                    !after_peer.authority_mutation_attempted,
+                "post-create inspection fence allowed peer authority I/O");
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear an inspection fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        auto stale_peer = create(storage, chain);
+        storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
+        storage.remove_fixed_child_file(FixedAuthorityChild::Root);
+        storage.reset_observations();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                storage.arm_fault(FaultOperation::AuthorityIdentityRead,
+                                  FaultPosition::Before,
+                                  FaultAction::Error);
+            },
+            "create did not pause before post-create identity validation", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "failed post-create identity read cleared its fence");
+        require(!result.published() && !result.journal.has_value(),
+                "failed post-create identity read returned authority");
+        const auto fenced = storage.snapshot();
+        require(fenced.journal_bytes.empty() &&
+                    fenced.authority_root_bytes.empty() &&
+                    fenced.stage_files_absent &&
+                    !fenced.authority_mutation_attempted,
+                "failed post-create identity read changed authority");
+        storage.reset_observations();
+        const auto before_peer = storage.snapshot();
+        auto peer = storage.make_journal(generous_limits());
+        auto blocked = peer.append_and_publish(std::move(stale_peer),
+                                               chain.successor);
+        require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                       "failed identity read did not retain its fence");
+        const auto after_peer = storage.snapshot();
+        require(!stale_peer.available() &&
+                    storage.attempt_count(
+                        FaultOperation::AuthorityLockOpen) == 0 &&
+                    same_persistent_state(after_peer, before_peer) &&
+                    !after_peer.authority_mutation_attempted,
+                "identity-read fence allowed peer authority I/O");
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear an identity-read fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                storage.seed_untrusted_file("journal.jsonl",
+                                            "post-create-journal");
+            },
+            "create did not pause during post-create journal inspection", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "post-create journal residue cleared its fence");
+        const auto fenced = storage.snapshot();
+        require(fenced.journal_bytes == "post-create-journal" &&
+                    fenced.authority_root_bytes.empty() &&
+                    fenced.stage_files_absent &&
+                    !fenced.authority_mutation_attempted,
+                "before-effect create changed post-create journal residue");
+        auto peer = storage.make_journal(generous_limits());
+        auto blocked = peer.create_new(TrustedReplayFloor::uninitialized(),
+                                       chain.genesis);
+        require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                       "post-create journal residue did not retain its fence");
+        require(same_persistent_state(storage.snapshot(), fenced),
+                "fenced peer changed post-create journal residue");
+        storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear a journal residue fence");
+    }
+
+    for (const auto child : {FixedAuthorityChild::Root,
+                             FixedAuthorityChild::JournalStage,
+                             FixedAuthorityChild::RootStage}) {
+        auto storage = JournalTestStorage::fresh();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                storage.replace_fixed_child_file(child,
+                                                 "compound-fixed-residue");
+            },
+            "create did not pause during compound namespace inspection", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "compound fixed residue cleared a provisional fence");
+        const auto fenced = storage.snapshot();
+        const auto compound_entries = static_cast<std::size_t>(std::count_if(
+            fenced.live_file_bytes.begin(), fenced.live_file_bytes.end(),
+            [](const auto &entry) {
+                return entry.second == "compound-fixed-residue";
+            }));
+        require(fenced.journal_bytes.empty() &&
+                    compound_entries == 1 &&
+                    !fenced.authority_mutation_attempted,
+                "before-effect create changed compound fixed residue");
+        auto peer = storage.make_journal(generous_limits());
+        auto blocked = peer.create_new(TrustedReplayFloor::uninitialized(),
+                                       chain.genesis);
+        require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                       "compound fixed residue did not retain its fence");
+        require(same_persistent_state(storage.snapshot(), fenced),
+                "fenced peer changed compound fixed residue");
+        storage.remove_fixed_child_file(child);
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear a compound residue fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh();
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                storage.arm_fault(FaultOperation::AuthorityUnlock,
+                                  FaultPosition::After, FaultAction::Error);
+            },
+            "create did not pause before its post-create unlock", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "failed post-create unlock cleared its fence");
+        const auto after = storage.snapshot();
+        require(after.journal_bytes.empty() &&
+                    after.authority_root_bytes.empty() &&
+                    after.stage_files_absent &&
+                    !after.authority_mutation_attempted,
+                "failed post-create unlock changed authority");
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear an unlock fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh(PlatformContract::Linux);
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                require(storage.try_unlink_lock_file(),
+                        "post-create lock fixture did not remove the lock");
+            },
+            "create did not pause during post-create lock validation", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "missing post-create lock cleared its fence");
+        const auto after = storage.snapshot();
+        require(after.journal_bytes.empty() &&
+                    after.authority_root_bytes.empty() &&
+                    after.stage_files_absent &&
+                    !after.authority_mutation_attempted,
+                "missing post-create lock changed authority");
+        require(storage.try_recreate_lock_file(),
+                "post-create lock fixture did not restore the lock");
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear a missing-lock fence");
+    }
+
+    {
+        auto storage = JournalTestStorage::fresh(PlatformContract::Linux);
+        storage.arm_fault(FaultOperation::InitialJournalCreate,
+                          FaultPosition::Before, FaultAction::Error);
+        auto result = create_after_paused_operation(
+            storage, chain, FaultOperation::FixedNamespaceInspect,
+            [&] {
+                const auto original_identity = storage.lock_identity();
+                require(original_identity != 0 &&
+                            storage.try_unlink_lock_file() &&
+                            storage.try_recreate_lock_file() &&
+                            storage.lock_identity() != original_identity,
+                        "post-create identity fixture did not rebind the lock");
+            },
+            "create did not pause during post-create identity validation", 2);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "rebound post-create identity cleared its fence");
+        const auto after = storage.snapshot();
+        require(after.journal_bytes.empty() &&
+                    after.authority_root_bytes.empty() &&
+                    after.stage_files_absent &&
+                    !after.authority_mutation_attempted,
+                "rebound post-create identity changed authority");
+        auto recovery = storage.make_journal(generous_limits());
+        auto recovered = recovery.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(recovered, DurableJournalStatus::Published,
+                       "locked create did not clear a rebound identity fence");
+    }
+}
+
+void require_retained_fresh_create_requires_live_lock() {
+    const auto chain = make_chain();
+    auto storage = JournalTestStorage::fresh(PlatformContract::Linux);
+    storage.arm_fault(FaultOperation::InitialJournalCreate,
+                      FaultPosition::After, FaultAction::Error);
+    auto faulting = storage.make_journal(generous_limits());
+    auto failed = faulting.create_new(TrustedReplayFloor::uninitialized(),
+                                      chain.genesis);
+    require_result(failed, DurableJournalStatus::RecoveryRequired,
+                   "effectful create did not establish a retained fence");
+    storage.remove_fixed_child_file(FixedAuthorityChild::Journal);
+    storage.reset_observations();
+
+    auto blocked = create_after_paused_operation(
+        storage, chain, FaultOperation::FixedNamespaceInspect,
+        [&] {
+            require(storage.try_unlink_lock_file(),
+                    "retained-fence fixture did not remove the live lock");
+        },
+        "retained create did not pause during fixed inspection");
+    require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                   "retained create accepted a missing live lock");
+    const auto after = storage.snapshot();
+    require(after.journal_bytes.empty() && after.authority_root_bytes.empty() &&
+                after.stage_files_absent &&
+                !after.authority_mutation_attempted,
+            "retained create mutated a namespace without its live lock");
+    require(storage.try_recreate_lock_file(),
+            "retained-fence fixture did not restore the live lock");
+    auto recovery = storage.make_journal(generous_limits());
+    auto recovered = recovery.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+    require_result(recovered, DurableJournalStatus::Published,
+                   "locked create did not clear a missing-lock fence");
+}
+
+const std::vector<FaultOperation> repair_operations = [] {
+    auto operations = pre_authority_operations;
+    operations.insert(operations.end(), {
+                                            FaultOperation::RootOpen,
+                                            FaultOperation::RootRead,
+                                            FaultOperation::RootClose,
+                                            FaultOperation::JournalOpen,
+                                            FaultOperation::JournalRead,
+                                            FaultOperation::JournalReadClose,
+                                            FaultOperation::TailRepairOpen,
+                                            FaultOperation::TailRepairTruncate,
+                                            FaultOperation::TailRepairFlush,
+                                            FaultOperation::TailRepairClose,
+                                            FaultOperation::AuthorityUnlock,
+                                            FaultOperation::AuthorityLockClose,
+                                        });
+    return operations;
+}();
+
+const std::vector<FaultOperation> compaction_operations = [] {
+    auto operations = pre_authority_operations;
+    operations.insert(operations.end(),
+                      {
+                          FaultOperation::RootOpen,
+                          FaultOperation::RootRead,
+                          FaultOperation::RootClose,
+                          FaultOperation::JournalOpen,
+                          FaultOperation::JournalRead,
+                          FaultOperation::JournalReadClose,
+                          FaultOperation::CompactionStageCreate,
+                          FaultOperation::CompactionWrite,
+                          FaultOperation::CompactionFlush,
+                          FaultOperation::CompactionClose,
+                          FaultOperation::CompactionReplace,
+                          FaultOperation::CompactionNamespaceDurability,
+                          FaultOperation::AuthorityUnlock,
+                          FaultOperation::AuthorityLockClose,
+                      });
+    return operations;
+}();
+
+const std::vector<FaultOperation> read_only_recovery_operations = [] {
+    auto operations = pre_authority_operations;
+    operations.insert(operations.end(), {
+                                            FaultOperation::RootOpen,
+                                            FaultOperation::RootRead,
+                                            FaultOperation::RootClose,
+                                            FaultOperation::JournalOpen,
+                                            FaultOperation::JournalRead,
+                                            FaultOperation::JournalReadClose,
+                                            FaultOperation::AuthorityUnlock,
+                                            FaultOperation::AuthorityLockClose,
+                                        });
+    return operations;
+}();
+
+void require_read_only_recovery_faults() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    for (const auto operation : read_only_recovery_operations) {
+        for (const auto position :
+             {FaultPosition::Before, FaultPosition::After}) {
+            auto storage = JournalTestStorage::seeded(
+                committed, std::string(chain.genesis_root.canonical_bytes()));
+            auto peer =
+                recover(storage, chain.genesis_root.canonical_bytes());
+            storage.reset_observations();
+            const auto before = storage.snapshot();
+            storage.arm_fault(operation, position, FaultAction::Error);
+            auto journal = storage.make_journal(generous_limits());
+            auto result =
+                journal.recover_existing(TrustedReplayFloor::exact_root(
+                    std::string(chain.genesis_root.canonical_bytes())));
+            const auto expected =
+                preflight_may_have_effect(operation, position,
+                                          FaultAction::Error)
+                    ? DurableJournalStatus::RecoveryRequired
+                    : DurableJournalStatus::UnsupportedStorage;
+            require_result(result, expected,
+                           "read-only recovery fault changed stable outcome");
+            const auto after = storage.snapshot();
+            require(after.journal_bytes == before.journal_bytes &&
+                        after.authority_root_bytes ==
+                            before.authority_root_bytes &&
+                        !after.authority_mutation_attempted &&
+                        after.open_handles.empty() && after.stage_files_absent,
+                    "read-only recovery fault mutated or leaked authority");
+            if (operation == FaultOperation::RootClose ||
+                operation == FaultOperation::JournalReadClose ||
+                operation == FaultOperation::AuthorityLockClose) {
+                require(storage.attempt_count(operation) == 1,
+                        "read-only checked close was retried or omitted");
+            }
+            require_storage_released_after_return(
+                storage, "read-only recovery fault retained a handle");
+
+            if (preflight_may_have_effect(operation, position,
+                                          FaultAction::Error)) {
+                storage.reset_observations();
+                const auto before_fenced_write = storage.snapshot();
+                auto writer = storage.make_journal(generous_limits());
+                auto blocked = writer.append_and_publish(
+                    std::move(peer), chain.successor);
+                require_result(
+                    blocked, DurableJournalStatus::RecoveryRequired,
+                    "effect-uncertain preflight did not retain its fence");
+                const auto after_fenced_write = storage.snapshot();
+                require(
+                    !peer.available() &&
+                        same_persistent_state(after_fenced_write,
+                                              before_fenced_write) &&
+                        !after_fenced_write.authority_mutation_attempted,
+                    "preflight fence allowed a peer write");
+                require_storage_released_after_return(
+                    storage, "preflight fence retained a handle");
+            }
+
+            storage.reset_observations();
+            auto retry = storage.make_journal(generous_limits());
+            auto retried =
+                retry.recover_existing(TrustedReplayFloor::exact_root(
+                    std::string(chain.genesis_root.canonical_bytes())));
+            require_result(retried, DurableJournalStatus::Published,
+                           "read-only recovery did not retry cleanly");
+            require(storage.snapshot().journal_bytes == committed &&
+                        storage.snapshot().stage_files_absent &&
+                        storage.snapshot().durable_stage_files_absent &&
+                        storage.snapshot().open_handles.empty(),
+                    "read-only retry left probe or handle residue");
+            require_storage_released_after_return(
+                storage, "read-only recovery retry retained a handle");
+        }
+    }
+}
+
+bool flow_may_have_mutated(const std::vector<FaultOperation> &operations,
+                           FaultOperation first_mutation,
+                           FaultOperation operation, FaultPosition position,
+                           FaultAction action) {
+    if (operation == first_mutation) {
+        return position == FaultPosition::After ||
+               action == FaultAction::EffectThenError;
+    }
+    const auto found =
+        std::find(operations.begin(), operations.end(), operation);
+    const auto mutation =
+        std::find(operations.begin(), operations.end(), first_mutation);
+    return found > mutation;
+}
+
+void require_repair_faults() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    const auto with_tail =
+        committed + frame(chain.successor) + frame(chain.fork);
+
+    for (const auto operation : repair_operations) {
+        for (const auto position :
+             {FaultPosition::Before, FaultPosition::After}) {
+            for (const auto action : {FaultAction::Error, FaultAction::Crash,
+                                      FaultAction::EffectThenError}) {
+                auto storage = JournalTestStorage::seeded(
+                    committed,
+                    std::string(chain.genesis_root.canonical_bytes()));
+                auto peer =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                storage.overwrite_fixed_child_bytes(
+                    FixedAuthorityChild::Journal, with_tail);
+                storage.reset_observations();
+                storage.arm_fault(operation, position, action);
+                auto journal = storage.make_journal(generous_limits());
+                auto result =
+                    journal.recover_existing(TrustedReplayFloor::exact_root(
+                        std::string(chain.genesis_root.canonical_bytes())));
+                const bool authority_may_have_mutated = flow_may_have_mutated(
+                    repair_operations, FaultOperation::TailRepairTruncate,
+                    operation, position, action);
+                const auto expected =
+                    (authority_may_have_mutated || preflight_may_have_effect(
+                                                       operation, position,
+                                                       action))
+                        ? DurableJournalStatus::RecoveryRequired
+                        : DurableJournalStatus::UnsupportedStorage;
+                require_result(result, expected,
+                               "tail-repair fault returned the wrong outcome");
+                if (action != FaultAction::Crash) {
+                    require_storage_released_after_return(
+                        storage,
+                        "tail-repair fault retained an authority handle");
+                }
+                if (authority_may_have_mutated ||
+                    preflight_may_have_effect(operation, position, action)) {
+                    const auto before_fence = storage.snapshot();
+                    storage.reset_observations();
+                    auto fence = storage.make_journal(generous_limits());
+                    auto fenced = fence.append_and_publish(std::move(peer),
+                                                           chain.successor);
+                    require_result(
+                        fenced, DurableJournalStatus::RecoveryRequired,
+                        "possibly-effectful repair did not fence a pre-fault "
+                        "authority token");
+                    const auto after_fence = storage.snapshot();
+                    require(
+                        !peer.available() &&
+                            same_persistent_state(after_fence, before_fence) &&
+                            !after_fence.authority_mutation_attempted,
+                        "repair fence attempt changed authority");
+                    if (action != FaultAction::Crash) {
+                        require_storage_released_after_return(
+                            storage,
+                            "repair fence retained an authority handle");
+                    }
+                }
+                storage.restart();
+                storage.reset_observations();
+                auto recovered =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                require(recovered.root_bytes() ==
+                            chain.genesis_root.canonical_bytes(),
+                        "tail-repair crash changed authority");
+                require(
+                    storage.snapshot().journal_bytes == committed &&
+                        storage.snapshot().journal_durable &&
+                        storage.snapshot().journal_closed &&
+                        storage.snapshot().stage_files_absent,
+                    "tail repair was not durable before write-ready recovery");
+                auto continuation = storage.make_journal(generous_limits());
+                auto continued = continuation.append_and_publish(
+                    std::move(recovered), chain.successor);
+                require_result(continued, DurableJournalStatus::Published,
+                               "repaired journal could not continue appending");
+            }
+        }
+    }
+}
+
+void require_physical_compaction() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis) + frame(chain.successor);
+    auto baseline = JournalTestStorage::seeded(
+        committed, std::string(chain.successor_root.canonical_bytes()));
+    const auto exact_snapshot = baseline.snapshot();
+
+    auto success = baseline.clone();
+    auto authority = recover(success, chain.genesis_root.canonical_bytes());
+    auto journal = success.make_journal(generous_limits());
+    auto compacted = journal.compact_physical(std::move(authority));
+    require_result(compacted, DurableJournalStatus::Published,
+                   "physical compaction was rejected");
+    require(!authority.available() && compacted.journal->available() &&
+                success.snapshot().journal_bytes ==
+                    exact_snapshot.journal_bytes &&
+                success.snapshot().authority_root_bytes ==
+                    exact_snapshot.authority_root_bytes &&
+                success.snapshot().open_handles.empty() &&
+                success.snapshot().all_authority_io_under_lock,
+            "physical compaction duplicated or changed authority");
+
+    for (const auto operation : compaction_operations) {
+        for (const auto position :
+             {FaultPosition::Before, FaultPosition::After}) {
+            for (const auto action : {FaultAction::Error, FaultAction::Crash,
+                                      FaultAction::EffectThenError}) {
+                auto storage = baseline.clone();
+                auto live =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                auto peer =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                storage.reset_observations();
+                storage.arm_fault(operation, position, action);
+                auto faulting_journal = storage.make_journal(generous_limits());
+                auto result =
+                    faulting_journal.compact_physical(std::move(live));
+                const bool authority_may_have_mutated = flow_may_have_mutated(
+                    compaction_operations,
+                    FaultOperation::CompactionStageCreate, operation, position,
+                    action);
+                const auto expected =
+                    (authority_may_have_mutated || preflight_may_have_effect(
+                                                       operation, position,
+                                                       action))
+                        ? DurableJournalStatus::RecoveryRequired
+                        : DurableJournalStatus::UnsupportedStorage;
+                require_result(
+                    result, expected,
+                    "compaction fault returned the wrong stable outcome");
+                require(!live.available(),
+                        "compaction fault retained a write-capable handle");
+                if (action != FaultAction::Crash) {
+                    require_storage_released_after_return(
+                        storage,
+                        "compaction fault retained an authority handle");
+                }
+                if (authority_may_have_mutated ||
+                    preflight_may_have_effect(operation, position, action)) {
+                    const auto before_fence = storage.snapshot();
+                    storage.reset_observations();
+                    auto fence = storage.make_journal(generous_limits());
+                    auto fenced =
+                        fence.append_and_publish(std::move(peer), chain.third);
+                    require_result(
+                        fenced, DurableJournalStatus::RecoveryRequired,
+                        "possibly-effectful compaction did not fence a "
+                        "pre-fault authority token");
+                    const auto after_fence = storage.snapshot();
+                    require(
+                        !peer.available() &&
+                            same_persistent_state(after_fence, before_fence) &&
+                            !after_fence.authority_mutation_attempted,
+                        "compaction fence attempt changed authority");
+                    if (action != FaultAction::Crash) {
+                        require_storage_released_after_return(
+                            storage,
+                            "compaction fence retained an authority handle");
+                    }
+                }
+                storage.restart();
+                const auto restart_snapshot = storage.snapshot();
+                storage.reset_observations();
+                auto recovered =
+                    recover(storage, chain.genesis_root.canonical_bytes());
+                require(recovered.root_bytes() ==
+                            chain.successor_root.canonical_bytes(),
+                        "compaction crash changed authority");
+                require(
+                    storage.snapshot().journal_bytes ==
+                            exact_snapshot.journal_bytes &&
+                        storage.snapshot().authority_root_bytes ==
+                            exact_snapshot.authority_root_bytes &&
+                        stage_files_unchanged(restart_snapshot,
+                                              storage.snapshot()) &&
+                        storage.snapshot().journal_durable,
+                    "compaction crash did not preserve byte-identical storage");
+                auto continuation = storage.make_journal(generous_limits());
+                auto continued = continuation.append_and_publish(
+                    std::move(recovered), chain.third);
+                require_result(
+                    continued, DurableJournalStatus::Published,
+                    "compaction recovery could not continue appending");
+            }
+        }
+    }
+}
+
+void require_exact_schema_export() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis) + frame(chain.successor);
+    auto storage = JournalTestStorage::seeded(
+        committed, std::string(chain.successor_root.canonical_bytes()));
+    auto authority = recover(storage, chain.genesis_root.canonical_bytes());
+    const auto before = storage.snapshot();
+    auto journal = storage.make_journal(generous_limits());
+
+    auto unconfirmed = journal.export_exact_schema_candidate(
+        authority, supported_journal_schema, JournalQuiescence::Unconfirmed);
+    require(!unconfirmed.exported() && !unconfirmed.candidate.has_value() &&
+                unconfirmed.status ==
+                    ExactSchemaExportStatus::QuiescenceRequired,
+            "unconfirmed export returned a candidate");
+    require(storage.snapshot() == before,
+            "unconfirmed export readied or changed storage");
+
+    auto exported = journal.export_exact_schema_candidate(
+        authority, supported_journal_schema, JournalQuiescence::Confirmed);
+    require(exported.status == ExactSchemaExportStatus::ExportedCandidate &&
+                exported.exported() && exported.candidate.has_value(),
+            "confirmed exact-schema export was rejected");
+    require(exported.candidate->schema.major ==
+                    supported_journal_schema.major &&
+                exported.candidate->schema.minor ==
+                    supported_journal_schema.minor &&
+                exported.candidate->journal_bytes == committed &&
+                exported.candidate->authority_root_bytes ==
+                    chain.successor_root.canonical_bytes(),
+            "exact-schema export changed bytes or schema");
+    require(authority.available(),
+            "nonauthorizing export consumed live authority");
+    require(same_persistent_state(storage.snapshot(), before) &&
+                storage.snapshot().open_handles.empty() &&
+                storage.snapshot().all_authority_io_under_lock,
+            "exact-schema export changed or leaked live storage");
+
+    for (const auto operation : read_only_recovery_operations) {
+        for (const auto position :
+             {FaultPosition::Before, FaultPosition::After}) {
+            auto fault_storage = JournalTestStorage::seeded(
+                committed, std::string(chain.successor_root.canonical_bytes()));
+            auto fault_authority =
+                recover(fault_storage, chain.genesis_root.canonical_bytes());
+            auto fault_peer =
+                recover(fault_storage, chain.genesis_root.canonical_bytes());
+            fault_storage.reset_observations();
+            const auto fault_before = fault_storage.snapshot();
+            fault_storage.arm_fault(operation, position, FaultAction::Error);
+            auto fault_journal = fault_storage.make_journal(generous_limits());
+            auto fault_export = fault_journal.export_exact_schema_candidate(
+                fault_authority, supported_journal_schema,
+                JournalQuiescence::Confirmed);
+            const auto expected =
+                preflight_may_have_effect(operation, position,
+                                          FaultAction::Error)
+                    ? ExactSchemaExportStatus::RecoveryRequired
+                    : ExactSchemaExportStatus::UnsupportedStorage;
+            require(fault_export.status ==
+                            expected &&
+                        !fault_export.exported() &&
+                        !fault_export.candidate.has_value() &&
+                        fault_authority.available(),
+                    "export storage fault returned authority bytes");
+            const auto fault_after = fault_storage.snapshot();
+            require(authority_files_unchanged(fault_before, fault_after) &&
+                        !fault_after.authority_mutation_attempted &&
+                        fault_after.open_handles.empty(),
+                    "export storage fault changed or leaked authority");
+            require_storage_released_after_return(
+                fault_storage, "export storage fault retained a handle");
+
+            if (preflight_may_have_effect(operation, position,
+                                          FaultAction::Error)) {
+                fault_storage.reset_observations();
+                const auto before_fenced_write = fault_storage.snapshot();
+                auto writer = fault_storage.make_journal(generous_limits());
+                auto blocked = writer.append_and_publish(
+                    std::move(fault_peer), chain.third);
+                require_result(
+                    blocked, DurableJournalStatus::RecoveryRequired,
+                    "effect-uncertain export preflight did not retain its "
+                    "fence");
+                const auto after_fenced_write = fault_storage.snapshot();
+                require(
+                    !fault_peer.available() &&
+                        same_persistent_state(after_fenced_write,
+                                              before_fenced_write) &&
+                        !after_fenced_write.authority_mutation_attempted,
+                    "export preflight fence allowed a peer write");
+                require_storage_released_after_return(
+                    fault_storage, "export preflight fence retained a handle");
+
+                fault_storage.reset_observations();
+                const auto before_fenced_export = fault_storage.snapshot();
+                auto fenced_exporter =
+                    fault_storage.make_journal(generous_limits());
+                auto fenced_export =
+                    fenced_exporter.export_exact_schema_candidate(
+                        fault_authority, supported_journal_schema,
+                        JournalQuiescence::Confirmed);
+                require(
+                    fenced_export.status ==
+                            ExactSchemaExportStatus::RecoveryRequired &&
+                        !fenced_export.exported() &&
+                        !fenced_export.candidate.has_value() &&
+                        fault_authority.available() &&
+                        same_persistent_state(fault_storage.snapshot(),
+                                              before_fenced_export) &&
+                        !fault_storage.snapshot().authority_mutation_attempted,
+                    "fenced export consumed authority or read storage");
+                require_storage_released_after_return(
+                    fault_storage, "fenced export retained a handle");
+
+                fault_storage.reset_observations();
+                auto recovered = recover(
+                    fault_storage, chain.genesis_root.canonical_bytes());
+                require(recovered.root_bytes() ==
+                            chain.successor_root.canonical_bytes(),
+                        "locked recovery did not clear the export preflight "
+                        "fence");
+            }
+
+            fault_storage.reset_observations();
+            auto retry = fault_storage.make_journal(generous_limits());
+            auto retried = retry.export_exact_schema_candidate(
+                fault_authority, supported_journal_schema,
+                JournalQuiescence::Confirmed);
+            require(retried.status ==
+                            ExactSchemaExportStatus::ExportedCandidate &&
+                        retried.exported() && retried.candidate.has_value() &&
+                        same_persistent_state(fault_storage.snapshot(),
+                                              fault_before),
+                    "export storage fault did not retry cleanly");
+            require_storage_released_after_return(
+                fault_storage, "export retry retained an authority handle");
+        }
+    }
+
+    storage.reset_observations();
+    const auto schema_before = storage.snapshot();
+    for (const auto schema :
+         {SchemaVersion{0, 0},
+          SchemaVersion{supported_journal_schema.major + 1, 0},
+          SchemaVersion{supported_journal_schema.major,
+                        supported_journal_schema.minor + 1}}) {
+        auto rejected = journal.export_exact_schema_candidate(
+            authority, schema, JournalQuiescence::Confirmed);
+        require(rejected.status == ExactSchemaExportStatus::SchemaMismatch &&
+                    !rejected.exported() && !rejected.candidate.has_value() &&
+                    authority.available(),
+                "different-schema export returned a candidate");
+        require(storage.snapshot() == schema_before,
+                "different-schema export changed live storage");
+    }
+
+    auto stale_storage = JournalTestStorage::seeded(
+        frame(chain.genesis),
+        std::string(chain.genesis_root.canonical_bytes()));
+    auto stale = recover(stale_storage, chain.genesis_root.canonical_bytes());
+    auto winner = recover(stale_storage, chain.genesis_root.canonical_bytes());
+    auto winning_journal = stale_storage.make_journal(generous_limits());
+    auto advanced =
+        winning_journal.append_and_publish(std::move(winner), chain.successor);
+    require_result(advanced, DurableJournalStatus::Published,
+                   "export stale-authority fixture did not advance");
+    stale_storage.reset_observations();
+    const auto stale_before = stale_storage.snapshot();
+    auto stale_journal = stale_storage.make_journal(generous_limits());
+    auto stale_export = stale_journal.export_exact_schema_candidate(
+        stale, supported_journal_schema, JournalQuiescence::Confirmed);
+    require(stale_export.status ==
+                    ExactSchemaExportStatus::ConflictBeforeRead &&
+                !stale_export.exported() &&
+                !stale_export.candidate.has_value() && stale.available() &&
+                stale_storage.attempt_count(FaultOperation::RootRead) > 0 &&
+                stale_storage.attempt_count(FaultOperation::JournalOpen) == 0 &&
+                stale_storage.attempt_count(FaultOperation::JournalRead) == 0 &&
+                !stale_storage.snapshot().authority_mutation_attempted &&
+                stale_storage.snapshot().all_authority_io_under_lock,
+            "stale authority exported a candidate");
+    require(same_persistent_state(stale_storage.snapshot(), stale_before),
+            "stale export changed authority storage");
+    require_storage_released_after_return(
+        stale_storage, "stale export retained an authority handle");
+
+    auto unsupported_storage = JournalTestStorage::seeded(
+        committed, std::string(chain.successor_root.canonical_bytes()));
+    auto unsupported_authority =
+        recover(unsupported_storage, chain.genesis_root.canonical_bytes());
+    unsupported_storage.arm_fault(FaultOperation::RootOpen,
+                                  FaultPosition::Before, FaultAction::Error);
+    const auto unsupported_before = unsupported_storage.snapshot();
+    auto unsupported_journal =
+        unsupported_storage.make_journal(generous_limits());
+    auto unsupported_export = unsupported_journal.export_exact_schema_candidate(
+        unsupported_authority, supported_journal_schema,
+        JournalQuiescence::Confirmed);
+    require(unsupported_export.status ==
+                    ExactSchemaExportStatus::UnsupportedStorage &&
+                !unsupported_export.exported() &&
+                !unsupported_export.candidate.has_value(),
+            "export storage failure returned a candidate");
+    require(unsupported_storage.snapshot().journal_bytes ==
+                    unsupported_before.journal_bytes &&
+                unsupported_storage.snapshot().authority_root_bytes ==
+                    unsupported_before.authority_root_bytes,
+            "unsupported export changed authority storage");
+
+    auto limited_storage = JournalTestStorage::seeded(
+        committed, std::string(chain.successor_root.canonical_bytes()));
+    auto limited_authority =
+        recover(limited_storage, chain.genesis_root.canonical_bytes());
+    auto export_limits = generous_limits();
+    export_limits.max_committed_bytes = committed.size() - 1;
+    const auto limited_before = limited_storage.snapshot();
+    auto limited_journal = limited_storage.make_journal(export_limits);
+    auto limited_export = limited_journal.export_exact_schema_candidate(
+        limited_authority, supported_journal_schema,
+        JournalQuiescence::Confirmed);
+    require(limited_export.status == ExactSchemaExportStatus::LimitExceeded &&
+                !limited_export.exported() &&
+                !limited_export.candidate.has_value(),
+            "over-limit export returned a candidate");
+    require(limited_storage.snapshot() == limited_before,
+            "over-limit export changed authority storage");
+
+    auto corrupt_storage = JournalTestStorage::seeded(
+        committed, std::string(chain.successor_root.canonical_bytes()));
+    auto corrupt_authority =
+        recover(corrupt_storage, chain.genesis_root.canonical_bytes());
+    corrupt_storage.overwrite_fixed_child_bytes(FixedAuthorityChild::Root, "{");
+    corrupt_storage.reset_observations();
+    const auto corrupt_before = corrupt_storage.snapshot();
+    auto corrupt_journal = corrupt_storage.make_journal(generous_limits());
+    auto corrupt_export = corrupt_journal.export_exact_schema_candidate(
+        corrupt_authority, supported_journal_schema,
+        JournalQuiescence::Confirmed);
+    require(
+        corrupt_export.status == ExactSchemaExportStatus::CorruptOrRollback &&
+            !corrupt_export.exported() &&
+            !corrupt_export.candidate.has_value() &&
+            corrupt_authority.available() &&
+            same_persistent_state(corrupt_storage.snapshot(), corrupt_before) &&
+            !corrupt_storage.snapshot().authority_mutation_attempted,
+        "corrupt stored authority exported or triggered mutation");
+}
+
+void require_unsupported_preflight() {
+    const auto chain = make_chain();
+    for (const auto platform :
+         {PlatformContract::Linux, PlatformContract::Windows,
+          PlatformContract::MacOS}) {
+        for (const auto capability :
+             {DurabilityCapability::RegularFileFlush,
+              DurabilityCapability::TailTruncateAndFlush,
+              DurabilityCapability::SameDirectoryReplace,
+              DurabilityCapability::NamespaceDurability}) {
+            auto storage = JournalTestStorage::fresh(platform);
+            storage.make_capability_unavailable(capability);
+            const auto before = storage.snapshot();
+            auto journal = storage.make_journal(generous_limits());
+            auto result = journal.create_new(
+                TrustedReplayFloor::uninitialized(), chain.genesis);
+            require_result(
+                result, DurableJournalStatus::UnsupportedStorage,
+                "unavailable native durability did not refuse publication");
+            const auto after = storage.snapshot();
+            require(authority_files_unchanged(before, after) &&
+                        !after.authority_mutation_attempted &&
+                        after.open_handles.empty(),
+                    "unsupported adapter changed authority during create "
+                    "preflight");
+
+            auto existing = JournalTestStorage::seeded(
+                frame(chain.genesis),
+                std::string(chain.genesis_root.canonical_bytes()), platform);
+            existing.make_capability_unavailable(capability);
+            const auto existing_before = existing.snapshot();
+            auto existing_journal = existing.make_journal(generous_limits());
+            auto existing_result = existing_journal.recover_existing(
+                TrustedReplayFloor::exact_root(
+                    std::string(chain.genesis_root.canonical_bytes())));
+            require_result(
+                existing_result, DurableJournalStatus::UnsupportedStorage,
+                "unavailable native durability did not refuse recovery");
+            const auto existing_after = existing.snapshot();
+            require(
+                authority_files_unchanged(existing_before, existing_after) &&
+                    !existing_after.authority_mutation_attempted &&
+                    existing_after.open_handles.empty(),
+                "unsupported adapter changed authority during recovery "
+                "preflight");
+        }
+
+        for (const auto child :
+             {FixedAuthorityChild::Journal, FixedAuthorityChild::Root,
+              FixedAuthorityChild::Lock, FixedAuthorityChild::JournalStage,
+              FixedAuthorityChild::RootStage}) {
+            for (const auto kind : {UnsupportedEntryKind::Symlink,
+                                    UnsupportedEntryKind::NonRegular,
+                                    UnsupportedEntryKind::ReparsePoint}) {
+                auto storage = JournalTestStorage::fresh(platform);
+                storage.poison_fixed_child(child, kind);
+                const auto before = storage.snapshot();
+                auto journal = storage.make_journal(generous_limits());
+                auto result = journal.create_new(
+                    TrustedReplayFloor::uninitialized(), chain.genesis);
+                require_result(result, DurableJournalStatus::UnsupportedStorage,
+                               "unsafe fixed child was accepted");
+                const auto after = storage.snapshot();
+                require(authority_files_unchanged(before, after) &&
+                            !after.authority_mutation_attempted &&
+                            after.open_handles.empty(),
+                        "unsafe fixed-child preflight changed authority");
+                if (child != FixedAuthorityChild::Lock) {
+                    require(storage.attempt_count(
+                                FaultOperation::PreflightProbe) > 0 &&
+                                storage.attempt_count(
+                                    FaultOperation::RootOpen) == 0 &&
+                                storage.attempt_count(
+                                    FaultOperation::JournalOpen) == 0,
+                            "unsafe fixed child was discovered after authority "
+                            "I/O");
+                }
+            }
+        }
+
+        auto missing =
+            JournalTestStorage::missing_authority_directory(platform);
+        const auto missing_before = missing.snapshot();
+        auto missing_journal = missing.make_journal(generous_limits());
+        auto missing_result = missing_journal.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(missing_result, DurableJournalStatus::UnsupportedStorage,
+                       "missing authority directory was created implicitly");
+        require(same_persistent_state(missing.snapshot(), missing_before),
+                "missing authority directory changed its parent");
+    }
+}
+
+std::filesystem::path extended_length_path(const std::filesystem::path &path) {
+#ifdef _WIN32
+    const auto absolute = std::filesystem::absolute(path).lexically_normal();
+    const auto native = absolute.native();
+    if (native.rfind(L"\\\\?\\", 0) == 0) {
+        return absolute;
+    }
+    if (native.rfind(L"\\\\", 0) == 0) {
+        return std::filesystem::path(L"\\\\?\\UNC\\" + native.substr(2));
+    }
+    return std::filesystem::path(L"\\\\?\\" + native);
+#else
+    return path;
+#endif
+}
+
+class NativeDirectory {
+public:
+    explicit NativeDirectory(std::string_view label) {
+        const auto nonce =
+            std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = std::filesystem::temp_directory_path() /
+                (std::string("lemonade-") + std::string(label) + "-" +
+                 std::to_string(nonce));
+        std::filesystem::create_directories(path_);
+    }
+
+    ~NativeDirectory() {
+        std::error_code error;
+        std::filesystem::remove_all(extended_length_path(path_), error);
+    }
+
+    NativeDirectory(const NativeDirectory &) = delete;
+    NativeDirectory &operator=(const NativeDirectory &) = delete;
+
+    const std::filesystem::path &path() const noexcept { return path_; }
+
+private:
+    std::filesystem::path path_;
+};
+
+class ScopedCurrentPath {
+public:
+    ScopedCurrentPath() : lock_(mutex()), original_(std::filesystem::current_path()) {}
+
+    ~ScopedCurrentPath() {
+        std::error_code error;
+        std::filesystem::current_path(original_, error);
+        require(!error, "test current directory could not be restored");
+    }
+
+    ScopedCurrentPath(const ScopedCurrentPath &) = delete;
+    ScopedCurrentPath &operator=(const ScopedCurrentPath &) = delete;
+
+    void change_to(const std::filesystem::path &path) {
+        std::filesystem::current_path(path);
+    }
+
+private:
+    static std::mutex &mutex() {
+        static std::mutex value;
+        return value;
+    }
+
+    std::unique_lock<std::mutex> lock_;
+    std::filesystem::path original_;
+};
+
+std::string read_bytes(const std::filesystem::path &path) {
+    std::ifstream stream(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(stream),
+                       std::istreambuf_iterator<char>());
+}
+
+void write_bytes(const std::filesystem::path &path, std::string_view bytes) {
+    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    require(stream.good(), "test control file write failed");
+}
+
+void append_bytes(const std::filesystem::path &path, std::string_view bytes) {
+    std::ofstream stream(path, std::ios::binary | std::ios::app);
+    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    require(stream.good(), "test control file append failed");
+}
+
+std::map<std::string, std::string>
+snapshot_regular_files(const std::filesystem::path &root) {
+    std::map<std::string, std::string> snapshot;
+    for (const auto &entry :
+         std::filesystem::recursive_directory_iterator(root)) {
+        if (entry.is_regular_file()) {
+            snapshot.emplace(
+                entry.path().lexically_relative(root).generic_string(),
+                read_bytes(entry.path()));
+        }
+    }
+    return snapshot;
+}
+
+PublishedJournal create_native(const std::filesystem::path &directory,
+                               const Chain &chain) {
+    auto journal = DurableJournal::native(directory, generous_limits());
+    auto result =
+        journal.create_new(TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(result, DurableJournalStatus::Published,
+                   "native create did not publish authority");
+    return std::move(*result.journal);
+}
+
+PublishedJournal recover_native(const std::filesystem::path &directory,
+                                std::string_view floor) {
+    auto journal = DurableJournal::native(directory, generous_limits());
+    auto result = journal.recover_existing(
+        TrustedReplayFloor::exact_root(std::string(floor)));
+    require_result(result, DurableJournalStatus::Published,
+                   "native recovery did not return authority");
+    return std::move(*result.journal);
+}
+
+void require_native_preflight_identity_phase_residue() {
+    const auto chain = make_chain();
+    using lemon::residency::detail::DurablePreflightTestFault;
+    for (const auto fault :
+         {DurablePreflightTestFault::ProbeIdentityCaptureFailureOnce,
+          DurablePreflightTestFault::StageIdentityCaptureFailureOnce}) {
+        NativeDirectory directory("task020-native-preflight-phase-failure");
+        auto adapter = lemon::residency::detail::
+            make_platform_durable_file_adapter_for_test(directory.path(),
+                                                        fault);
+        auto journal = lemon::residency::detail::make_durable_journal_for_test(
+            std::move(adapter), generous_limits());
+
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::RecoveryRequired,
+                       "post-create identity failure was not effect-uncertain");
+        require(!result.published() && !result.journal.has_value(),
+                "post-create identity failure returned authority");
+
+        const auto after_failure = snapshot_regular_files(directory.path());
+        const auto anonymous_residue =
+            std::find_if(after_failure.begin(), after_failure.end(),
+                         [](const auto &entry) {
+                             return entry.first != "authority.lock" &&
+                                    entry.second.empty();
+                         });
+        const bool stage_residue =
+            anonymous_residue != after_failure.end() &&
+            std::filesystem::path(anonymous_residue->first).extension() ==
+                ".stage";
+        const bool expected_stage_residue =
+            fault ==
+            DurablePreflightTestFault::StageIdentityCaptureFailureOnce;
+        require(after_failure.size() == 2 &&
+                    anonymous_residue != after_failure.end() &&
+                    stage_residue == expected_stage_residue &&
+                    after_failure.count("authority.lock") == 1,
+                "post-create identity failure changed anonymous residue");
+        const auto uncertain_residue_path = anonymous_residue->first;
+        const auto uncertain_residue_bytes = anonymous_residue->second;
+
+        auto reconciler = DurableJournal::native(directory.path(),
+                                                 generous_limits());
+        auto reconciled = reconciler.create_new(
+            TrustedReplayFloor::uninitialized(), chain.genesis);
+        require_result(reconciled, DurableJournalStatus::Published,
+                       "locked create did not reconcile a fresh fence");
+        const auto published = snapshot_regular_files(directory.path());
+        const auto retained_residue =
+            published.find(uncertain_residue_path);
+        require(published.size() == 4 &&
+                    published.at("journal.jsonl") == frame(chain.genesis) &&
+                    published.at("authority-root.json") ==
+                        chain.genesis_root.canonical_bytes() &&
+                    published.count("authority.lock") == 1 &&
+                    retained_residue != published.end() &&
+                    retained_residue->second == uncertain_residue_bytes,
+                "fresh fence reconciliation changed authority or residue");
+    }
+}
+
+void require_native_preflight_fence_blocks_nonfresh_authority() {
+    const auto chain = make_chain();
+    NativeDirectory directory("task020-native-preflight-nonfresh-fence");
+    auto peer = create_native(directory.path(), chain);
+    const auto stable = snapshot_regular_files(directory.path());
+    auto adapter = lemon::residency::detail::
+        make_platform_durable_file_adapter_for_test(
+            directory.path(), lemon::residency::detail::
+                                  DurablePreflightTestFault::
+                                      ProbeIdentityCaptureFailureOnce);
+    auto journal = lemon::residency::detail::make_durable_journal_for_test(
+        std::move(adapter), generous_limits());
+
+    auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+        std::string(chain.genesis_root.canonical_bytes())));
+    require_result(result, DurableJournalStatus::RecoveryRequired,
+                   "post-create identity failure was not effect-uncertain");
+    require(!result.published() && !result.journal.has_value(),
+            "post-create identity failure returned authority");
+
+    const auto after_failure = snapshot_regular_files(directory.path());
+    const auto uncertain_entries = static_cast<std::size_t>(std::count_if(
+        after_failure.begin(), after_failure.end(), [&](const auto &entry) {
+            return stable.count(entry.first) == 0 && entry.second.empty();
+        }));
+    require(after_failure.size() == stable.size() + 1 &&
+                uncertain_entries == 1 &&
+                after_failure.at("journal.jsonl") == frame(chain.genesis) &&
+                after_failure.at("authority-root.json") ==
+                    chain.genesis_root.canonical_bytes(),
+            "post-create identity failure did not preserve uncertain residue");
+
+    auto blocked_create = DurableJournal::native(directory.path(),
+                                                 generous_limits());
+    auto create_result = blocked_create.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(create_result, DurableJournalStatus::RecoveryRequired,
+                   "fenced existing authority admitted a fresh create");
+    require(snapshot_regular_files(directory.path()) == after_failure,
+            "fenced create changed existing authority");
+
+    auto blocked_writer = DurableJournal::native(directory.path(),
+                                                 generous_limits());
+    auto blocked = blocked_writer.append_and_publish(std::move(peer),
+                                                     chain.successor);
+    require_result(blocked, DurableJournalStatus::RecoveryRequired,
+                   "post-create identity failure did not fence peer writes");
+    require(!peer.available() &&
+                snapshot_regular_files(directory.path()) == after_failure,
+            "preflight identity fence changed authority");
+
+    auto recovered =
+        recover_native(directory.path(), chain.genesis_root.canonical_bytes());
+    auto continuation = DurableJournal::native(directory.path(),
+                                               generous_limits());
+    auto continued = continuation.append_and_publish(std::move(recovered),
+                                                     chain.successor);
+    require_result(continued, DurableJournalStatus::Published,
+                   "locked recovery did not clear the preflight fence");
+}
+
+void require_native_preflight_preserves_siblings() {
+    const auto chain = make_chain();
+    NativeDirectory directory("task020-native-preflight-siblings");
+
+    write_bytes(directory.path() / ".durability-probe", "legacy-primary");
+    write_bytes(directory.path() / ".durability-probe.stage", "legacy-stage");
+
+    static_cast<void>(create_native(directory.path(), chain));
+
+    const auto files = snapshot_regular_files(directory.path());
+    require(files.size() == 5 &&
+                files.at(".durability-probe") == "legacy-primary" &&
+                files.at(".durability-probe.stage") == "legacy-stage" &&
+                files.at("journal.jsonl") == frame(chain.genesis) &&
+                files.at("authority-root.json") ==
+                    chain.genesis_root.canonical_bytes() &&
+                files.count("authority.lock") == 1,
+            "native preflight changed sibling files or left residue");
+}
+
+void require_native_preflight_stage_collision_exhaustion_is_fenced() {
+    const auto chain = make_chain();
+    NativeDirectory directory("task020-native-preflight-stage-collisions");
+    auto adapter = lemon::residency::detail::
+        make_platform_durable_file_adapter_for_test(
+            directory.path(), lemon::residency::detail::
+                                  DurablePreflightTestFault::
+                                      StageCreateCollisionExhaustion);
+    auto journal = lemon::residency::detail::make_durable_journal_for_test(
+        std::move(adapter), generous_limits());
+
+    auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                     chain.genesis);
+    require_result(result, DurableJournalStatus::RecoveryRequired,
+                   "exhausted stage collisions were not effect-uncertain");
+    require(!result.published() && !result.journal.has_value(),
+            "exhausted stage collisions returned authority");
+
+    const auto after_failure = snapshot_regular_files(directory.path());
+    std::map<std::string, std::string> collision_sentinels;
+    for (const auto &[name, bytes] : after_failure) {
+        if (name != "authority.lock") {
+            collision_sentinels.emplace(name, bytes);
+        }
+    }
+    require(after_failure.size() == collision_sentinels.size() + 1 &&
+                after_failure.count("authority.lock") == 1 &&
+                !collision_sentinels.empty() &&
+                std::all_of(collision_sentinels.begin(),
+                            collision_sentinels.end(), [](const auto &entry) {
+                                return entry.second ==
+                                       "caller-owned-stage-collision";
+                            }),
+            "stage collision exhaustion changed sentinels or left residue");
+
+    auto reconciler = DurableJournal::native(directory.path(),
+                                             generous_limits());
+    auto reconciled = reconciler.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(reconciled, DurableJournalStatus::Published,
+                   "locked create did not reconcile the collision fence");
+    const auto published = snapshot_regular_files(directory.path());
+    require(published.size() == collision_sentinels.size() + 3 &&
+                published.at("journal.jsonl") == frame(chain.genesis) &&
+                published.at("authority-root.json") ==
+                    chain.genesis_root.canonical_bytes() &&
+                published.count("authority.lock") == 1,
+            "collision fence reconciliation did not publish authority");
+    for (const auto &[name, bytes] : collision_sentinels) {
+        const auto preserved = published.find(name);
+        require(preserved != published.end() && preserved->second == bytes,
+                "collision fence reconciliation changed a sentinel");
+    }
+}
+
+void require_native_relative_directory_binding() {
+    const auto chain = make_chain();
+    NativeDirectory parent("task020-relative-directory-binding");
+    const auto original_parent = parent.path() / "original";
+    const auto decoy_parent = parent.path() / "decoy";
+    const auto original_authority = original_parent / "authority";
+    const auto decoy_authority = decoy_parent / "authority";
+    std::filesystem::create_directories(original_authority);
+    std::filesystem::create_directories(decoy_authority);
+    write_bytes(original_parent / "sentinel.bin", "original-sentinel");
+    write_bytes(decoy_parent / "sentinel.bin", "decoy-sentinel");
+
+    {
+        ScopedCurrentPath current_path;
+        current_path.change_to(original_parent);
+        auto journal =
+            DurableJournal::native("authority", generous_limits());
+        current_path.change_to(decoy_parent);
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::Published,
+                       "relative native authority did not publish");
+    }
+
+    const auto original_files = snapshot_regular_files(original_authority);
+    require(original_files.size() == 3 &&
+                original_files.at("journal.jsonl") == frame(chain.genesis) &&
+                original_files.at("authority-root.json") ==
+                    chain.genesis_root.canonical_bytes() &&
+                original_files.count("authority.lock") == 1,
+            "relative native authority drifted from its opened directory");
+    require(snapshot_regular_files(decoy_authority).empty() &&
+                read_bytes(original_parent / "sentinel.bin") ==
+                    "original-sentinel" &&
+                read_bytes(decoy_parent / "sentinel.bin") ==
+                    "decoy-sentinel",
+            "current-directory drift redirected native authority I/O");
+}
+
+void require_native_unbound_adapter_preserves_working_directory() {
+    NativeDirectory parent("task020-native-unbound-adapter");
+    const auto blocking_file = parent.path() / "not-a-directory";
+    const auto working_directory = parent.path() / "working-directory";
+    write_bytes(blocking_file, "blocking-file");
+    std::filesystem::create_directories(working_directory);
+    write_bytes(working_directory / "journal.jsonl", "working-journal");
+    write_bytes(working_directory / "authority-root.json", "working-root");
+    write_bytes(working_directory / "journal.jsonl.stage",
+                "working-journal-stage");
+    write_bytes(working_directory / "authority-root.json.stage",
+                "working-root-stage");
+    write_bytes(working_directory / "authority.lock", "working-lock");
+    const auto before = snapshot_regular_files(working_directory);
+
+    auto adapter =
+        lemon::residency::detail::make_platform_durable_file_adapter(
+            blocking_file / "authority");
+    {
+        ScopedCurrentPath current_path;
+        current_path.change_to(working_directory);
+        const auto inspected = adapter->inspect_fixed_namespace();
+        const auto root = adapter->read_root(1024);
+        const auto journal = adapter->read_journal(1024);
+        const auto created = adapter->create_journal("created");
+        const auto appended = adapter->append_journal("appended");
+        const auto truncated = adapter->truncate_journal(0);
+        const auto replaced_journal = adapter->replace_journal("replacement");
+        const auto replaced_root = adapter->replace_root("replacement");
+        require(!inspected.result.succeeded() && !root.result.succeeded() &&
+                    !journal.result.succeeded() && !created.succeeded() &&
+                    !appended.succeeded() && !truncated.succeeded() &&
+                    !replaced_journal.succeeded() &&
+                    !replaced_root.succeeded(),
+                "unbound native adapter accepted a path operation");
+    }
+    require(snapshot_regular_files(working_directory) == before,
+            "unbound native adapter changed the working directory");
+}
+
+void require_native_bounded_read_boundaries() {
+    const auto chain = make_chain();
+    const auto committed = frame(chain.genesis);
+    auto limits = generous_limits();
+    limits.max_committed_bytes = committed.size();
+    limits.max_crash_tail_bytes = 1;
+
+    NativeDirectory exact("task020-native-read-exact-cap");
+    static_cast<void>(create_native(exact.path(), chain));
+    append_bytes(exact.path() / "journal.jsonl", "x");
+    auto exact_journal = DurableJournal::native(exact.path(), limits);
+    auto exact_result =
+        exact_journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+    require_result(exact_result, DurableJournalStatus::Published,
+                   "native exact-cap journal read was rejected");
+    require(read_bytes(exact.path() / "journal.jsonl") == committed &&
+                read_bytes(exact.path() / "authority-root.json") ==
+                    chain.genesis_root.canonical_bytes(),
+            "native exact-cap recovery did not repair the exact tail");
+
+    for (const auto &[label, tail] :
+         {std::pair{std::string("task020-native-read-cap-plus-one"),
+                    std::string("xy")},
+          std::pair{std::string("task020-native-read-cap-plus-many"),
+                    std::string(64, 'z')}}) {
+        NativeDirectory over(label);
+        static_cast<void>(create_native(over.path(), chain));
+        append_bytes(over.path() / "journal.jsonl", tail);
+        const auto before = snapshot_regular_files(over.path());
+        auto journal = DurableJournal::native(over.path(), limits);
+        auto result = journal.recover_existing(TrustedReplayFloor::exact_root(
+            std::string(chain.genesis_root.canonical_bytes())));
+        require_result(result, DurableJournalStatus::LimitExceeded,
+                       "native over-cap journal read was not limited");
+        require(snapshot_regular_files(over.path()) == before,
+                "native over-cap read changed authority bytes");
+    }
+}
+
+void require_native_literal_children() {
+    const std::vector<std::string> journal_ids{
+        "../escape",
+        "/absolute",
+        "C:\\root\\journal",
+        "\\\\?\\C:\\device",
+        "CON",
+        "con",
+        "A",
+        "a",
+        "%2e%2e%2fescape",
+        "..\\escape",
+        "aux.txt",
+        "PRN",
+        "COM1",
+        "LPT1",
+        "authority-root.json",
+        "authority.lock",
+        "JOURNAL.JSONL",
+        "\\\\server\\share",
+    };
+    const std::set<std::string> expected_children{
+        "authority-root.json", "authority.lock", "journal.jsonl"};
+    NativeDirectory parent("task020-unicode-parent");
+    write_bytes(parent.path() / "outside-sentinel.bin", "outside-authority");
+    for (std::size_t index = 0; index < journal_ids.size(); ++index) {
+        const auto authority_directory =
+            parent.path() / ("authority-case-" + std::to_string(index));
+        std::filesystem::create_directories(authority_directory);
+        static_cast<void>(
+            create_native(authority_directory, make_chain(journal_ids[index])));
+        std::set<std::string> children;
+        for (const auto &entry :
+             std::filesystem::directory_iterator(authority_directory)) {
+            children.insert(entry.path().filename().string());
+        }
+        require(children == expected_children,
+                "native identity influenced the fixed child set");
+    }
+    const auto parent_snapshot = snapshot_regular_files(parent.path());
+    require(parent_snapshot.at("outside-sentinel.bin") == "outside-authority" &&
+                parent_snapshot.size() == journal_ids.size() * 3 + 1,
+            "native identifier escaped or changed its selected directory");
+
+    const auto missing_directory = parent.path() / "missing-authority";
+    auto missing_journal =
+        DurableJournal::native(missing_directory, generous_limits());
+    auto missing_result = missing_journal.create_new(
+        TrustedReplayFloor::uninitialized(), make_chain().genesis);
+    require_result(missing_result, DurableJournalStatus::UnsupportedStorage,
+                   "native persistence created a missing authority directory");
+    require(!std::filesystem::exists(missing_directory) &&
+                read_bytes(parent.path() / "outside-sentinel.bin") ==
+                    "outside-authority",
+            "native missing-directory refusal changed its parent");
+
+    auto authority_directory = extended_length_path(
+        parent.path() /
+        std::filesystem::u8path(u8"authority-\u4F4F\u5B85-\u00E9-\U0001F680"));
+    for (int index = 0; index < 7; ++index) {
+        authority_directory /= std::string(48, static_cast<char>('a' + index));
+    }
+    std::filesystem::create_directories(authority_directory);
+    const auto long_path_chain = make_chain("../C:\\PRN/authority-root.json");
+    static_cast<void>(create_native(authority_directory, long_path_chain));
+    std::set<std::string> children;
+    for (const auto &entry :
+         std::filesystem::directory_iterator(authority_directory)) {
+        children.insert(entry.path().filename().string());
+    }
+    require(children == expected_children,
+            "native long Unicode parent changed fixed child names");
+    require(read_bytes(authority_directory / "journal.jsonl") ==
+                frame(long_path_chain.genesis),
+            "native path handling changed journal bytes");
+}
+
+std::set<std::string>
+direct_child_names(const std::filesystem::path &directory) {
+    std::set<std::string> names;
+    for (const auto &entry : std::filesystem::directory_iterator(directory)) {
+        names.insert(entry.path().filename().generic_string());
+    }
+    return names;
+}
+
+void require_native_fresh_namespace_asymmetry() {
+    const auto chain = make_chain();
+    const std::vector<std::pair<std::string, std::string>> blockers{
+        {"authority-root.json",
+         std::string(chain.genesis_root.canonical_bytes())},
+        {"journal.jsonl", frame(chain.genesis)},
+        {".authority-root.json.stage", "root-stage-residue"},
+        {".journal.jsonl.stage", "journal-stage-residue"},
+        {"authority-root.json", ""},
+        {"journal.jsonl", ""},
+    };
+    NativeDirectory parent("task020-native-create-asymmetry");
+    write_bytes(parent.path() / "parent-sentinel.bin", "parent-sentinel");
+
+    for (std::size_t index = 0; index < blockers.size(); ++index) {
+        const auto authority_directory =
+            parent.path() / ("incomplete-" + std::to_string(index));
+        std::filesystem::create_directory(authority_directory);
+        const auto &[name, bytes] = blockers[index];
+        write_bytes(authority_directory / "authority.lock", "");
+        write_bytes(authority_directory / name, bytes);
+        const auto before = snapshot_regular_files(authority_directory);
+
+        auto journal =
+            DurableJournal::native(authority_directory, generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "native create overwrote incomplete fixed namespace");
+        const auto after = snapshot_regular_files(authority_directory);
+        const auto preserved = after.find(name);
+        require(preserved != after.end() && preserved->second == bytes &&
+                    after == before,
+                "native create changed incomplete fixed evidence");
+        for (const auto &child : direct_child_names(authority_directory)) {
+            require(child == name || child == "authority.lock",
+                    "native create added authority files to an incomplete "
+                    "namespace");
+        }
+        require(read_bytes(parent.path() / "parent-sentinel.bin") ==
+                    "parent-sentinel",
+                "native incomplete create changed its parent");
+    }
+
+    const auto duplicate_directory = parent.path() / "complete-duplicate";
+    std::filesystem::create_directory(duplicate_directory);
+    static_cast<void>(create_native(duplicate_directory, chain));
+    const auto duplicate_before = snapshot_regular_files(duplicate_directory);
+    auto duplicate_journal =
+        DurableJournal::native(duplicate_directory, generous_limits());
+    auto duplicate = duplicate_journal.create_new(
+        TrustedReplayFloor::uninitialized(), chain.genesis);
+    require_result(duplicate, DurableJournalStatus::ConflictBeforeWrite,
+                   "native complete namespace was not a create conflict");
+    require(snapshot_regular_files(duplicate_directory) == duplicate_before,
+            "native duplicate create changed complete authority");
+
+    for (const auto &[stage_name, stage_bytes] :
+         {std::pair{std::string(".authority-root.json.stage"),
+                    std::string("root-stage-with-complete-authority")},
+          std::pair{std::string(".journal.jsonl.stage"),
+                    std::string("journal-stage-with-complete-authority")}}) {
+        const auto authority_directory =
+            parent.path() / (stage_name == ".authority-root.json.stage"
+                                 ? "complete-with-root-stage"
+                                 : "complete-with-journal-stage");
+        std::filesystem::create_directory(authority_directory);
+        static_cast<void>(create_native(authority_directory, chain));
+        write_bytes(authority_directory / stage_name, stage_bytes);
+        const auto before = snapshot_regular_files(authority_directory);
+
+        auto journal =
+            DurableJournal::native(authority_directory, generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         chain.genesis);
+        require_result(result, DurableJournalStatus::CorruptOrRollback,
+                       "native stage did not override complete-create "
+                       "conflict classification");
+        require(snapshot_regular_files(authority_directory) == before &&
+                    read_bytes(authority_directory / stage_name) == stage_bytes,
+                "native create changed complete authority with stage "
+                "residue");
+        require(read_bytes(parent.path() / "parent-sentinel.bin") ==
+                    "parent-sentinel",
+                "native complete-with-stage create changed its parent");
+    }
+
+    const auto lock_only_directory = parent.path() / "lock-only";
+    std::filesystem::create_directory(lock_only_directory);
+    write_bytes(lock_only_directory / "authority.lock", "");
+    static_cast<void>(create_native(lock_only_directory, chain));
+
+    const auto sentinel_directory = parent.path() / "unrelated-sentinel";
+    std::filesystem::create_directory(sentinel_directory);
+    write_bytes(sentinel_directory / "sentinel.bin", "unrelated-sentinel");
+    static_cast<void>(create_native(sentinel_directory, chain));
+    require(read_bytes(sentinel_directory / "sentinel.bin") ==
+                "unrelated-sentinel",
+            "native create changed an unrelated sentinel");
+}
+
+bool is_explicit_symlink_fixture_unavailability(const std::error_code &error) {
+#ifdef _WIN32
+    if (error.category() == std::system_category() &&
+        error.value() == ERROR_PRIVILEGE_NOT_HELD) {
+        return true;
+    }
+#endif
+    return error == std::errc::operation_not_permitted ||
+           error == std::errc::permission_denied ||
+           error == std::errc::function_not_supported ||
+           error == std::errc::not_supported ||
+           error == std::errc::read_only_file_system;
+}
+
+void require_symlink_fixture_unavailability_contract() {
+#ifdef _WIN32
+    require(is_explicit_symlink_fixture_unavailability(std::error_code(
+                ERROR_PRIVILEGE_NOT_HELD, std::system_category())),
+            "Windows symlink privilege failure was not treated as fixture "
+            "unavailability");
+    require(!is_explicit_symlink_fixture_unavailability(
+                std::error_code(ERROR_INVALID_NAME, std::system_category())),
+            "unrelated Windows symlink failure was treated as fixture "
+            "unavailability");
+#endif
+}
+
+void require_native_fixed_child_poisoning() {
+    const std::vector<std::string> fixed_children{
+        "journal.jsonl", "authority-root.json", "authority.lock",
+        ".journal.jsonl.stage", ".authority-root.json.stage"};
+    NativeDirectory parent("task020-fixed-child-poison");
+    const auto outside_directory = parent.path() / "outside";
+    std::filesystem::create_directory(outside_directory);
+    write_bytes(parent.path() / "parent-sentinel.bin", "parent-sentinel");
+    write_bytes(outside_directory / "target.bin", "outside-target");
+    const auto outside_before = snapshot_regular_files(outside_directory);
+
+    const auto require_unchanged_boundaries = [&] {
+        require(read_bytes(parent.path() / "parent-sentinel.bin") ==
+                        "parent-sentinel" &&
+                    snapshot_regular_files(outside_directory) == outside_before,
+                "fixed-child poison changed parent or outside bytes");
+    };
+    const auto require_only_poison_and_lock =
+        [&](const std::filesystem::path &authority_directory,
+            std::string_view poison_name) {
+            const auto children = direct_child_names(authority_directory);
+            for (const auto &child : children) {
+                require(child == poison_name || child == "authority.lock",
+                        "fixed-child refusal retained an unexpected child");
+            }
+            require(children.count(std::string(poison_name)) == 1,
+                    "fixed-child refusal replaced the poison entry");
+            if (poison_name != "authority.lock" &&
+                children.count("authority.lock") != 0) {
+                const auto lock_status = std::filesystem::symlink_status(
+                    authority_directory / "authority.lock");
+                require(std::filesystem::is_regular_file(lock_status) &&
+                            !std::filesystem::is_symlink(lock_status),
+                        "fixed-child refusal produced an unsafe lock entry");
+            }
+        };
+
+    for (std::size_t index = 0; index < fixed_children.size(); ++index) {
+        const auto authority_directory =
+            parent.path() / ("directory-poison-" + std::to_string(index));
+        std::filesystem::create_directory(authority_directory);
+        const auto poison = authority_directory / fixed_children[index];
+        std::filesystem::create_directory(poison);
+        write_bytes(poison / "sentinel.bin", "poison-sentinel");
+
+        auto journal =
+            DurableJournal::native(authority_directory, generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         make_chain().genesis);
+        require_result(result, DurableJournalStatus::UnsupportedStorage,
+                       "native fixed directory was treated as a regular file");
+        require(std::filesystem::is_directory(
+                    std::filesystem::symlink_status(poison)) &&
+                    direct_child_names(poison) ==
+                        std::set<std::string>{"sentinel.bin"} &&
+                    read_bytes(poison / "sentinel.bin") == "poison-sentinel",
+                "native fixed directory was followed or replaced");
+        require_only_poison_and_lock(authority_directory,
+                                     fixed_children[index]);
+        require_unchanged_boundaries();
+    }
+
+    bool symlink_fixture_unavailable = false;
+    for (std::size_t index = 0; index < fixed_children.size(); ++index) {
+        const auto authority_directory =
+            parent.path() / ("symlink-poison-" + std::to_string(index));
+        std::filesystem::create_directory(authority_directory);
+        const auto poison = authority_directory / fixed_children[index];
+        std::error_code symlink_error;
+        std::filesystem::create_symlink(outside_directory / "target.bin",
+                                        poison, symlink_error);
+        if (symlink_error) {
+            require(index == 0 && is_explicit_symlink_fixture_unavailability(
+                                      symlink_error),
+                    "native symlink poison fixture failed unexpectedly");
+            symlink_fixture_unavailable = true;
+            break;
+        }
+
+        auto journal =
+            DurableJournal::native(authority_directory, generous_limits());
+        auto result = journal.create_new(TrustedReplayFloor::uninitialized(),
+                                         make_chain().genesis);
+        require_result(result, DurableJournalStatus::UnsupportedStorage,
+                       "native fixed symlink was followed as authority");
+        require(std::filesystem::is_symlink(
+                    std::filesystem::symlink_status(poison)),
+                "native fixed symlink was replaced");
+        require_only_poison_and_lock(authority_directory,
+                                     fixed_children[index]);
+        require_unchanged_boundaries();
+    }
+    if (symlink_fixture_unavailable) {
+        require(snapshot_regular_files(outside_directory) == outside_before,
+                "unavailable symlink fixture changed outside bytes");
+    }
+}
+
+void require_native_storage_identity_binding() {
+    const auto chain = make_chain();
+    NativeDirectory directory_a("task020-identity-a");
+    NativeDirectory directory_b("task020-identity-b");
+    static_cast<void>(create_native(directory_a.path(), chain));
+    static_cast<void>(create_native(directory_b.path(), chain));
+
+    std::error_code hard_link_error;
+    std::filesystem::remove(directory_b.path() / "authority.lock",
+                            hard_link_error);
+    require(!hard_link_error,
+            "native alias fixture could not remove the closed lock entry");
+    std::filesystem::create_hard_link(directory_a.path() / "authority.lock",
+                                      directory_b.path() / "authority.lock",
+                                      hard_link_error);
+    require(!hard_link_error,
+            "native alias fixture could not hard-link lock identities");
+
+    const auto b_before = snapshot_regular_files(directory_b.path());
+    auto append_authority = recover_native(
+        directory_a.path(), chain.genesis_root.canonical_bytes());
+    auto append_journal =
+        DurableJournal::native(directory_b.path(), generous_limits());
+    auto append_result = append_journal.append_and_publish(
+        std::move(append_authority), chain.successor);
+    require_result(append_result, DurableJournalStatus::CorruptOrRollback,
+                   "cross-directory authority token appended by byte identity");
+    require(!append_authority.available() &&
+                snapshot_regular_files(directory_b.path()) == b_before,
+            "cross-directory append changed authority storage");
+
+    auto compact_authority = recover_native(
+        directory_a.path(), chain.genesis_root.canonical_bytes());
+    auto compact_journal =
+        DurableJournal::native(directory_b.path(), generous_limits());
+    auto compact_result =
+        compact_journal.compact_physical(std::move(compact_authority));
+    require_result(
+        compact_result, DurableJournalStatus::CorruptOrRollback,
+        "cross-directory authority token compacted by byte identity");
+    require(!compact_authority.available() &&
+                snapshot_regular_files(directory_b.path()) == b_before,
+            "cross-directory compaction changed authority storage");
+
+    auto export_authority = recover_native(
+        directory_a.path(), chain.genesis_root.canonical_bytes());
+    auto export_journal =
+        DurableJournal::native(directory_b.path(), generous_limits());
+    auto export_result = export_journal.export_exact_schema_candidate(
+        export_authority, supported_journal_schema,
+        JournalQuiescence::Confirmed);
+    require(
+        export_result.status == ExactSchemaExportStatus::CorruptOrRollback &&
+            !export_result.exported() && !export_result.candidate.has_value() &&
+            export_authority.available() &&
+            snapshot_regular_files(directory_b.path()) == b_before,
+        "cross-directory authority token exported by byte identity");
+
+    auto same_storage_journal =
+        DurableJournal::native(directory_a.path(), generous_limits());
+    auto published = same_storage_journal.append_and_publish(
+        std::move(export_authority), chain.successor);
+    require_result(published, DurableJournalStatus::Published,
+                   "fresh adapter for the same directory rejected authority");
+}
+
+void require_native_lock_recreation_invalidates_authority() {
+    const auto chain = make_chain();
+    const auto root = std::string(chain.genesis_root.canonical_bytes());
+    const auto replace_lock = [](const std::filesystem::path &directory) {
+        const auto lock = directory / "authority.lock";
+        const auto retired = directory / "retired-authority-lock.bin";
+        std::error_code error;
+        std::filesystem::create_hard_link(lock, retired, error);
+        require(!error,
+                "native recreated-lock fixture could not retain old identity");
+        std::filesystem::remove(lock, error);
+        require(!error,
+                "native recreated-lock fixture could not unlink old entry");
+        write_bytes(lock, {});
+    };
+    const auto require_rebound = [&](const std::filesystem::path &directory) {
+        auto rebound = recover_native(directory, root);
+        require(rebound.available(),
+                "fresh native recovery did not bind recreated stable lock");
+    };
+
+    NativeDirectory append_directory("task020-recreated-lock-append");
+    auto append_token = create_native(append_directory.path(), chain);
+    replace_lock(append_directory.path());
+    const auto append_before = snapshot_regular_files(append_directory.path());
+    auto append_journal =
+        DurableJournal::native(append_directory.path(), generous_limits());
+    auto append_result = append_journal.append_and_publish(
+        std::move(append_token), chain.successor);
+    require_result(append_result, DurableJournalStatus::UnsupportedStorage,
+                   "recreated native lock accepted an old append token");
+    require(!append_token.available() &&
+                snapshot_regular_files(append_directory.path()) ==
+                    append_before,
+            "recreated-lock append changed authority bytes or retained token");
+    require_rebound(append_directory.path());
+
+    NativeDirectory compact_directory("task020-recreated-lock-compact");
+    auto compact_token = create_native(compact_directory.path(), chain);
+    replace_lock(compact_directory.path());
+    const auto compact_before =
+        snapshot_regular_files(compact_directory.path());
+    auto compact_journal =
+        DurableJournal::native(compact_directory.path(), generous_limits());
+    auto compact_result =
+        compact_journal.compact_physical(std::move(compact_token));
+    require_result(compact_result, DurableJournalStatus::UnsupportedStorage,
+                   "recreated native lock accepted an old compaction token");
+    require(!compact_token.available() &&
+                snapshot_regular_files(compact_directory.path()) ==
+                    compact_before,
+            "recreated-lock compaction changed bytes or retained token");
+    require_rebound(compact_directory.path());
+
+    NativeDirectory export_directory("task020-recreated-lock-export");
+    auto export_token = create_native(export_directory.path(), chain);
+    replace_lock(export_directory.path());
+    const auto export_before = snapshot_regular_files(export_directory.path());
+    auto export_journal =
+        DurableJournal::native(export_directory.path(), generous_limits());
+    auto export_result = export_journal.export_exact_schema_candidate(
+        export_token, supported_journal_schema, JournalQuiescence::Confirmed);
+    require(
+        export_result.status == ExactSchemaExportStatus::UnsupportedStorage &&
+            !export_result.exported() && !export_result.candidate.has_value() &&
+            export_token.available() &&
+            snapshot_regular_files(export_directory.path()) == export_before,
+        "recreated native lock accepted, consumed, or changed export "
+        "authority");
+    require_rebound(export_directory.path());
+}
+
+void require_native_lock_path_revalidation() {
+    NativeDirectory directory("task020-live-lock-path");
+    const auto probe =
+        probe_native_lock_path_revalidation(directory.path().string());
+    require(probe.nonblocking_probe_rejected &&
+                probe.first_unlock_succeeded &&
+                probe.contender_succeeded,
+            "native replacement lock was not serialized with the held "
+            "authority lock");
+#ifdef _WIN32
+    require(probe.replacement_prevented_while_held &&
+                !probe.contender_rebound &&
+                probe.replacement_after_release_rebound,
+            "Windows authority lock path was replaceable while held or did "
+            "not rebind after release");
+#else
+    require(!probe.replacement_prevented_while_held &&
+                probe.stale_identity_rejected && probe.contender_rebound,
+            "POSIX authority identity did not reject and serialize a replaced "
+            "live lock path");
+#endif
+}
+
+void require_same_process_cas_race() {
+    const auto chain = make_chain();
+    NativeDirectory directory("task020-same-process");
+    static_cast<void>(create_native(directory.path(), chain));
+    auto left =
+        recover_native(directory.path(), chain.genesis_root.canonical_bytes());
+    auto right =
+        recover_native(directory.path(), chain.genesis_root.canonical_bytes());
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    int ready = 0;
+    bool go = false;
+    std::optional<DurableJournalStatus> left_status;
+    std::optional<DurableJournalStatus> right_status;
+    const auto run = [&](PublishedJournal authority,
+                         std::optional<DurableJournalStatus> &status) mutable {
+        {
+            std::unique_lock lock(mutex);
+            ++ready;
+            condition.notify_all();
+            condition.wait(lock, [&] { return go; });
+        }
+        auto journal =
+            DurableJournal::native(directory.path(), generous_limits());
+        status =
+            journal.append_and_publish(std::move(authority), chain.successor)
+                .status;
+    };
+    std::thread left_thread(run, std::move(left), std::ref(left_status));
+    std::thread right_thread(run, std::move(right), std::ref(right_status));
+    {
+        std::unique_lock lock(mutex);
+        condition.wait(lock, [&] { return ready == 2; });
+        go = true;
+    }
+    condition.notify_all();
+    left_thread.join();
+    right_thread.join();
+
+    const std::multiset<DurableJournalStatus> observed{*left_status,
+                                                       *right_status};
+    const std::multiset<DurableJournalStatus> expected{
+        DurableJournalStatus::Published,
+        DurableJournalStatus::ConflictBeforeWrite};
+    require(observed == expected,
+            "same-process CAS race did not select exactly one writer");
+    require(read_bytes(directory.path() / "journal.jsonl") ==
+                    frame(chain.genesis) + frame(chain.successor) &&
+                read_bytes(directory.path() / "authority-root.json") ==
+                    chain.successor_root.canonical_bytes(),
+            "losing same-process writer changed authority bytes");
+}
+
+std::string_view status_wire(DurableJournalStatus status) {
+    switch (status) {
+    case DurableJournalStatus::Published:
+        return "published";
+    case DurableJournalStatus::ConflictBeforeWrite:
+        return "conflict_before_write";
+    case DurableJournalStatus::UnsupportedStorage:
+        return "unsupported_storage";
+    case DurableJournalStatus::CorruptOrRollback:
+        return "corrupt_or_rollback";
+    case DurableJournalStatus::LimitExceeded:
+        return "limit_exceeded";
+    case DurableJournalStatus::RecoveryRequired:
+        return "recovery_required";
+    }
+    return "unknown";
+}
+
+int race_init(const std::filesystem::path &directory,
+              const std::filesystem::path &floor_file) {
+    const auto chain = make_chain();
+    const auto authority = create_native(directory, chain);
+    write_bytes(floor_file, authority.root_bytes());
+    return 0;
+}
+
+int race_worker(const std::filesystem::path &directory,
+                const std::filesystem::path &floor_file,
+                const std::filesystem::path &ready_file,
+                const std::filesystem::path &go_file) {
+    const auto chain = make_chain();
+    auto authority = recover_native(directory, read_bytes(floor_file));
+    write_bytes(ready_file, "ready");
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (!std::filesystem::exists(go_file)) {
+        require(std::chrono::steady_clock::now() < deadline,
+                "cross-process race start timed out");
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    auto journal = DurableJournal::native(directory, generous_limits());
+    const auto result =
+        journal.append_and_publish(std::move(authority), chain.successor);
+    std::cout << status_wire(result.status) << '\n';
+    return 0;
+}
+
+int race_verify(const std::filesystem::path &directory,
+                const std::filesystem::path &floor_file) {
+    const auto chain = make_chain();
+    const auto authority = recover_native(directory, read_bytes(floor_file));
+    require(authority.root_bytes() == chain.successor_root.canonical_bytes(),
+            "cross-process race recovered the wrong root");
+    require(read_bytes(directory / "journal.jsonl") ==
+                    frame(chain.genesis) + frame(chain.successor) &&
+                read_bytes(directory / "authority-root.json") ==
+                    chain.successor_root.canonical_bytes(),
+            "cross-process CAS loser changed authority bytes");
+    return 0;
+}
+
+int run_command(int argc, char **argv) {
+    if (argc == 4 && std::string_view(argv[1]) == "--race-init") {
+        return race_init(argv[2], argv[3]);
+    }
+    if (argc == 6 && std::string_view(argv[1]) == "--race-worker") {
+        return race_worker(argv[2], argv[3], argv[4], argv[5]);
+    }
+    if (argc == 4 && std::string_view(argv[1]) == "--race-verify") {
+        return race_verify(argv[2], argv[3]);
+    }
+    return -1;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    if (argc != 1) {
+        const auto command_result = run_command(argc, argv);
+        require(command_result >= 0,
+                "unsupported durable-journal public-seam arguments");
+        return command_result;
+    }
+
+    require_public_shape();
+    require_shared_io_helpers();
+    require_exact_initial_publication();
+    require_durable_journal_moves();
+    require_explicit_floor_states();
+    require_fresh_namespace_asymmetry();
+    require_unique_authority_moves();
+    require_fixed_paths();
+    require_identifier_boundaries_precede_persistence();
+    require_replay_and_floors();
+    require_surviving_stage_recovery();
+    require_root_parser_is_task019();
+    require_committed_origin_verification();
+    require_origin_verifier_publication_and_lifetime();
+    require_tail_classification_and_repair();
+    require_explicit_limits();
+    require_durability_ordering();
+    require_stage_replacement_swap_is_fail_closed();
+    require_paused_read_replacement_is_fail_closed();
+    require_paused_read_holds_authority_lock();
+    require_paused_write_observes_completed_effect();
+    require_fake_adapter_destructor_closes_open_lock();
+    require_final_under_lock_revalidation();
+    require_preflight_and_bounded_read_trace();
+    require_create_faults();
+    require_append_and_fault_recovery();
+    require_stale_cas_is_write_free();
+    require_history_invalid_append_is_write_free();
+    require_partial_io_and_interrupt_retries();
+    require_stable_lock_identity();
+    require_fence_epoch_cas_clear();
+    require_fake_storage_identity_binding();
+    require_fake_lock_recreation_invalidates_authority();
+    require_directory_lineage_fence_cleanup();
+    require_fenced_fresh_create_reconciles();
+    require_create_post_failure_clearance_proof();
+    require_retained_fresh_create_requires_live_lock();
+    require_repair_faults();
+    require_read_only_recovery_faults();
+    require_physical_compaction();
+    require_exact_schema_export();
+    require_unsupported_preflight();
+    require_native_preflight_identity_phase_residue();
+    require_native_preflight_fence_blocks_nonfresh_authority();
+    require_native_preflight_preserves_siblings();
+    require_native_preflight_stage_collision_exhaustion_is_fenced();
+    require_native_relative_directory_binding();
+    require_native_unbound_adapter_preserves_working_directory();
+    require_native_bounded_read_boundaries();
+    require_native_literal_children();
+    require_native_fresh_namespace_asymmetry();
+    require_symlink_fixture_unavailability_contract();
+    require_native_fixed_child_poisoning();
+    require_native_storage_identity_binding();
+    require_native_lock_recreation_invalidates_authority();
+    require_native_lock_path_revalidation();
+    require_same_process_cas_race();
+    return 0;
+}

--- a/test/residency/recovery/journal_persistence_test_support.cpp
+++ b/test/residency/recovery/journal_persistence_test_support.cpp
@@ -1,0 +1,2294 @@
+#include "journal_persistence_test_support.h"
+
+#include "platform/durable_file_adapter.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+#endif
+
+namespace lemon::residency::testing {
+
+namespace {
+
+using detail::DurableFileChannel;
+using detail::DurableFileResult;
+using detail::DurableFileStatus;
+using detail::DurableInterruptibleCall;
+using detail::DurableReadChannel;
+using detail::DurableReadChunkResult;
+using detail::DurableWriteResult;
+
+constexpr std::string_view journal_name = "journal.jsonl";
+constexpr std::string_view root_name = "authority-root.json";
+constexpr std::string_view lock_name = "authority.lock";
+constexpr std::string_view journal_stage_name = ".journal.jsonl.stage";
+constexpr std::string_view root_stage_name = ".authority-root.json.stage";
+constexpr std::string_view preflight_probe_name = ".durability-probe";
+constexpr std::string_view preflight_stage_name = ".durability-probe.stage";
+
+std::atomic<std::uint64_t> next_directory_identity{1};
+std::atomic<std::uint64_t> next_entry_identity{1};
+std::atomic<std::uint64_t> next_handle_identity{1};
+
+DurableFileResult result(DurableFileStatus status) {
+    return DurableFileResult{status, {}};
+}
+
+DurableFileResult succeeded() { return result(DurableFileStatus::Succeeded); }
+
+bool is_succeeded(const DurableFileResult &value) {
+    return value.status == DurableFileStatus::Succeeded;
+}
+
+DurableFileResult
+promote_after_persistent_effect(DurableFileResult value) {
+    if (is_succeeded(value) ||
+        value.status == DurableFileStatus::EffectMayHaveOccurred) {
+        return value;
+    }
+    return {DurableFileStatus::EffectMayHaveOccurred,
+            std::move(value.diagnostic)};
+}
+
+HelperResultKind helper_result_kind(DurableFileStatus status) {
+    switch (status) {
+    case DurableFileStatus::Succeeded:
+        return HelperResultKind::Succeeded;
+    case DurableFileStatus::Interrupted:
+        return HelperResultKind::Interrupted;
+    case DurableFileStatus::EffectMayHaveOccurred:
+        return HelperResultKind::EffectMayHaveOccurred;
+    case DurableFileStatus::Unsupported:
+    case DurableFileStatus::NotFound:
+    case DurableFileStatus::AlreadyExists:
+    case DurableFileStatus::FailedBeforeEffect:
+        return HelperResultKind::FailedBeforeEffect;
+    }
+    return HelperResultKind::FailedBeforeEffect;
+}
+
+bool is_authority_operation(FaultOperation operation) {
+    switch (operation) {
+    case FaultOperation::AuthorityIdentityRead:
+    case FaultOperation::FixedNamespaceInspect:
+    case FaultOperation::RootOpen:
+    case FaultOperation::RootRead:
+    case FaultOperation::RootClose:
+    case FaultOperation::JournalOpen:
+    case FaultOperation::JournalRead:
+    case FaultOperation::JournalReadClose:
+    case FaultOperation::JournalAppendOpen:
+    case FaultOperation::InitialJournalCreate:
+    case FaultOperation::JournalWrite:
+    case FaultOperation::JournalFlush:
+    case FaultOperation::JournalClose:
+    case FaultOperation::RootStageCreate:
+    case FaultOperation::RootStageWrite:
+    case FaultOperation::RootStageFlush:
+    case FaultOperation::RootStageClose:
+    case FaultOperation::RootReplace:
+    case FaultOperation::NamespaceDurability:
+    case FaultOperation::TailRepairOpen:
+    case FaultOperation::TailRepairTruncate:
+    case FaultOperation::TailRepairFlush:
+    case FaultOperation::TailRepairClose:
+    case FaultOperation::CompactionStageCreate:
+    case FaultOperation::CompactionWrite:
+    case FaultOperation::CompactionFlush:
+    case FaultOperation::CompactionClose:
+    case FaultOperation::CompactionReplace:
+    case FaultOperation::CompactionNamespaceDurability:
+        return true;
+    default:
+        return false;
+    }
+}
+
+class ScriptedProbeChannel final : public DurableFileChannel {
+public:
+    explicit ScriptedProbeChannel(std::vector<FaultAction> script,
+                                  std::string initial = {})
+        : script_(std::move(script)), bytes_(std::move(initial)) {}
+
+    DurableWriteResult write_some(std::string_view bytes) override {
+        ++attempts_;
+        const auto action = next_action();
+        if (!action.has_value()) {
+            bytes_.append(bytes);
+            return {succeeded(), bytes.size()};
+        }
+        switch (*action) {
+        case FaultAction::ShortWrite: {
+            const auto transferred =
+                bytes.size() <= 1 ? bytes.size() : bytes.size() / 2;
+            bytes_.append(bytes.substr(0, transferred));
+            return {succeeded(), transferred};
+        }
+        case FaultAction::InterruptedOnce:
+            return {result(DurableFileStatus::Interrupted), 0};
+        case FaultAction::ZeroProgress:
+            return {succeeded(), 0};
+        case FaultAction::OverreportedWrite:
+            return {succeeded(), bytes.size() + 1};
+        case FaultAction::EffectThenError:
+            bytes_.append(bytes);
+            return {result(DurableFileStatus::EffectMayHaveOccurred),
+                    bytes.size()};
+        case FaultAction::Error:
+        case FaultAction::Crash:
+            return {result(DurableFileStatus::FailedBeforeEffect), 0};
+        }
+        return {result(DurableFileStatus::Unsupported), 0};
+    }
+
+    DurableFileResult flush() override {
+        ++attempts_;
+        return scripted_call([] {});
+    }
+
+    DurableFileResult truncate(std::size_t bytes) override {
+        ++attempts_;
+        return scripted_call(
+            [&] { bytes_.resize(std::min(bytes, bytes_.size())); });
+    }
+
+    DurableFileResult close() override {
+        ++attempts_;
+        return scripted_call([] {});
+    }
+
+    const std::string &bytes() const noexcept { return bytes_; }
+    std::size_t attempts() const noexcept { return attempts_; }
+
+private:
+    std::optional<FaultAction> next_action() {
+        if (next_action_ == script_.size()) {
+            return std::nullopt;
+        }
+        return script_[next_action_++];
+    }
+
+    template <typename Effect> DurableFileResult scripted_call(Effect effect) {
+        const auto action = next_action();
+        if (!action.has_value()) {
+            effect();
+            return succeeded();
+        }
+        switch (*action) {
+        case FaultAction::InterruptedOnce:
+            return result(DurableFileStatus::Interrupted);
+        case FaultAction::Error:
+        case FaultAction::Crash:
+        case FaultAction::ZeroProgress:
+        case FaultAction::OverreportedWrite:
+            return result(DurableFileStatus::FailedBeforeEffect);
+        case FaultAction::EffectThenError:
+            effect();
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        case FaultAction::ShortWrite:
+            effect();
+            return succeeded();
+        }
+        return result(DurableFileStatus::Unsupported);
+    }
+
+    std::vector<FaultAction> script_;
+    std::size_t next_action_ = 0;
+    std::string bytes_;
+    std::size_t attempts_ = 0;
+};
+
+class ScriptedOrchestrationChannel final : public DurableFileChannel {
+public:
+    ScriptedOrchestrationChannel(std::vector<FaultAction> write_script,
+                                 std::vector<FaultAction> flush_script,
+                                 std::vector<FaultAction> truncate_script,
+                                 std::vector<FaultAction> close_script,
+                                 std::string initial = {})
+        : write_script_(std::move(write_script)),
+          flush_script_(std::move(flush_script)),
+          truncate_script_(std::move(truncate_script)),
+          close_script_(std::move(close_script)), bytes_(std::move(initial)) {}
+
+    DurableWriteResult write_some(std::string_view bytes) override {
+        ++write_attempts_;
+        const auto action = next_action(write_script_, next_write_action_);
+        if (!action.has_value()) {
+            bytes_.append(bytes);
+            return {succeeded(), bytes.size()};
+        }
+        switch (*action) {
+        case FaultAction::ShortWrite: {
+            const auto transferred =
+                bytes.size() <= 1 ? bytes.size() : bytes.size() / 2;
+            bytes_.append(bytes.substr(0, transferred));
+            return {succeeded(), transferred};
+        }
+        case FaultAction::InterruptedOnce:
+            return {result(DurableFileStatus::Interrupted), 0};
+        case FaultAction::ZeroProgress:
+            return {succeeded(), 0};
+        case FaultAction::OverreportedWrite:
+            return {succeeded(), bytes.size() + 1};
+        case FaultAction::EffectThenError:
+            bytes_.append(bytes);
+            return {result(DurableFileStatus::EffectMayHaveOccurred),
+                    bytes.size()};
+        case FaultAction::Error:
+        case FaultAction::Crash:
+            return {result(DurableFileStatus::FailedBeforeEffect), 0};
+        }
+        return {result(DurableFileStatus::Unsupported), 0};
+    }
+
+    DurableFileResult flush() override {
+        ++flush_attempts_;
+        return scripted_call(flush_script_, next_flush_action_, [] {});
+    }
+
+    DurableFileResult truncate(std::size_t bytes) override {
+        ++truncate_attempts_;
+        return scripted_call(truncate_script_, next_truncate_action_, [&] {
+            bytes_.resize(std::min(bytes, bytes_.size()));
+        });
+    }
+
+    DurableFileResult close() override {
+        ++close_attempts_;
+        return scripted_call(close_script_, next_close_action_, [] {});
+    }
+
+    const std::string &bytes() const noexcept { return bytes_; }
+    std::size_t write_attempts() const noexcept { return write_attempts_; }
+    std::size_t flush_attempts() const noexcept { return flush_attempts_; }
+    std::size_t truncate_attempts() const noexcept {
+        return truncate_attempts_;
+    }
+    std::size_t close_attempts() const noexcept { return close_attempts_; }
+
+private:
+    static std::optional<FaultAction>
+    next_action(const std::vector<FaultAction> &script, std::size_t &next) {
+        if (next == script.size()) {
+            return std::nullopt;
+        }
+        return script[next++];
+    }
+
+    template <typename Effect>
+    static DurableFileResult
+    scripted_call(const std::vector<FaultAction> &script, std::size_t &next,
+                  Effect effect) {
+        const auto action = next_action(script, next);
+        if (!action.has_value()) {
+            effect();
+            return succeeded();
+        }
+        switch (*action) {
+        case FaultAction::InterruptedOnce:
+            return result(DurableFileStatus::Interrupted);
+        case FaultAction::Error:
+        case FaultAction::Crash:
+        case FaultAction::ZeroProgress:
+        case FaultAction::OverreportedWrite:
+            return result(DurableFileStatus::FailedBeforeEffect);
+        case FaultAction::EffectThenError:
+            effect();
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        case FaultAction::ShortWrite:
+            effect();
+            return succeeded();
+        }
+        return result(DurableFileStatus::Unsupported);
+    }
+
+    std::vector<FaultAction> write_script_;
+    std::vector<FaultAction> flush_script_;
+    std::vector<FaultAction> truncate_script_;
+    std::vector<FaultAction> close_script_;
+    std::size_t next_write_action_ = 0;
+    std::size_t next_flush_action_ = 0;
+    std::size_t next_truncate_action_ = 0;
+    std::size_t next_close_action_ = 0;
+    std::string bytes_;
+    std::size_t write_attempts_ = 0;
+    std::size_t flush_attempts_ = 0;
+    std::size_t truncate_attempts_ = 0;
+    std::size_t close_attempts_ = 0;
+};
+
+class ScriptedReadChannel final : public DurableReadChannel {
+public:
+    ScriptedReadChannel(std::string bytes, std::vector<FaultAction> read_script,
+                        std::vector<FaultAction> close_script)
+        : bytes_(std::move(bytes)), read_script_(std::move(read_script)),
+          close_script_(std::move(close_script)) {}
+
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        ++read_attempts_;
+        requested_bytes_.push_back(max_bytes);
+        const auto action = next_action(read_script_, next_read_action_);
+        if (action == FaultAction::InterruptedOnce) {
+            return record_chunk(
+                {result(DurableFileStatus::Interrupted), {}, false});
+        }
+        if (action == FaultAction::ZeroProgress) {
+            return record_chunk({succeeded(), {}, false});
+        }
+        if (action == FaultAction::OverreportedWrite) {
+            return record_chunk(
+                {succeeded(), std::string(max_bytes + 1, 'x'), false});
+        }
+        if (action == FaultAction::Error || action == FaultAction::Crash) {
+            return record_chunk(
+                {result(DurableFileStatus::FailedBeforeEffect), {}, false});
+        }
+
+        auto transferred = std::min(max_bytes, bytes_.size() - offset_);
+        if (action == FaultAction::ShortWrite && transferred > 1) {
+            transferred /= 2;
+        }
+        auto chunk = bytes_.substr(offset_, transferred);
+        offset_ += transferred;
+        const auto end_of_file = transferred == 0 && offset_ == bytes_.size();
+        if (action == FaultAction::EffectThenError) {
+            return record_chunk(
+                {result(DurableFileStatus::EffectMayHaveOccurred),
+                 std::move(chunk), end_of_file});
+        }
+        return record_chunk({succeeded(), std::move(chunk), end_of_file});
+    }
+
+    DurableFileResult close() override {
+        ++close_attempts_;
+        const auto action = next_action(close_script_, next_close_action_);
+        if (!action.has_value() || action == FaultAction::ShortWrite) {
+            return succeeded();
+        }
+        if (action == FaultAction::InterruptedOnce) {
+            return result(DurableFileStatus::Interrupted);
+        }
+        if (action == FaultAction::EffectThenError) {
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        return result(DurableFileStatus::FailedBeforeEffect);
+    }
+
+    const std::vector<std::size_t> &requested_bytes() const noexcept {
+        return requested_bytes_;
+    }
+    const std::vector<std::size_t> &returned_bytes() const noexcept {
+        return returned_bytes_;
+    }
+    std::size_t read_attempts() const noexcept { return read_attempts_; }
+    std::size_t close_attempts() const noexcept { return close_attempts_; }
+
+private:
+    static std::optional<FaultAction>
+    next_action(const std::vector<FaultAction> &script, std::size_t &next) {
+        if (next == script.size()) {
+            return std::nullopt;
+        }
+        return script[next++];
+    }
+
+    DurableReadChunkResult record_chunk(DurableReadChunkResult chunk) {
+        returned_bytes_.push_back(chunk.bytes.size());
+        return chunk;
+    }
+
+    std::string bytes_;
+    std::vector<FaultAction> read_script_;
+    std::vector<FaultAction> close_script_;
+    std::vector<std::size_t> requested_bytes_;
+    std::vector<std::size_t> returned_bytes_;
+    std::size_t offset_ = 0;
+    std::size_t next_read_action_ = 0;
+    std::size_t next_close_action_ = 0;
+    std::size_t read_attempts_ = 0;
+    std::size_t close_attempts_ = 0;
+};
+
+} // namespace
+
+struct JournalTestStorage::State {
+    enum class EntryKind { Regular, Symlink, NonRegular, ReparsePoint };
+
+    struct Entry {
+        EntryKind kind = EntryKind::Regular;
+        std::string live_bytes;
+        std::string durable_bytes;
+        bool live_exists = false;
+        bool durable_exists = false;
+        bool durable_content_available = false;
+        std::uint64_t identity = 0;
+    };
+
+    struct FaultScript {
+        FaultOperation operation;
+        FaultPosition position;
+        std::deque<FaultAction> actions;
+    };
+
+    explicit State(PlatformContract selected_platform, bool directory_present)
+        : platform(selected_platform),
+          authority_directory_exists(directory_present),
+          directory_identity(next_directory_identity.fetch_add(1)) {}
+
+    void add_durable_regular(std::string_view name, std::string bytes) {
+        auto &entry = entries[std::string(name)];
+        entry.kind = EntryKind::Regular;
+        entry.live_bytes = bytes;
+        entry.durable_bytes = std::move(bytes);
+        entry.live_exists = true;
+        entry.durable_exists = true;
+        entry.durable_content_available = true;
+        if (entry.identity == 0) {
+            entry.identity = next_entry_identity.fetch_add(1);
+        }
+    }
+
+    Entry *live_entry(std::string_view name) {
+        const auto found = entries.find(std::string(name));
+        if (found == entries.end() || !found->second.live_exists) {
+            return nullptr;
+        }
+        return &found->second;
+    }
+
+    const Entry *live_entry(std::string_view name) const {
+        const auto found = entries.find(std::string(name));
+        if (found == entries.end() || !found->second.live_exists) {
+            return nullptr;
+        }
+        return &found->second;
+    }
+
+    void observe(FaultOperation operation, bool lock_held,
+                 bool mutation_attempted, std::uint64_t lock_identity,
+                 std::size_t requested_bytes = 0,
+                 std::size_t transferred_bytes = 0) {
+        observations.push_back(OperationObservation{
+            operation, lock_held, mutation_attempted, lock_identity,
+            requested_bytes, transferred_bytes});
+    }
+
+    std::optional<FaultAction> take_fault(FaultOperation operation,
+                                          FaultPosition position) {
+        if (!fault.has_value() || fault->operation != operation ||
+            fault->position != position || fault->actions.empty()) {
+            return std::nullopt;
+        }
+        const auto action = fault->actions.front();
+        fault->actions.pop_front();
+        if (fault->actions.empty()) {
+            fault.reset();
+        }
+        return action;
+    }
+
+    void restart() {
+        if (simulated_crash) {
+            for (auto &[name, entry] : entries) {
+                static_cast<void>(name);
+                if (entry.kind == EntryKind::Regular && entry.live_exists &&
+                    entry.durable_content_available) {
+                    entry.durable_exists = true;
+                }
+            }
+        }
+        for (auto &[name, entry] : entries) {
+            static_cast<void>(name);
+            entry.live_exists = entry.durable_exists;
+            entry.live_bytes = entry.durable_bytes;
+        }
+        held_lock_identities.clear();
+        blocked_lock_waiters = 0;
+        fault.reset();
+        pause_operation.reset();
+        pause_occurrence = 0;
+        paused = false;
+        pause_released = false;
+        open_entries.clear();
+        open_lock_handles.clear();
+        simulated_crash = false;
+        condition.notify_all();
+    }
+
+    PlatformContract platform;
+    bool authority_directory_exists;
+    const std::uint64_t directory_identity;
+    std::map<std::string, Entry> entries;
+    std::set<DurabilityCapability> unavailable_capabilities;
+    std::optional<FaultScript> fault;
+    std::vector<OperationObservation> observations;
+    std::set<std::uint64_t> held_lock_identities;
+    std::size_t blocked_lock_waiters = 0;
+    std::optional<FaultOperation> pause_operation;
+    std::size_t pause_occurrence = 0;
+    bool pause_consumed = false;
+    bool paused = false;
+    bool pause_released = false;
+    std::set<std::string> open_entries;
+    std::set<std::uint64_t> open_lock_handles;
+    bool simulated_crash = false;
+    mutable std::mutex mutex;
+    std::condition_variable condition;
+};
+
+HelperProbeResult probe_write_all(std::string bytes,
+                                  std::vector<FaultAction> script) {
+    ScriptedProbeChannel channel(std::move(script));
+    const auto call_result = detail::write_all(channel, bytes);
+    return {helper_result_kind(call_result.status), channel.bytes(),
+            channel.attempts()};
+}
+
+HelperProbeResult probe_flush_retry(std::vector<FaultAction> script) {
+    ScriptedProbeChannel channel(std::move(script));
+    const auto call_result = detail::flush_retrying_interrupts(channel);
+    return {helper_result_kind(call_result.status), channel.bytes(),
+            channel.attempts()};
+}
+
+HelperProbeResult probe_truncate_retry(std::string bytes,
+                                       std::size_t truncate_to,
+                                       std::vector<FaultAction> script) {
+    ScriptedProbeChannel channel(std::move(script), std::move(bytes));
+    const auto call_result =
+        detail::truncate_retrying_interrupts(channel, truncate_to);
+    return {helper_result_kind(call_result.status), channel.bytes(),
+            channel.attempts()};
+}
+
+HelperProbeResult probe_close_once(std::vector<FaultAction> script) {
+    ScriptedProbeChannel channel(std::move(script));
+    const auto call_result = detail::close_once(channel);
+    return {helper_result_kind(call_result.status), channel.bytes(),
+            channel.attempts()};
+}
+
+HelperOrchestrationProbeResult
+probe_write_flush_close(std::string bytes,
+                        std::vector<FaultAction> write_script,
+                        std::vector<FaultAction> flush_script,
+                        std::vector<FaultAction> close_script) {
+    ScriptedOrchestrationChannel channel(std::move(write_script),
+                                         std::move(flush_script), {},
+                                         std::move(close_script));
+    const auto call_result = detail::write_flush_close(channel, bytes);
+    return {helper_result_kind(call_result.status),
+            channel.bytes(),
+            channel.write_attempts(),
+            channel.flush_attempts(),
+            channel.truncate_attempts(),
+            channel.close_attempts()};
+}
+
+HelperOrchestrationProbeResult
+probe_truncate_flush_close(std::string bytes, std::size_t truncate_to,
+                           std::vector<FaultAction> truncate_script,
+                           std::vector<FaultAction> flush_script,
+                           std::vector<FaultAction> close_script) {
+    ScriptedOrchestrationChannel channel(
+        {}, std::move(flush_script), std::move(truncate_script),
+        std::move(close_script), std::move(bytes));
+    const auto call_result = detail::truncate_flush_close(channel, truncate_to);
+    return {helper_result_kind(call_result.status),
+            channel.bytes(),
+            channel.write_attempts(),
+            channel.flush_attempts(),
+            channel.truncate_attempts(),
+            channel.close_attempts()};
+}
+
+ReadHelperProbeResult
+probe_read_bounded_close(std::string bytes, std::size_t max_bytes,
+                         std::vector<FaultAction> read_script,
+                         std::vector<FaultAction> close_script) {
+    ScriptedReadChannel channel(std::move(bytes), std::move(read_script),
+                                std::move(close_script));
+    const auto call_result = detail::read_bounded_close(channel, max_bytes);
+    return {helper_result_kind(call_result.result.status),
+            std::move(call_result.bytes),
+            call_result.truncated,
+            channel.requested_bytes(),
+            channel.returned_bytes(),
+            channel.read_attempts(),
+            channel.close_attempts()};
+}
+
+NativeLockPathProbeResult
+probe_native_lock_path_revalidation(std::string directory) {
+    const auto root = std::filesystem::path(std::move(directory));
+    const auto lock_path = root / "authority.lock";
+    auto first = detail::make_platform_durable_file_adapter(root);
+    auto second = detail::make_platform_durable_file_adapter(root);
+    const auto first_lock = first->lock_authority();
+    const auto first_identity = first->authority_identity();
+    if (!first_lock.succeeded() || !first_identity.result.succeeded()) {
+        return {};
+    }
+
+    std::error_code error;
+    const auto removed_while_held = std::filesystem::remove(lock_path, error);
+    const bool replacement_prevented = !removed_while_held || error;
+    bool stale_identity_rejected = false;
+    if (!replacement_prevented) {
+        std::ofstream(lock_path, std::ios::binary).close();
+        stale_identity_rejected =
+            !first->authority_identity().result.succeeded();
+    }
+
+#ifdef _WIN32
+    const auto probe_handle = ::CreateFileW(
+        lock_path.c_str(), GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    OVERLAPPED overlapped{};
+    const auto probe_locked =
+        probe_handle != INVALID_HANDLE_VALUE &&
+        ::LockFileEx(probe_handle,
+                     LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0,
+                     MAXDWORD, MAXDWORD, &overlapped) != FALSE;
+    const auto nonblocking_probe_rejected =
+        !probe_locked && ::GetLastError() == ERROR_LOCK_VIOLATION;
+    if (probe_locked) {
+        static_cast<void>(
+            ::UnlockFileEx(probe_handle, 0, MAXDWORD, MAXDWORD, &overlapped));
+    }
+    if (probe_handle != INVALID_HANDLE_VALUE) {
+        static_cast<void>(::CloseHandle(probe_handle));
+    }
+#else
+    const auto probe_fd =
+        ::open(root.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    errno = 0;
+    const auto probe_locked =
+        probe_fd >= 0 && ::flock(probe_fd, LOCK_EX | LOCK_NB) == 0;
+    const auto nonblocking_probe_rejected =
+        !probe_locked && (errno == EWOULDBLOCK || errno == EAGAIN);
+    if (probe_locked) {
+        static_cast<void>(::flock(probe_fd, LOCK_UN));
+    }
+    if (probe_fd >= 0) {
+        static_cast<void>(::close(probe_fd));
+    }
+#endif
+    const auto first_unlock = first->unlock_authority();
+    detail::DurableFileResult contender_lock;
+    detail::DurableIdentityResult contender_identity;
+    detail::DurableFileResult contender_unlock;
+    if (first_unlock.succeeded()) {
+        contender_lock = second->lock_authority();
+        if (contender_lock.succeeded()) {
+            contender_identity = second->authority_identity();
+            contender_unlock = second->unlock_authority();
+        }
+    }
+
+    const bool contender_succeeded =
+        contender_lock.succeeded() && contender_identity.result.succeeded() &&
+        contender_unlock.succeeded();
+    const bool contender_rebound =
+        contender_succeeded &&
+        contender_identity.identity != first_identity.identity;
+
+    bool replacement_after_release_rebound = false;
+    if (replacement_prevented && contender_succeeded) {
+        error.clear();
+        const auto removed_after_release =
+            std::filesystem::remove(lock_path, error);
+        if (removed_after_release && !error) {
+            std::ofstream(lock_path, std::ios::binary).close();
+            auto rebound = detail::make_platform_durable_file_adapter(root);
+            const auto rebound_lock = rebound->lock_authority();
+            const auto rebound_identity = rebound->authority_identity();
+            const auto rebound_unlock = rebound->unlock_authority();
+            replacement_after_release_rebound =
+                rebound_lock.succeeded() &&
+                rebound_identity.result.succeeded() &&
+                rebound_identity.identity != first_identity.identity &&
+                rebound_unlock.succeeded();
+        }
+    }
+
+    return {replacement_prevented,
+            stale_identity_rejected,
+            nonblocking_probe_rejected,
+            first_unlock.succeeded(),
+            contender_succeeded,
+            contender_rebound,
+            replacement_after_release_rebound};
+}
+
+class JournalTestStorage::Adapter final : public detail::DurableFileAdapter {
+public:
+    explicit Adapter(std::shared_ptr<State> state)
+        : state_(std::move(state)),
+          lock_handle_identity_(next_handle_identity.fetch_add(1)) {}
+
+    ~Adapter() override {
+        std::lock_guard lock(state_->mutex);
+        release_owned_lock();
+        if (!state_->simulated_crash) {
+            close_open_lock_handle();
+        }
+    }
+
+    DurableFileResult lock_authority() override {
+        {
+            std::unique_lock lock(state_->mutex);
+            const auto opened =
+                run_step(lock, FaultOperation::AuthorityLockOpen, false, [&] {
+                    if (!state_->authority_directory_exists) {
+                        return;
+                    }
+                    if (state_->live_entry(lock_name) == nullptr) {
+                        state_->add_durable_regular(lock_name, {});
+                    }
+                    state_->open_lock_handles.insert(lock_handle_identity_);
+                });
+            if (!is_succeeded(opened)) {
+                return close_lock_after(lock, opened);
+            }
+            const auto *entry = state_->live_entry(lock_name);
+            if (!state_->authority_directory_exists || entry == nullptr ||
+                entry->kind != State::EntryKind::Regular) {
+                return close_lock_after(lock,
+                                        result(DurableFileStatus::Unsupported));
+            }
+            opened_lock_identity_ = entry->identity;
+        }
+
+        class AcquireCall final : public DurableInterruptibleCall {
+        public:
+            explicit AcquireCall(Adapter &adapter) : adapter_(adapter) {}
+
+            DurableFileResult attempt() override {
+                return adapter_.acquire_opened_lock_once();
+            }
+
+        private:
+            Adapter &adapter_;
+        } acquire_call(*this);
+
+        const auto acquired = detail::retry_interrupted(acquire_call);
+        if (!is_succeeded(acquired)) {
+            std::unique_lock lock(state_->mutex);
+            return close_lock_after(lock, acquired);
+        }
+
+        std::unique_lock lock(state_->mutex);
+        const auto *current = state_->live_entry(lock_name);
+        if (current != nullptr && current->kind == State::EntryKind::Regular &&
+            current->identity == opened_lock_identity_) {
+            pause_if_requested(lock, FaultOperation::AuthorityLockAcquire);
+            current = state_->live_entry(lock_name);
+            if (current != nullptr &&
+                current->kind == State::EntryKind::Regular &&
+                current->identity == opened_lock_identity_) {
+                return succeeded();
+            }
+        }
+        const auto unlocked = run_step(lock, FaultOperation::AuthorityUnlock,
+                                       false, [&] { release_owned_lock(); });
+        return close_lock_after(
+            lock, combine_results(result(DurableFileStatus::FailedBeforeEffect),
+                                  unlocked));
+    }
+
+    detail::DurableIdentityResult authority_identity() override {
+        std::unique_lock lock(state_->mutex);
+        const auto checked =
+            run_step(lock, FaultOperation::AuthorityIdentityRead, false, [] {});
+        if (!is_succeeded(checked)) {
+            return {checked, {}};
+        }
+        const auto *current = state_->live_entry(lock_name);
+        if (!owns_lock() || current == nullptr ||
+            current->kind != State::EntryKind::Regular ||
+            current->identity != opened_lock_identity_) {
+            return {result(DurableFileStatus::FailedBeforeEffect), {}};
+        }
+        return {succeeded(),
+                "directory:" + std::to_string(state_->directory_identity) +
+                    "/lock:" + std::to_string(opened_lock_identity_)};
+    }
+
+    DurableFileResult preflight_capabilities() override {
+        const std::vector<
+            std::pair<FaultOperation, std::optional<DurabilityCapability>>>
+            operations{
+                {FaultOperation::PreflightProbe, std::nullopt},
+                {FaultOperation::PreflightFlushCreate, std::nullopt},
+                {FaultOperation::PreflightFlushWrite, std::nullopt},
+                {FaultOperation::PreflightFlushFileFlush,
+                 DurabilityCapability::RegularFileFlush},
+                {FaultOperation::PreflightFlushClose, std::nullopt},
+                {FaultOperation::PreflightTruncate,
+                 DurabilityCapability::TailTruncateAndFlush},
+                {FaultOperation::PreflightTruncateFlush,
+                 DurabilityCapability::TailTruncateAndFlush},
+                {FaultOperation::PreflightTruncateClose, std::nullopt},
+                {FaultOperation::PreflightReplaceStageCreate, std::nullopt},
+                {FaultOperation::PreflightReplaceStageWrite, std::nullopt},
+                {FaultOperation::PreflightReplaceStageFlush, std::nullopt},
+                {FaultOperation::PreflightReplaceStageClose, std::nullopt},
+                {FaultOperation::PreflightReplace,
+                 DurabilityCapability::SameDirectoryReplace},
+                {FaultOperation::PreflightNamespaceDurability,
+                 DurabilityCapability::NamespaceDurability},
+                {FaultOperation::PreflightCleanup, std::nullopt},
+            };
+
+        for (const auto &[operation, capability] : operations) {
+            class PreflightCall final : public DurableInterruptibleCall {
+            public:
+                PreflightCall(Adapter &adapter, FaultOperation operation)
+                    : adapter_(adapter), operation_(operation) {}
+
+                DurableFileResult attempt() override {
+                    std::unique_lock lock(adapter_.state_->mutex);
+                    return adapter_.run_step(lock, operation_, false, [&] {
+                        adapter_.apply_preflight_operation(operation_);
+                    });
+                }
+
+            private:
+                Adapter &adapter_;
+                FaultOperation operation_;
+            } call(*this, operation);
+            const auto checked = is_preflight_close(operation)
+                                     ? call.attempt()
+                                     : detail::retry_interrupted(call);
+            if (!is_succeeded(checked)) {
+                return finish_preflight_failure(operation, checked);
+            }
+            if (is_preflight_close(operation)) {
+                std::lock_guard lock(state_->mutex);
+                close_preflight_handle(operation);
+            }
+            bool unavailable = false;
+            bool unsafe_fixed_entry = false;
+            {
+                std::lock_guard lock(state_->mutex);
+                unavailable =
+                    capability.has_value() &&
+                    state_->unavailable_capabilities.count(*capability) != 0;
+                unsafe_fixed_entry =
+                    operation == FaultOperation::PreflightProbe &&
+                    !fixed_entries_are_safe();
+            }
+            if (unavailable) {
+                return finish_preflight_failure(
+                    operation, result(DurableFileStatus::Unsupported));
+            }
+            if (unsafe_fixed_entry) {
+                return result(DurableFileStatus::Unsupported);
+            }
+        }
+        return succeeded();
+    }
+
+    detail::DurableFixedNamespaceResult inspect_fixed_namespace() override {
+        std::unique_lock lock(state_->mutex);
+        const auto inspected =
+            run_step(lock, FaultOperation::FixedNamespaceInspect, false, [] {});
+        if (!is_succeeded(inspected)) {
+            return {inspected, false, false, false, false, false};
+        }
+        if (!owns_lock() || !fixed_entries_are_safe()) {
+            return {result(DurableFileStatus::Unsupported),
+                    false,
+                    false,
+                    false,
+                    false,
+                    false};
+        }
+        return {succeeded(),
+                state_->live_entry(journal_name) != nullptr,
+                state_->live_entry(root_name) != nullptr,
+                state_->live_entry(journal_stage_name) != nullptr,
+                state_->live_entry(root_stage_name) != nullptr,
+                state_->live_entry(lock_name) != nullptr};
+    }
+
+    detail::DurableReadResult read_root(std::size_t max_bytes) override {
+        return read_fixed(root_name, FaultOperation::RootOpen,
+                          FaultOperation::RootRead, FaultOperation::RootClose,
+                          max_bytes);
+    }
+
+    detail::DurableReadResult read_journal(std::size_t max_bytes) override {
+        return read_fixed(journal_name, FaultOperation::JournalOpen,
+                          FaultOperation::JournalRead,
+                          FaultOperation::JournalReadClose, max_bytes);
+    }
+
+    DurableFileResult create_journal(std::string_view bytes) override {
+        {
+            std::unique_lock lock(state_->mutex);
+            if (state_->live_entry(journal_name) != nullptr) {
+                return result(DurableFileStatus::AlreadyExists);
+            }
+            const auto created =
+                run_step(lock, FaultOperation::InitialJournalCreate, true, [&] {
+                    auto &entry = state_->entries[std::string(journal_name)];
+                    entry.kind = State::EntryKind::Regular;
+                    entry.live_exists = true;
+                    entry.live_bytes.clear();
+                    entry.identity = next_entry_identity.fetch_add(1);
+                    state_->open_entries.insert(std::string(journal_name));
+                });
+            if (!is_succeeded(created)) {
+                if (state_->open_entries.count(std::string(journal_name)) ==
+                        0 ||
+                    state_->simulated_crash) {
+                    return created;
+                }
+                const auto closed =
+                    run_step(lock, FaultOperation::JournalClose, false, [&] {
+                        state_->open_entries.erase(std::string(journal_name));
+                    });
+                state_->open_entries.erase(std::string(journal_name));
+                return combine_results(created, closed);
+            }
+        }
+        Channel channel(
+            *this, journal_name, false, FaultOperation::JournalWrite,
+            FaultOperation::JournalFlush, FaultOperation::JournalWrite,
+            FaultOperation::JournalClose);
+        return promote_after_persistent_effect(
+            detail::write_flush_close(channel, bytes));
+    }
+
+    DurableFileResult append_journal(std::string_view bytes) override {
+        {
+            std::unique_lock lock(state_->mutex);
+            const auto journal_exists =
+                state_->live_entry(journal_name) != nullptr;
+            const auto opened =
+                run_step(lock, FaultOperation::JournalAppendOpen, false, [&] {
+                    if (journal_exists) {
+                        state_->open_entries.insert(std::string(journal_name));
+                    }
+                });
+            if (!is_succeeded(opened)) {
+                if (state_->open_entries.count(std::string(journal_name)) ==
+                        0 ||
+                    state_->simulated_crash) {
+                    return result(DurableFileStatus::FailedBeforeEffect);
+                }
+                const auto closed =
+                    run_step(lock, FaultOperation::JournalClose, false, [&] {
+                        state_->open_entries.erase(std::string(journal_name));
+                    });
+                state_->open_entries.erase(std::string(journal_name));
+                static_cast<void>(closed);
+                return result(DurableFileStatus::FailedBeforeEffect);
+            }
+            if (state_->live_entry(journal_name) == nullptr) {
+                return result(DurableFileStatus::NotFound);
+            }
+        }
+        Channel channel(*this, journal_name, true, FaultOperation::JournalWrite,
+                        FaultOperation::JournalFlush,
+                        FaultOperation::JournalWrite,
+                        FaultOperation::JournalClose);
+        return detail::write_flush_close(channel, bytes);
+    }
+
+    DurableFileResult truncate_journal(std::size_t bytes) override {
+        {
+            std::unique_lock lock(state_->mutex);
+            const auto journal_exists =
+                state_->live_entry(journal_name) != nullptr;
+            const auto opened =
+                run_step(lock, FaultOperation::TailRepairOpen, false, [&] {
+                    if (journal_exists) {
+                        state_->open_entries.insert(std::string(journal_name));
+                    }
+                });
+            if (!is_succeeded(opened)) {
+                if (state_->open_entries.count(std::string(journal_name)) ==
+                        0 ||
+                    state_->simulated_crash) {
+                    return result(DurableFileStatus::FailedBeforeEffect);
+                }
+                const auto closed =
+                    run_step(lock, FaultOperation::TailRepairClose, false, [&] {
+                        state_->open_entries.erase(std::string(journal_name));
+                    });
+                state_->open_entries.erase(std::string(journal_name));
+                static_cast<void>(closed);
+                return result(DurableFileStatus::FailedBeforeEffect);
+            }
+            if (state_->live_entry(journal_name) == nullptr) {
+                return result(DurableFileStatus::NotFound);
+            }
+        }
+        Channel channel(
+            *this, journal_name, false, FaultOperation::JournalWrite,
+            FaultOperation::TailRepairFlush, FaultOperation::TailRepairTruncate,
+            FaultOperation::TailRepairClose);
+        return detail::truncate_flush_close(channel, bytes);
+    }
+
+    DurableFileResult replace_journal(std::string_view bytes) override {
+        return replace_fixed(
+            journal_stage_name, journal_name, bytes,
+            FaultOperation::CompactionStageCreate,
+            FaultOperation::CompactionWrite, FaultOperation::CompactionFlush,
+            FaultOperation::CompactionClose, FaultOperation::CompactionReplace,
+            FaultOperation::CompactionNamespaceDurability);
+    }
+
+    DurableFileResult replace_root(std::string_view bytes) override {
+        return replace_fixed(
+            root_stage_name, root_name, bytes, FaultOperation::RootStageCreate,
+            FaultOperation::RootStageWrite, FaultOperation::RootStageFlush,
+            FaultOperation::RootStageClose, FaultOperation::RootReplace,
+            FaultOperation::NamespaceDurability);
+    }
+
+    DurableFileResult unlock_authority() override {
+        std::unique_lock lock(state_->mutex);
+        const auto unlocked = run_step(lock, FaultOperation::AuthorityUnlock,
+                                       false, [&] { release_owned_lock(); });
+        return close_lock_after(lock, unlocked);
+    }
+
+private:
+    DurableFileResult
+    close_lock_after(std::unique_lock<std::mutex> &lock,
+                     const DurableFileResult &operation_result) {
+        if (state_->simulated_crash || !lock_handle_is_open()) {
+            return operation_result;
+        }
+        const auto closed =
+            run_step(lock, FaultOperation::AuthorityLockClose, false, [&] {
+                release_owned_lock();
+                close_open_lock_handle();
+            });
+        if (!state_->simulated_crash) {
+            release_owned_lock();
+            close_open_lock_handle();
+        }
+        return combine_results(operation_result, closed);
+    }
+
+    class Channel final : public DurableFileChannel {
+    public:
+        Channel(Adapter &adapter, std::string_view name, bool append,
+                FaultOperation write_operation, FaultOperation flush_operation,
+                FaultOperation truncate_operation,
+                FaultOperation close_operation)
+            : adapter_(adapter), name_(name), append_(append),
+              write_operation_(write_operation),
+              flush_operation_(flush_operation),
+              truncate_operation_(truncate_operation),
+              close_operation_(close_operation) {}
+
+        DurableWriteResult write_some(std::string_view bytes) override {
+            return adapter_.write_some(name_, bytes, append_ && wrote_any_,
+                                       append_ && !wrote_any_, write_operation_,
+                                       wrote_any_);
+        }
+
+        DurableFileResult flush() override {
+            std::unique_lock lock(adapter_.state_->mutex);
+            return adapter_.run_step(lock, flush_operation_, true, [&] {
+                auto *entry = adapter_.state_->live_entry(name_);
+                if (entry != nullptr) {
+                    entry->durable_bytes = entry->live_bytes;
+                    entry->durable_content_available = true;
+                }
+            });
+        }
+
+        DurableFileResult truncate(std::size_t bytes) override {
+            std::unique_lock lock(adapter_.state_->mutex);
+            return adapter_.run_step(
+                lock, truncate_operation_, true,
+                [&] {
+                    auto *entry = adapter_.state_->live_entry(name_);
+                    if (entry != nullptr) {
+                        entry->live_bytes.resize(
+                            std::min(bytes, entry->live_bytes.size()));
+                    }
+                },
+                bytes, bytes);
+        }
+
+        DurableFileResult close() override {
+            std::unique_lock lock(adapter_.state_->mutex);
+            if (adapter_.state_->simulated_crash) {
+                return result(DurableFileStatus::EffectMayHaveOccurred);
+            }
+            const auto closed =
+                adapter_.run_step(lock, close_operation_, false, [&] {
+                    adapter_.state_->open_entries.erase(name_);
+                });
+            if (!adapter_.state_->simulated_crash) {
+                adapter_.state_->open_entries.erase(name_);
+            }
+            return closed;
+        }
+
+    private:
+        Adapter &adapter_;
+        std::string name_;
+        bool append_;
+        FaultOperation write_operation_;
+        FaultOperation flush_operation_;
+        FaultOperation truncate_operation_;
+        FaultOperation close_operation_;
+        bool wrote_any_ = false;
+    };
+
+    class ReadChannel final : public DurableReadChannel {
+    public:
+        ReadChannel(Adapter &adapter, std::string_view name,
+                    FaultOperation read_operation,
+                    FaultOperation close_operation)
+            : adapter_(adapter), name_(name), read_operation_(read_operation),
+              close_operation_(close_operation) {}
+
+        DurableReadChunkResult read_some(std::size_t max_bytes) override {
+            std::unique_lock lock(adapter_.state_->mutex);
+            const auto *entry = adapter_.state_->live_entry(name_);
+            if (entry == nullptr) {
+                return {result(DurableFileStatus::NotFound), {}, false};
+            }
+            if (entry->kind != State::EntryKind::Regular) {
+                return {result(DurableFileStatus::Unsupported), {}, false};
+            }
+            const auto available =
+                offset_ < entry->live_bytes.size()
+                    ? entry->live_bytes.size() - offset_
+                    : 0;
+            const auto transferred = std::min(max_bytes, available);
+            std::string bytes;
+            bool end_of_file = false;
+            const auto read = adapter_.run_step(
+                lock, read_operation_, false,
+                [&] {
+                    if (transferred != 0) {
+                        bytes = entry->live_bytes.substr(offset_, transferred);
+                        offset_ += transferred;
+                    }
+                    end_of_file = available == 0;
+                },
+                max_bytes, transferred);
+            if (!is_succeeded(read) &&
+                read.status != DurableFileStatus::EffectMayHaveOccurred) {
+                return {read, {}, false};
+            }
+            return {read, std::move(bytes), end_of_file};
+        }
+
+        DurableFileResult close() override {
+            std::unique_lock lock(adapter_.state_->mutex);
+            if (adapter_.state_->simulated_crash) {
+                return result(DurableFileStatus::EffectMayHaveOccurred);
+            }
+            const auto closed =
+                adapter_.run_step(lock, close_operation_, false, [&] {
+                    adapter_.state_->open_entries.erase(name_);
+                });
+            if (!adapter_.state_->simulated_crash) {
+                adapter_.state_->open_entries.erase(name_);
+            }
+            return closed;
+        }
+
+    private:
+        Adapter &adapter_;
+        std::string name_;
+        FaultOperation read_operation_;
+        FaultOperation close_operation_;
+        std::size_t offset_ = 0;
+    };
+
+    DurableFileResult acquire_opened_lock_once() {
+        std::unique_lock lock(state_->mutex);
+        const auto before = state_->take_fault(
+            FaultOperation::AuthorityLockAcquire, FaultPosition::Before);
+        if (before.has_value()) {
+            if (*before == FaultAction::Crash) {
+                state_->simulated_crash = true;
+            }
+            if (*before == FaultAction::InterruptedOnce) {
+                state_->observe(FaultOperation::AuthorityLockAcquire, false,
+                                false, opened_lock_identity_);
+                return result(DurableFileStatus::Interrupted);
+            }
+            if (*before != FaultAction::EffectThenError) {
+                state_->observe(FaultOperation::AuthorityLockAcquire, false,
+                                false, opened_lock_identity_);
+                return result(DurableFileStatus::FailedBeforeEffect);
+            }
+        }
+        const bool must_wait =
+            state_->held_lock_identities.count(opened_lock_identity_) != 0;
+        if (must_wait) {
+            ++state_->blocked_lock_waiters;
+            state_->condition.notify_all();
+        }
+        state_->condition.wait(lock, [&] {
+            return state_->held_lock_identities.count(opened_lock_identity_) ==
+                   0;
+        });
+        if (must_wait) {
+            --state_->blocked_lock_waiters;
+        }
+        state_->held_lock_identities.insert(opened_lock_identity_);
+        owned_lock_identity_ = opened_lock_identity_;
+        state_->observe(FaultOperation::AuthorityLockAcquire, true, false,
+                        opened_lock_identity_);
+        const auto after = state_->take_fault(
+            FaultOperation::AuthorityLockAcquire, FaultPosition::After);
+        if (before.has_value() || after.has_value()) {
+            if (after == FaultAction::Crash) {
+                state_->simulated_crash = true;
+            }
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        return succeeded();
+    }
+
+    template <typename Effect>
+    DurableFileResult run_step(std::unique_lock<std::mutex> &lock,
+                               FaultOperation operation, bool mutation,
+                               Effect effect, std::size_t requested_bytes = 0,
+                               std::size_t transferred_bytes = 0) {
+        const auto before =
+            state_->take_fault(operation, FaultPosition::Before);
+        if (before.has_value()) {
+            if (*before == FaultAction::Crash) {
+                state_->simulated_crash = true;
+            }
+            if (*before == FaultAction::InterruptedOnce) {
+                state_->observe(operation, owns_lock(), false,
+                                owned_lock_identity_, requested_bytes, 0);
+                return result(DurableFileStatus::Interrupted);
+            }
+            if (*before != FaultAction::EffectThenError) {
+                state_->observe(operation, owns_lock(), false,
+                                owned_lock_identity_, requested_bytes, 0);
+                return result(DurableFileStatus::FailedBeforeEffect);
+            }
+            effect();
+            state_->observe(operation, owns_lock(), mutation,
+                            owned_lock_identity_, requested_bytes,
+                            mutation ? transferred_bytes : 0);
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+
+        effect();
+        state_->observe(operation, owns_lock(), mutation, owned_lock_identity_,
+                        requested_bytes, transferred_bytes);
+        pause_if_requested(lock, operation);
+        const auto after = state_->take_fault(operation, FaultPosition::After);
+        if (after.has_value()) {
+            if (*after == FaultAction::Crash) {
+                state_->simulated_crash = true;
+            }
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        return succeeded();
+    }
+
+    void pause_if_requested(std::unique_lock<std::mutex> &lock,
+                            FaultOperation operation) {
+        if (state_->pause_operation != operation || state_->pause_consumed) {
+            return;
+        }
+        if (state_->pause_occurrence > 1) {
+            --state_->pause_occurrence;
+            return;
+        }
+        state_->pause_consumed = true;
+        state_->paused = true;
+        state_->condition.notify_all();
+        state_->condition.wait(lock, [&] { return state_->pause_released; });
+        state_->paused = false;
+    }
+
+    detail::DurableReadResult read_fixed(std::string_view name,
+                                         FaultOperation open_operation,
+                                         FaultOperation read_operation,
+                                         FaultOperation close_operation,
+                                         std::size_t max_bytes) {
+        std::unique_lock lock(state_->mutex);
+        const auto *entry_before_open = state_->live_entry(name);
+        const auto opened = run_step(
+            lock, open_operation, false,
+            [&] {
+                if (entry_before_open != nullptr) {
+                    state_->open_entries.insert(std::string(name));
+                }
+            },
+            max_bytes);
+        if (!is_succeeded(opened)) {
+            if (state_->open_entries.count(std::string(name)) == 0 ||
+                state_->simulated_crash) {
+                return {opened, {}, false};
+            }
+            lock.unlock();
+            ReadChannel opened_channel(*this, name, read_operation,
+                                       close_operation);
+            const auto closed_after_open =
+                detail::close_read_once(opened_channel);
+            return {combine_results(opened, closed_after_open), {}, false};
+        }
+        const auto *entry = state_->live_entry(name);
+        if (entry == nullptr) {
+            return {result(DurableFileStatus::NotFound), {}, false};
+        }
+        if (entry->kind != State::EntryKind::Regular) {
+            const auto unsupported = result(DurableFileStatus::Unsupported);
+            lock.unlock();
+            ReadChannel unsafe_channel(*this, name, read_operation,
+                                       close_operation);
+            const auto closed_unsafe = detail::close_read_once(unsafe_channel);
+            return {combine_results(unsupported, closed_unsafe), {}, false};
+        }
+        lock.unlock();
+        ReadChannel channel(*this, name, read_operation, close_operation);
+        return detail::read_bounded_close(channel, max_bytes);
+    }
+
+    DurableWriteResult write_some(std::string_view name, std::string_view bytes,
+                                  bool append_after_partial,
+                                  bool append_initial, FaultOperation operation,
+                                  bool &wrote_any) {
+        std::unique_lock lock(state_->mutex);
+        auto *entry = state_->live_entry(name);
+        if (entry == nullptr || entry->kind != State::EntryKind::Regular) {
+            return {result(DurableFileStatus::NotFound), 0};
+        }
+        const auto before =
+            state_->take_fault(operation, FaultPosition::Before);
+        if (before.has_value()) {
+            if (*before == FaultAction::Crash) {
+                state_->simulated_crash = true;
+            }
+            switch (*before) {
+            case FaultAction::InterruptedOnce:
+                state_->observe(operation, owns_lock(), false,
+                                owned_lock_identity_, bytes.size(), 0);
+                return {result(DurableFileStatus::Interrupted), 0};
+            case FaultAction::ZeroProgress:
+                state_->observe(operation, owns_lock(), false,
+                                owned_lock_identity_, bytes.size(), 0);
+                return {succeeded(), 0};
+            case FaultAction::OverreportedWrite:
+                state_->observe(operation, owns_lock(), false,
+                                owned_lock_identity_, bytes.size(),
+                                bytes.size() + 1);
+                return {succeeded(), bytes.size() + 1};
+            case FaultAction::ShortWrite: {
+                const auto transferred =
+                    bytes.size() <= 1 ? bytes.size() : bytes.size() / 2;
+                apply_write(*entry, bytes.substr(0, transferred),
+                            append_after_partial, append_initial, wrote_any);
+                state_->observe(operation, owns_lock(), true,
+                                owned_lock_identity_, bytes.size(),
+                                transferred);
+                return {succeeded(), transferred};
+            }
+            case FaultAction::EffectThenError:
+                apply_write(*entry, bytes, append_after_partial, append_initial,
+                            wrote_any);
+                state_->observe(operation, owns_lock(), true,
+                                owned_lock_identity_, bytes.size(),
+                                bytes.size());
+                return {result(DurableFileStatus::EffectMayHaveOccurred),
+                        bytes.size()};
+            case FaultAction::Error:
+            case FaultAction::Crash:
+                state_->observe(operation, owns_lock(), false,
+                                owned_lock_identity_, bytes.size(), 0);
+                return {result(DurableFileStatus::FailedBeforeEffect), 0};
+            }
+        }
+        apply_write(*entry, bytes, append_after_partial, append_initial,
+                    wrote_any);
+        state_->observe(operation, owns_lock(), true, owned_lock_identity_,
+                        bytes.size(), bytes.size());
+        pause_if_requested(lock, operation);
+        const auto after = state_->take_fault(operation, FaultPosition::After);
+        if (after.has_value()) {
+            if (*after == FaultAction::Crash) {
+                state_->simulated_crash = true;
+            }
+            return {result(DurableFileStatus::EffectMayHaveOccurred),
+                    bytes.size()};
+        }
+        return {succeeded(), bytes.size()};
+    }
+
+    static void apply_write(State::Entry &entry, std::string_view bytes,
+                            bool append_after_partial, bool append_initial,
+                            bool &wrote_any) {
+        if (append_after_partial || append_initial || wrote_any) {
+            entry.live_bytes.append(bytes);
+        } else {
+            entry.live_bytes.assign(bytes);
+        }
+        wrote_any = true;
+    }
+
+    static DurableFileResult
+    combine_results(const DurableFileResult &operation_result,
+                    const DurableFileResult &close_result) {
+        if (operation_result.status ==
+                DurableFileStatus::EffectMayHaveOccurred ||
+            close_result.status == DurableFileStatus::EffectMayHaveOccurred) {
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        if (!is_succeeded(operation_result)) {
+            return operation_result;
+        }
+        return close_result;
+    }
+
+    DurableFileResult replace_fixed(
+        std::string_view stage_name, std::string_view target_name,
+        std::string_view bytes, FaultOperation create_operation,
+        FaultOperation write_operation, FaultOperation flush_operation,
+        FaultOperation close_operation, FaultOperation replace_operation,
+        FaultOperation namespace_operation) {
+        std::uint64_t stage_identity = 0;
+        {
+            std::unique_lock lock(state_->mutex);
+            const auto created = run_step(lock, create_operation, true, [&] {
+                auto &entry = state_->entries[std::string(stage_name)];
+                entry = State::Entry{};
+                entry.live_exists = true;
+                entry.identity = next_entry_identity.fetch_add(1);
+                stage_identity = entry.identity;
+                state_->open_entries.insert(std::string(stage_name));
+            });
+            if (!is_succeeded(created)) {
+                if (state_->open_entries.count(std::string(stage_name)) == 0 ||
+                    state_->simulated_crash) {
+                    return created;
+                }
+                const auto closed = run_step(lock, close_operation, false, [&] {
+                    state_->open_entries.erase(std::string(stage_name));
+                });
+                state_->open_entries.erase(std::string(stage_name));
+                return combine_results(created, closed);
+            }
+        }
+        Channel channel(*this, stage_name, false, write_operation,
+                        flush_operation, write_operation, close_operation);
+        auto call_result = detail::write_flush_close(channel, bytes);
+        if (!is_succeeded(call_result)) {
+            return promote_after_persistent_effect(std::move(call_result));
+        }
+        {
+            std::unique_lock lock(state_->mutex);
+            const auto replaced = run_step(lock, replace_operation, true, [&] {
+                const auto *stage = state_->live_entry(stage_name);
+                auto &target = state_->entries[std::string(target_name)];
+                target.kind = State::EntryKind::Regular;
+                target.live_exists = true;
+                target.live_bytes =
+                    stage == nullptr ? std::string{} : stage->live_bytes;
+                target.identity = stage == nullptr ? 0 : stage->identity;
+                erase_live(stage_name);
+            });
+            if (!is_succeeded(replaced)) {
+                return promote_after_persistent_effect(replaced);
+            }
+        }
+        class NamespaceCall final : public DurableInterruptibleCall {
+        public:
+            NamespaceCall(Adapter &adapter, FaultOperation operation,
+                          std::string_view stage_name,
+                          std::string_view target_name)
+                : adapter_(adapter), operation_(operation),
+                  stage_name_(stage_name), target_name_(target_name) {}
+
+            DurableFileResult attempt() override {
+                std::unique_lock lock(adapter_.state_->mutex);
+                return adapter_.run_step(lock, operation_, true, [&] {
+                    adapter_.commit_replacement(stage_name_, target_name_);
+                });
+            }
+
+        private:
+            Adapter &adapter_;
+            FaultOperation operation_;
+            std::string stage_name_;
+            std::string target_name_;
+        } namespace_call(*this, namespace_operation, stage_name, target_name);
+        const auto namespace_result = promote_after_persistent_effect(
+            detail::retry_interrupted(namespace_call));
+        if (!is_succeeded(namespace_result)) {
+            return namespace_result;
+        }
+        std::unique_lock lock(state_->mutex);
+        const auto *target = state_->live_entry(target_name);
+        if (target == nullptr || target->kind != State::EntryKind::Regular ||
+            target->identity != stage_identity || target->live_bytes != bytes ||
+            !target->durable_exists || !target->durable_content_available ||
+            target->durable_bytes != bytes) {
+            return result(DurableFileStatus::EffectMayHaveOccurred);
+        }
+        return namespace_result;
+    }
+
+    bool fixed_entries_are_safe() const {
+        if (!state_->authority_directory_exists) {
+            return false;
+        }
+        for (const auto name : {journal_name, root_name, lock_name,
+                                journal_stage_name, root_stage_name}) {
+            const auto *entry = state_->live_entry(name);
+            if (entry != nullptr && entry->kind != State::EntryKind::Regular) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool is_preflight_close(FaultOperation operation) {
+        return operation == FaultOperation::PreflightFlushClose ||
+               operation == FaultOperation::PreflightTruncateClose ||
+               operation == FaultOperation::PreflightReplaceStageClose;
+    }
+
+    void close_preflight_handle(FaultOperation operation) {
+        if (operation == FaultOperation::PreflightReplaceStageClose) {
+            state_->open_entries.erase(std::string(preflight_stage_name));
+        } else {
+            state_->open_entries.erase(std::string(preflight_probe_name));
+        }
+    }
+
+    DurableFileResult
+    finish_preflight_failure(FaultOperation operation,
+                             const DurableFileResult &operation_result) {
+        std::unique_lock lock(state_->mutex);
+        if (state_->simulated_crash) {
+            return operation_result;
+        }
+        auto combined = operation_result;
+        if (is_preflight_close(operation)) {
+            close_preflight_handle(operation);
+        } else {
+            std::optional<FaultOperation> close_operation;
+            const auto ordinal = static_cast<int>(operation);
+            if (state_->open_entries.count(std::string(preflight_stage_name)) !=
+                0) {
+                close_operation = FaultOperation::PreflightReplaceStageClose;
+            } else if (state_->open_entries.count(
+                           std::string(preflight_probe_name)) != 0) {
+                close_operation =
+                    ordinal <= static_cast<int>(
+                                   FaultOperation::PreflightFlushClose)
+                        ? FaultOperation::PreflightFlushClose
+                        : FaultOperation::PreflightTruncateClose;
+            }
+            if (close_operation.has_value()) {
+                const auto closed =
+                    run_step(lock, *close_operation, false,
+                             [&] { close_preflight_handle(*close_operation); });
+                close_preflight_handle(*close_operation);
+                combined = combine_results(combined, closed);
+            }
+        }
+        if (operation == FaultOperation::PreflightCleanup) {
+            return combined;
+        }
+        const auto cleaned =
+            run_step(lock, FaultOperation::PreflightCleanup, false, [&] {
+                state_->open_entries.erase(std::string(preflight_probe_name));
+                state_->open_entries.erase(std::string(preflight_stage_name));
+                erase_live(preflight_probe_name);
+                erase_durable(preflight_probe_name);
+                erase_live(preflight_stage_name);
+                erase_durable(preflight_stage_name);
+            });
+        return combine_results(combined, cleaned);
+    }
+
+    void commit_replacement(std::string_view stage_name,
+                            std::string_view target_name) {
+        auto &stage = state_->entries[std::string(stage_name)];
+        auto &target = state_->entries[std::string(target_name)];
+        if (stage.durable_content_available) {
+            target.durable_bytes = stage.durable_bytes;
+            target.durable_content_available = true;
+        }
+        for (auto &[name, entry] : state_->entries) {
+            static_cast<void>(name);
+            entry.durable_exists = entry.live_exists;
+        }
+        stage.durable_exists = false;
+        stage.durable_bytes.clear();
+        stage.durable_content_available = false;
+    }
+
+    void apply_preflight_operation(FaultOperation operation) {
+        switch (operation) {
+        case FaultOperation::PreflightProbe:
+            erase_live(preflight_probe_name);
+            erase_durable(preflight_probe_name);
+            erase_live(preflight_stage_name);
+            erase_durable(preflight_stage_name);
+            break;
+        case FaultOperation::PreflightFlushCreate: {
+            auto &entry = state_->entries[std::string(preflight_probe_name)];
+            entry = State::Entry{};
+            entry.live_exists = true;
+            entry.identity = next_entry_identity.fetch_add(1);
+            state_->open_entries.insert(std::string(preflight_probe_name));
+            break;
+        }
+        case FaultOperation::PreflightFlushWrite:
+            state_->entries[std::string(preflight_probe_name)].live_bytes =
+                "flush-probe";
+            break;
+        case FaultOperation::PreflightFlushFileFlush:
+        case FaultOperation::PreflightTruncateFlush:
+            state_->entries[std::string(preflight_probe_name)].durable_bytes =
+                state_->entries[std::string(preflight_probe_name)].live_bytes;
+            state_->entries[std::string(preflight_probe_name)].durable_exists =
+                true;
+            state_->entries[std::string(preflight_probe_name)]
+                .durable_content_available = true;
+            break;
+        case FaultOperation::PreflightFlushClose:
+            state_->open_entries.erase(std::string(preflight_probe_name));
+            break;
+        case FaultOperation::PreflightTruncateClose:
+            state_->open_entries.erase(std::string(preflight_probe_name));
+            break;
+        case FaultOperation::PreflightReplaceStageClose:
+            state_->open_entries.erase(std::string(preflight_stage_name));
+            break;
+        case FaultOperation::PreflightTruncate:
+            state_->open_entries.insert(std::string(preflight_probe_name));
+            state_->entries[std::string(preflight_probe_name)]
+                .live_bytes.clear();
+            break;
+        case FaultOperation::PreflightReplaceStageCreate: {
+            auto &entry = state_->entries[std::string(preflight_stage_name)];
+            entry = State::Entry{};
+            entry.live_exists = true;
+            entry.identity = next_entry_identity.fetch_add(1);
+            state_->open_entries.insert(std::string(preflight_stage_name));
+            break;
+        }
+        case FaultOperation::PreflightReplaceStageWrite:
+            state_->entries[std::string(preflight_stage_name)].live_bytes =
+                "replace-probe";
+            break;
+        case FaultOperation::PreflightReplaceStageFlush:
+            state_->entries[std::string(preflight_stage_name)].durable_bytes =
+                state_->entries[std::string(preflight_stage_name)].live_bytes;
+            state_->entries[std::string(preflight_stage_name)].durable_exists =
+                true;
+            state_->entries[std::string(preflight_stage_name)]
+                .durable_content_available = true;
+            break;
+        case FaultOperation::PreflightReplace:
+            state_->entries[std::string(preflight_probe_name)].live_bytes =
+                state_->entries[std::string(preflight_stage_name)].live_bytes;
+            erase_live(preflight_stage_name);
+            break;
+        case FaultOperation::PreflightNamespaceDurability: {
+            auto &probe = state_->entries[std::string(preflight_probe_name)];
+            auto &stage = state_->entries[std::string(preflight_stage_name)];
+            if (stage.durable_content_available) {
+                probe.durable_bytes = stage.durable_bytes;
+                probe.durable_content_available = true;
+            }
+            probe.durable_exists = probe.live_exists;
+            stage.durable_exists = false;
+            stage.durable_bytes.clear();
+            stage.durable_content_available = false;
+        } break;
+        case FaultOperation::PreflightCleanup:
+            state_->open_entries.erase(std::string(preflight_probe_name));
+            state_->open_entries.erase(std::string(preflight_stage_name));
+            erase_live(preflight_probe_name);
+            erase_durable(preflight_probe_name);
+            erase_live(preflight_stage_name);
+            erase_durable(preflight_stage_name);
+            break;
+        default:
+            break;
+        }
+    }
+
+    void erase_live(std::string_view name) {
+        auto found = state_->entries.find(std::string(name));
+        if (found != state_->entries.end()) {
+            found->second.live_exists = false;
+            found->second.live_bytes.clear();
+        }
+    }
+
+    void erase_durable(std::string_view name) {
+        auto found = state_->entries.find(std::string(name));
+        if (found != state_->entries.end()) {
+            found->second.durable_exists = false;
+            found->second.durable_bytes.clear();
+            found->second.durable_content_available = false;
+        }
+    }
+
+    bool owns_lock() const {
+        return owned_lock_identity_ != 0 &&
+               state_->held_lock_identities.count(owned_lock_identity_) != 0;
+    }
+
+    bool lock_handle_is_open() const {
+        return state_->open_lock_handles.count(lock_handle_identity_) != 0;
+    }
+
+    void close_open_lock_handle() {
+        if (lock_handle_is_open()) {
+            state_->open_lock_handles.erase(lock_handle_identity_);
+        }
+        opened_lock_identity_ = 0;
+    }
+
+    void release_owned_lock() {
+        if (owned_lock_identity_ == 0) {
+            return;
+        }
+        state_->held_lock_identities.erase(owned_lock_identity_);
+        owned_lock_identity_ = 0;
+        state_->condition.notify_all();
+    }
+
+    std::shared_ptr<State> state_;
+    const std::uint64_t lock_handle_identity_;
+    std::uint64_t opened_lock_identity_ = 0;
+    std::uint64_t owned_lock_identity_ = 0;
+};
+
+JournalTestStorage::JournalTestStorage(std::shared_ptr<State> state)
+    : state_(std::move(state)) {}
+
+JournalTestStorage JournalTestStorage::fresh() {
+#ifdef _WIN32
+    return fresh(PlatformContract::Windows);
+#elif defined(__APPLE__)
+    return fresh(PlatformContract::MacOS);
+#else
+    return fresh(PlatformContract::Linux);
+#endif
+}
+
+JournalTestStorage JournalTestStorage::fresh(PlatformContract platform) {
+    return JournalTestStorage(std::make_shared<State>(platform, true));
+}
+
+JournalTestStorage
+JournalTestStorage::seeded(std::string journal_bytes,
+                           std::optional<std::string> authority_root_bytes) {
+    auto storage = fresh();
+    {
+        std::lock_guard lock(storage.state_->mutex);
+        storage.state_->add_durable_regular(journal_name,
+                                            std::move(journal_bytes));
+        storage.state_->add_durable_regular(lock_name, {});
+        if (authority_root_bytes.has_value()) {
+            storage.state_->add_durable_regular(
+                root_name, std::move(*authority_root_bytes));
+        }
+    }
+    return storage;
+}
+
+JournalTestStorage
+JournalTestStorage::seeded(std::string journal_bytes,
+                           std::string authority_root_bytes) {
+    return seeded(std::move(journal_bytes),
+                  std::optional<std::string>(std::move(authority_root_bytes)));
+}
+
+JournalTestStorage JournalTestStorage::seeded(std::string journal_bytes,
+                                              std::string authority_root_bytes,
+                                              PlatformContract platform) {
+    auto storage = fresh(platform);
+    {
+        std::lock_guard lock(storage.state_->mutex);
+        storage.state_->add_durable_regular(journal_name,
+                                            std::move(journal_bytes));
+        storage.state_->add_durable_regular(lock_name, {});
+        storage.state_->add_durable_regular(root_name,
+                                            std::move(authority_root_bytes));
+    }
+    return storage;
+}
+
+JournalTestStorage
+JournalTestStorage::missing_authority_directory(PlatformContract platform) {
+    return JournalTestStorage(std::make_shared<State>(platform, false));
+}
+
+JournalTestStorage::JournalTestStorage(const JournalTestStorage &) = default;
+
+JournalTestStorage &
+JournalTestStorage::operator=(const JournalTestStorage &) = default;
+
+JournalTestStorage::JournalTestStorage(JournalTestStorage &&) noexcept =
+    default;
+
+JournalTestStorage &
+JournalTestStorage::operator=(JournalTestStorage &&) noexcept = default;
+
+JournalTestStorage::~JournalTestStorage() = default;
+
+JournalTestStorage JournalTestStorage::clone() const {
+    std::lock_guard lock(state_->mutex);
+    auto cloned = std::make_shared<State>(state_->platform,
+                                          state_->authority_directory_exists);
+    cloned->entries = state_->entries;
+    for (auto &[name, entry] : cloned->entries) {
+        static_cast<void>(name);
+        if (entry.live_exists || entry.durable_exists) {
+            entry.identity = next_entry_identity.fetch_add(1);
+        }
+    }
+    cloned->unavailable_capabilities = state_->unavailable_capabilities;
+    return JournalTestStorage(std::move(cloned));
+}
+
+DurableJournal JournalTestStorage::make_journal(JournalLimits limits) {
+    return detail::make_durable_journal_for_test(
+        std::make_unique<Adapter>(state_), limits);
+}
+
+NamespaceSnapshot JournalTestStorage::snapshot() const {
+    std::lock_guard lock(state_->mutex);
+    NamespaceSnapshot snapshot;
+    const auto *journal = state_->live_entry(journal_name);
+    if (journal != nullptr && journal->kind == State::EntryKind::Regular) {
+        snapshot.journal_bytes = journal->live_bytes;
+    }
+    const auto *root = state_->live_entry(root_name);
+    if (root != nullptr && root->kind == State::EntryKind::Regular) {
+        snapshot.authority_root_bytes = root->live_bytes;
+    }
+    for (const auto &[name, entry] : state_->entries) {
+        if (entry.live_exists || entry.durable_exists) {
+            switch (entry.kind) {
+            case State::EntryKind::Regular:
+                snapshot.entry_kinds.emplace(name, "regular");
+                break;
+            case State::EntryKind::Symlink:
+                snapshot.entry_kinds.emplace(name, "symlink");
+                break;
+            case State::EntryKind::NonRegular:
+                snapshot.entry_kinds.emplace(name, "nonregular");
+                break;
+            case State::EntryKind::ReparsePoint:
+                snapshot.entry_kinds.emplace(name, "reparse");
+                break;
+            }
+        }
+        if (entry.live_exists) {
+            snapshot.relative_paths.insert(name);
+            if (entry.kind == State::EntryKind::Regular) {
+                snapshot.live_file_bytes.emplace(name, entry.live_bytes);
+            }
+        }
+        if (entry.durable_exists) {
+            snapshot.durable_paths.insert(name);
+            if (entry.durable_content_available) {
+                snapshot.durable_content_available.insert(name);
+            }
+            if (entry.kind == State::EntryKind::Regular) {
+                snapshot.durable_file_bytes.emplace(name, entry.durable_bytes);
+            }
+        }
+    }
+    snapshot.observations = state_->observations;
+    snapshot.open_handles = state_->open_entries;
+    for (const auto handle : state_->open_lock_handles) {
+        snapshot.open_handles.insert("authority.lock#handle:" +
+                                     std::to_string(handle));
+    }
+    snapshot.namespace_durable = std::all_of(
+        state_->entries.begin(), state_->entries.end(), [](const auto &item) {
+            return item.second.live_exists == item.second.durable_exists;
+        });
+    snapshot.journal_durable =
+        journal == nullptr ||
+        (journal->durable_exists && journal->durable_content_available &&
+         journal->live_bytes == journal->durable_bytes);
+    snapshot.authority_root_durable =
+        root == nullptr ||
+        (root->durable_exists && root->durable_content_available &&
+         root->live_bytes == root->durable_bytes);
+    snapshot.journal_closed = snapshot.open_handles.empty();
+    snapshot.stage_files_absent =
+        state_->live_entry(journal_stage_name) == nullptr &&
+        state_->live_entry(root_stage_name) == nullptr;
+    const auto journal_stage =
+        state_->entries.find(std::string(journal_stage_name));
+    const auto root_stage = state_->entries.find(std::string(root_stage_name));
+    snapshot.durable_stage_files_absent =
+        (journal_stage == state_->entries.end() ||
+         !journal_stage->second.durable_exists) &&
+        (root_stage == state_->entries.end() ||
+         !root_stage->second.durable_exists);
+
+    const auto *lock_entry = state_->live_entry(lock_name);
+    snapshot.lock_file_present = lock_entry != nullptr;
+    snapshot.lock_file_stable =
+        lock_entry != nullptr && lock_entry->kind == State::EntryKind::Regular;
+
+    snapshot.all_authority_io_under_lock = true;
+    std::optional<std::size_t> first_root_read;
+    std::optional<std::size_t> first_journal_read;
+    snapshot.authority_mutation_attempted = false;
+    for (std::size_t index = 0; index < snapshot.observations.size(); ++index) {
+        const auto &observation = snapshot.observations[index];
+        if (observation.operation == FaultOperation::RootRead &&
+            !first_root_read.has_value()) {
+            first_root_read = index;
+        }
+        if (observation.operation == FaultOperation::JournalRead &&
+            !first_journal_read.has_value()) {
+            first_journal_read = index;
+        }
+        snapshot.authority_mutation_attempted |= observation.mutation_attempted;
+        if ((is_authority_operation(observation.operation) ||
+             observation.mutation_attempted) &&
+            !observation.lock_held) {
+            snapshot.all_authority_io_under_lock = false;
+        }
+    }
+    snapshot.root_read_before_journal_read =
+        !first_journal_read.has_value() ||
+        (first_root_read.has_value() && *first_root_read < *first_journal_read);
+    return snapshot;
+}
+
+void JournalTestStorage::seed_untrusted_file(std::string name,
+                                             std::string bytes) {
+    std::lock_guard lock(state_->mutex);
+    state_->add_durable_regular(name, std::move(bytes));
+}
+
+void JournalTestStorage::overwrite_fixed_child_bytes(FixedAuthorityChild child,
+                                                     std::string bytes) {
+    const std::map<FixedAuthorityChild, std::string_view> names{
+        {FixedAuthorityChild::Journal, journal_name},
+        {FixedAuthorityChild::Root, root_name},
+        {FixedAuthorityChild::Lock, lock_name},
+        {FixedAuthorityChild::JournalStage, journal_stage_name},
+        {FixedAuthorityChild::RootStage, root_stage_name},
+    };
+    std::lock_guard lock(state_->mutex);
+    state_->add_durable_regular(names.at(child), std::move(bytes));
+}
+
+void JournalTestStorage::replace_fixed_child_file(FixedAuthorityChild child,
+                                                  std::string bytes) {
+    const std::map<FixedAuthorityChild, std::string_view> names{
+        {FixedAuthorityChild::Journal, journal_name},
+        {FixedAuthorityChild::Root, root_name},
+        {FixedAuthorityChild::Lock, lock_name},
+        {FixedAuthorityChild::JournalStage, journal_stage_name},
+        {FixedAuthorityChild::RootStage, root_stage_name},
+    };
+    std::lock_guard lock(state_->mutex);
+    auto &entry = state_->entries[std::string(names.at(child))];
+    entry = State::Entry{};
+    entry.live_bytes = bytes;
+    entry.durable_bytes = std::move(bytes);
+    entry.live_exists = true;
+    entry.durable_exists = true;
+    entry.durable_content_available = true;
+    entry.identity = next_entry_identity.fetch_add(1);
+}
+
+void JournalTestStorage::remove_fixed_child_file(FixedAuthorityChild child) {
+    const std::map<FixedAuthorityChild, std::string_view> names{
+        {FixedAuthorityChild::Journal, journal_name},
+        {FixedAuthorityChild::Root, root_name},
+        {FixedAuthorityChild::Lock, lock_name},
+        {FixedAuthorityChild::JournalStage, journal_stage_name},
+        {FixedAuthorityChild::RootStage, root_stage_name},
+    };
+    std::lock_guard lock(state_->mutex);
+    state_->entries.erase(std::string(names.at(child)));
+}
+
+void JournalTestStorage::arm_fault(FaultOperation operation,
+                                   FaultPosition position, FaultAction action) {
+    arm_fault_sequence(operation, position, {action});
+}
+
+void JournalTestStorage::arm_fault_sequence(FaultOperation operation,
+                                            FaultPosition position,
+                                            std::vector<FaultAction> actions) {
+    std::lock_guard lock(state_->mutex);
+    state_->fault = State::FaultScript{
+        operation, position,
+        std::deque<FaultAction>(actions.begin(), actions.end())};
+    state_->simulated_crash = false;
+}
+
+void JournalTestStorage::restart() {
+    std::lock_guard lock(state_->mutex);
+    state_->restart();
+}
+
+void JournalTestStorage::reset_observations() {
+    std::lock_guard lock(state_->mutex);
+    state_->observations.clear();
+}
+
+std::size_t JournalTestStorage::attempt_count(FaultOperation operation) const {
+    std::lock_guard lock(state_->mutex);
+    return static_cast<std::size_t>(
+        std::count_if(state_->observations.begin(), state_->observations.end(),
+                      [&](const OperationObservation &observation) {
+                          return observation.operation == operation;
+                      }));
+}
+
+void JournalTestStorage::make_capability_unavailable(
+    DurabilityCapability capability) {
+    std::lock_guard lock(state_->mutex);
+    state_->unavailable_capabilities.insert(capability);
+}
+
+void JournalTestStorage::poison_fixed_child(FixedAuthorityChild child,
+                                            UnsupportedEntryKind kind) {
+    const std::map<FixedAuthorityChild, std::string_view> names{
+        {FixedAuthorityChild::Journal, journal_name},
+        {FixedAuthorityChild::Root, root_name},
+        {FixedAuthorityChild::Lock, lock_name},
+        {FixedAuthorityChild::JournalStage, journal_stage_name},
+        {FixedAuthorityChild::RootStage, root_stage_name},
+    };
+    std::lock_guard lock(state_->mutex);
+    auto &entry = state_->entries[std::string(names.at(child))];
+    entry.live_exists = true;
+    entry.durable_exists = true;
+    entry.identity = next_entry_identity.fetch_add(1);
+    switch (kind) {
+    case UnsupportedEntryKind::Symlink:
+        entry.kind = State::EntryKind::Symlink;
+        break;
+    case UnsupportedEntryKind::NonRegular:
+        entry.kind = State::EntryKind::NonRegular;
+        break;
+    case UnsupportedEntryKind::ReparsePoint:
+        entry.kind = State::EntryKind::ReparsePoint;
+        break;
+    }
+}
+
+void JournalTestStorage::pause_after(FaultOperation operation) {
+    pause_after_nth(operation, 1);
+}
+
+void JournalTestStorage::pause_after_nth(FaultOperation operation,
+                                         std::size_t occurrence) {
+    std::lock_guard lock(state_->mutex);
+    state_->pause_operation = operation;
+    state_->pause_occurrence = occurrence;
+    state_->pause_consumed = false;
+    state_->pause_released = false;
+    state_->paused = false;
+}
+
+bool JournalTestStorage::destroy_adapter_with_open_lock(bool simulated_crash) {
+    auto adapter = std::make_unique<Adapter>(state_);
+    const auto locked = adapter->lock_authority();
+    {
+        std::lock_guard lock(state_->mutex);
+        state_->simulated_crash = simulated_crash;
+    }
+    return locked.succeeded();
+}
+
+bool JournalTestStorage::wait_until_paused(std::uint64_t timeout_milliseconds) {
+    std::unique_lock lock(state_->mutex);
+    return state_->condition.wait_for(
+        lock, std::chrono::milliseconds(timeout_milliseconds),
+        [&] { return state_->paused; });
+}
+
+bool JournalTestStorage::wait_until_lock_waiter(
+    std::uint64_t timeout_milliseconds) const {
+    std::unique_lock lock(state_->mutex);
+    return state_->condition.wait_for(
+        lock, std::chrono::milliseconds(timeout_milliseconds),
+        [&] { return state_->blocked_lock_waiters != 0; });
+}
+
+void JournalTestStorage::release_pause() {
+    std::lock_guard lock(state_->mutex);
+    state_->pause_released = true;
+    state_->condition.notify_all();
+}
+
+bool JournalTestStorage::try_unlink_lock_file() {
+    std::lock_guard lock(state_->mutex);
+    if (state_->platform == PlatformContract::Windows &&
+        !state_->open_lock_handles.empty()) {
+        return false;
+    }
+    auto *entry = state_->live_entry(lock_name);
+    if (entry == nullptr) {
+        return false;
+    }
+    entry->live_exists = false;
+    entry->durable_exists = false;
+    return true;
+}
+
+bool JournalTestStorage::try_recreate_lock_file() {
+    std::lock_guard lock(state_->mutex);
+    if (state_->platform == PlatformContract::Windows &&
+        !state_->open_lock_handles.empty()) {
+        return false;
+    }
+    if (state_->live_entry(lock_name) != nullptr) {
+        return false;
+    }
+    state_->entries[std::string(lock_name)].identity = 0;
+    state_->add_durable_regular(lock_name, {});
+    return true;
+}
+
+bool JournalTestStorage::try_replace_lock_with_reparse_point() {
+    std::lock_guard lock(state_->mutex);
+    if (!state_->open_lock_handles.empty()) {
+        return false;
+    }
+    auto *entry = state_->live_entry(lock_name);
+    if (entry == nullptr) {
+        return false;
+    }
+    entry->kind = State::EntryKind::ReparsePoint;
+    return true;
+}
+
+void JournalTestStorage::alias_lock_identity_from(
+    const JournalTestStorage &other) {
+    if (state_.get() == other.state_.get()) {
+        return;
+    }
+    std::scoped_lock lock(state_->mutex, other.state_->mutex);
+    auto *target = state_->live_entry(lock_name);
+    const auto *source = other.state_->live_entry(lock_name);
+    if (target != nullptr && source != nullptr) {
+        target->identity = source->identity;
+    }
+}
+
+std::uint64_t JournalTestStorage::lock_identity() const {
+    std::lock_guard lock(state_->mutex);
+    const auto *entry = state_->live_entry(lock_name);
+    return entry == nullptr ? 0 : entry->identity;
+}
+
+bool operator==(const NamespaceSnapshot &left, const NamespaceSnapshot &right) {
+    const auto observations_equal =
+        left.observations.size() == right.observations.size() &&
+        std::equal(left.observations.begin(), left.observations.end(),
+                   right.observations.begin(),
+                   [](const OperationObservation &left_observation,
+                      const OperationObservation &right_observation) {
+                       return left_observation.operation ==
+                                  right_observation.operation &&
+                              left_observation.lock_held ==
+                                  right_observation.lock_held &&
+                              left_observation.mutation_attempted ==
+                                  right_observation.mutation_attempted &&
+                              left_observation.lock_identity ==
+                                  right_observation.lock_identity &&
+                              left_observation.requested_bytes ==
+                                  right_observation.requested_bytes &&
+                              left_observation.transferred_bytes ==
+                                  right_observation.transferred_bytes;
+                   });
+    return left.journal_bytes == right.journal_bytes &&
+           left.authority_root_bytes == right.authority_root_bytes &&
+           left.relative_paths == right.relative_paths &&
+           left.durable_paths == right.durable_paths &&
+           left.durable_content_available == right.durable_content_available &&
+           left.entry_kinds == right.entry_kinds &&
+           left.live_file_bytes == right.live_file_bytes &&
+           left.durable_file_bytes == right.durable_file_bytes &&
+           left.open_handles == right.open_handles && observations_equal &&
+           left.namespace_durable == right.namespace_durable &&
+           left.journal_durable == right.journal_durable &&
+           left.authority_root_durable == right.authority_root_durable &&
+           left.journal_closed == right.journal_closed &&
+           left.stage_files_absent == right.stage_files_absent &&
+           left.durable_stage_files_absent ==
+               right.durable_stage_files_absent &&
+           left.all_authority_io_under_lock ==
+               right.all_authority_io_under_lock &&
+           left.lock_file_present == right.lock_file_present &&
+           left.lock_file_stable == right.lock_file_stable &&
+           left.root_read_before_journal_read ==
+               right.root_read_before_journal_read &&
+           left.authority_mutation_attempted ==
+               right.authority_mutation_attempted;
+}
+
+bool same_persistent_state(const NamespaceSnapshot &left,
+                           const NamespaceSnapshot &right) {
+    return left.journal_bytes == right.journal_bytes &&
+           left.authority_root_bytes == right.authority_root_bytes &&
+           left.relative_paths == right.relative_paths &&
+           left.durable_paths == right.durable_paths &&
+           left.durable_content_available == right.durable_content_available &&
+           left.entry_kinds == right.entry_kinds &&
+           left.live_file_bytes == right.live_file_bytes &&
+           left.durable_file_bytes == right.durable_file_bytes &&
+           left.namespace_durable == right.namespace_durable &&
+           left.journal_durable == right.journal_durable &&
+           left.authority_root_durable == right.authority_root_durable &&
+           left.stage_files_absent == right.stage_files_absent &&
+           left.durable_stage_files_absent ==
+               right.durable_stage_files_absent &&
+           left.lock_file_present == right.lock_file_present &&
+           left.lock_file_stable == right.lock_file_stable;
+}
+
+} // namespace lemon::residency::testing

--- a/test/residency/recovery/journal_persistence_test_support.h
+++ b/test/residency/recovery/journal_persistence_test_support.h
@@ -1,0 +1,261 @@
+#pragma once
+
+#ifndef LEMONADE_RESIDENCY_DURABLE_TESTING
+#error "durable journal test support is confined to the test target"
+#endif
+
+#include "lemon/residency/durable_journal.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace lemon::residency::testing {
+
+enum class PlatformContract { Linux, Windows, MacOS };
+
+enum class FaultPosition { Before, After };
+
+enum class FaultAction {
+    Error,
+    Crash,
+    EffectThenError,
+    ShortWrite,
+    InterruptedOnce,
+    ZeroProgress,
+    OverreportedWrite,
+};
+
+enum class FaultOperation {
+    PreflightProbe,
+    PreflightFlushCreate,
+    PreflightFlushWrite,
+    PreflightFlushFileFlush,
+    PreflightFlushClose,
+    PreflightTruncate,
+    PreflightTruncateFlush,
+    PreflightTruncateClose,
+    PreflightReplaceStageCreate,
+    PreflightReplaceStageWrite,
+    PreflightReplaceStageFlush,
+    PreflightReplaceStageClose,
+    PreflightReplace,
+    PreflightNamespaceDurability,
+    PreflightCleanup,
+    FixedNamespaceInspect,
+    AuthorityLockOpen,
+    AuthorityLockAcquire,
+    AuthorityIdentityRead,
+    RootOpen,
+    RootRead,
+    RootClose,
+    JournalOpen,
+    JournalRead,
+    JournalReadClose,
+    JournalAppendOpen,
+    InitialJournalCreate,
+    JournalWrite,
+    JournalFlush,
+    JournalClose,
+    RootStageCreate,
+    RootStageWrite,
+    RootStageFlush,
+    RootStageClose,
+    RootReplace,
+    NamespaceDurability,
+    AuthorityUnlock,
+    AuthorityLockClose,
+    TailRepairOpen,
+    TailRepairTruncate,
+    TailRepairFlush,
+    TailRepairClose,
+    CompactionStageCreate,
+    CompactionWrite,
+    CompactionFlush,
+    CompactionClose,
+    CompactionReplace,
+    CompactionNamespaceDurability,
+};
+
+enum class DurabilityCapability {
+    RegularFileFlush,
+    TailTruncateAndFlush,
+    SameDirectoryReplace,
+    NamespaceDurability,
+};
+
+enum class FixedAuthorityChild { Journal, Root, Lock, JournalStage, RootStage };
+
+enum class UnsupportedEntryKind { Symlink, NonRegular, ReparsePoint };
+
+struct OperationObservation {
+    FaultOperation operation;
+    bool lock_held;
+    bool mutation_attempted;
+    std::uint64_t lock_identity;
+    std::size_t requested_bytes;
+    std::size_t transferred_bytes;
+};
+
+struct NamespaceSnapshot {
+    std::string journal_bytes;
+    std::string authority_root_bytes;
+    std::set<std::string> relative_paths;
+    std::set<std::string> durable_paths;
+    std::set<std::string> durable_content_available;
+    std::map<std::string, std::string> entry_kinds;
+    std::map<std::string, std::string> live_file_bytes;
+    std::map<std::string, std::string> durable_file_bytes;
+    std::set<std::string> open_handles;
+    std::vector<OperationObservation> observations;
+    bool namespace_durable;
+    bool journal_durable;
+    bool authority_root_durable;
+    bool journal_closed;
+    bool stage_files_absent;
+    bool durable_stage_files_absent;
+    bool all_authority_io_under_lock;
+    bool lock_file_present;
+    bool lock_file_stable;
+    bool root_read_before_journal_read;
+    bool authority_mutation_attempted;
+};
+
+enum class HelperResultKind {
+    Succeeded,
+    Interrupted,
+    FailedBeforeEffect,
+    EffectMayHaveOccurred,
+};
+
+struct HelperProbeResult {
+    HelperResultKind result;
+    std::string bytes;
+    std::size_t attempts;
+};
+
+struct HelperOrchestrationProbeResult {
+    HelperResultKind result;
+    std::string bytes;
+    std::size_t write_attempts;
+    std::size_t flush_attempts;
+    std::size_t truncate_attempts;
+    std::size_t close_attempts;
+};
+
+struct ReadHelperProbeResult {
+    HelperResultKind result;
+    std::string bytes;
+    bool truncated;
+    std::vector<std::size_t> requested_bytes;
+    std::vector<std::size_t> returned_bytes;
+    std::size_t read_attempts;
+    std::size_t close_attempts;
+};
+
+struct NativeLockPathProbeResult {
+    bool replacement_prevented_while_held;
+    bool stale_identity_rejected;
+    bool nonblocking_probe_rejected;
+    bool first_unlock_succeeded;
+    bool contender_succeeded;
+    bool contender_rebound;
+    bool replacement_after_release_rebound;
+};
+
+bool operator==(const NamespaceSnapshot &left, const NamespaceSnapshot &right);
+bool same_persistent_state(const NamespaceSnapshot &left,
+                           const NamespaceSnapshot &right);
+HelperProbeResult probe_write_all(std::string bytes,
+                                  std::vector<FaultAction> script);
+HelperProbeResult probe_flush_retry(std::vector<FaultAction> script);
+HelperProbeResult probe_truncate_retry(std::string bytes,
+                                       std::size_t truncate_to,
+                                       std::vector<FaultAction> script);
+HelperProbeResult probe_close_once(std::vector<FaultAction> script);
+HelperOrchestrationProbeResult
+probe_write_flush_close(std::string bytes,
+                        std::vector<FaultAction> write_script,
+                        std::vector<FaultAction> flush_script,
+                        std::vector<FaultAction> close_script);
+HelperOrchestrationProbeResult
+probe_truncate_flush_close(std::string bytes, std::size_t truncate_to,
+                           std::vector<FaultAction> truncate_script,
+                           std::vector<FaultAction> flush_script,
+                           std::vector<FaultAction> close_script);
+ReadHelperProbeResult
+probe_read_bounded_close(std::string bytes, std::size_t max_bytes,
+                         std::vector<FaultAction> read_script,
+                         std::vector<FaultAction> close_script);
+NativeLockPathProbeResult
+probe_native_lock_path_revalidation(std::string directory);
+
+class JournalTestStorage {
+public:
+    static JournalTestStorage fresh();
+    static JournalTestStorage fresh(PlatformContract platform);
+    static JournalTestStorage
+    seeded(std::string journal_bytes,
+           std::optional<std::string> authority_root_bytes);
+    static JournalTestStorage seeded(std::string journal_bytes,
+                                     std::string authority_root_bytes);
+    static JournalTestStorage seeded(std::string journal_bytes,
+                                     std::string authority_root_bytes,
+                                     PlatformContract platform);
+    static JournalTestStorage
+    missing_authority_directory(PlatformContract platform);
+
+    JournalTestStorage(const JournalTestStorage &);
+    JournalTestStorage &operator=(const JournalTestStorage &);
+    JournalTestStorage(JournalTestStorage &&) noexcept;
+    JournalTestStorage &operator=(JournalTestStorage &&) noexcept;
+    ~JournalTestStorage();
+
+    JournalTestStorage clone() const;
+    DurableJournal make_journal(JournalLimits limits);
+    NamespaceSnapshot snapshot() const;
+    void seed_untrusted_file(std::string name, std::string bytes);
+    void overwrite_fixed_child_bytes(FixedAuthorityChild child,
+                                     std::string bytes);
+    void replace_fixed_child_file(FixedAuthorityChild child,
+                                  std::string bytes);
+    void remove_fixed_child_file(FixedAuthorityChild child);
+
+    void arm_fault(FaultOperation operation, FaultPosition position,
+                   FaultAction action);
+    void arm_fault_sequence(FaultOperation operation, FaultPosition position,
+                            std::vector<FaultAction> actions);
+    void restart();
+    void reset_observations();
+    std::size_t attempt_count(FaultOperation operation) const;
+
+    void make_capability_unavailable(DurabilityCapability capability);
+    void poison_fixed_child(FixedAuthorityChild child,
+                            UnsupportedEntryKind kind);
+
+    void pause_after(FaultOperation operation);
+    void pause_after_nth(FaultOperation operation, std::size_t occurrence);
+    bool destroy_adapter_with_open_lock(bool simulated_crash);
+    bool wait_until_paused(std::uint64_t timeout_milliseconds);
+    bool wait_until_lock_waiter(std::uint64_t timeout_milliseconds) const;
+    void release_pause();
+    bool try_unlink_lock_file();
+    bool try_recreate_lock_file();
+    bool try_replace_lock_with_reparse_point();
+    void alias_lock_identity_from(const JournalTestStorage &other);
+    std::uint64_t lock_identity() const;
+
+private:
+    struct State;
+    class Adapter;
+    explicit JournalTestStorage(std::shared_ptr<State> state);
+
+    std::shared_ptr<State> state_;
+};
+
+} // namespace lemon::residency::testing

--- a/test/residency/recovery/test_durable_journal_public_seam.py
+++ b/test/residency/recovery/test_durable_journal_public_seam.py
@@ -1,0 +1,9164 @@
+import hashlib
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping
+from pathlib import Path, PurePath, PureWindowsPath
+
+RUNNER = Path(__file__).resolve()
+REPO_ROOT = RUNNER.parents[3]
+PUBLIC_SEAM = REPO_ROOT / "test/residency/recovery/durable_journal_public_seam.cpp"
+PRIVATE_AUTHORITY_GATE = (
+    REPO_ROOT / "test/residency/recovery/durable_journal_private_authority_gate.cpp"
+)
+TEST_SUPPORT = (
+    REPO_ROOT / "test/residency/recovery/journal_persistence_test_support.cpp"
+)
+TEST_SUPPORT_HEADER = (
+    REPO_ROOT / "test/residency/recovery/journal_persistence_test_support.h"
+)
+INCLUDE_ROOT = REPO_ROOT / "src/cpp/include"
+INTERNAL_INCLUDE_ROOT = REPO_ROOT / "src/cpp/server/residency"
+TEST_INCLUDE_ROOT = REPO_ROOT / "test/residency/recovery"
+DURABLE_HEADER = INCLUDE_ROOT / "lemon/residency/durable_journal.h"
+DURABLE_SOURCE = REPO_ROOT / "src/cpp/server/residency/durable_journal.cpp"
+JOURNAL_SOURCE = REPO_ROOT / "src/cpp/server/residency/journal.cpp"
+JOURNAL_HEADER = INCLUDE_ROOT / "lemon/residency/journal.h"
+ADAPTER_HEADER = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter.h"
+ADAPTER_COMMON = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter.cpp"
+ADAPTER_POSIX = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter_posix.cpp"
+ADAPTER_WINDOWS = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter_windows.cpp"
+ADAPTER_MACOS = INTERNAL_INCLUDE_ROOT / "platform/durable_file_adapter_macos.cpp"
+CMAKE = REPO_ROOT / "CMakeLists.txt"
+WORKFLOW = REPO_ROOT / ".github/workflows/cpp_server_build_test_release.yml"
+PROCESS_TIMEOUT_SECONDS = 240
+TESTING_DEFINITION = "LEMONADE_RESIDENCY_DURABLE_TESTING"
+UNAVAILABLE = "TASK-020 durable residency persistence contract is unavailable"
+COMPILER_UNAVAILABLE = "durable journal public-seam compiler is unavailable"
+COMPILATION_FAILED = "durable journal public-seam compilation failed"
+COMPILATION_TIMED_OUT = "durable journal public-seam compilation timed out"
+EXECUTABLE_UNAVAILABLE = "durable journal public-seam executable is unavailable"
+EXECUTION_TIMED_OUT = "durable journal public-seam execution timed out"
+CONTRACT_ASSERTION_FAILED = "durable journal public-seam contract assertion failed"
+TASK019_HASHES = {
+    JOURNAL_HEADER: "afc94955a9fa57dc0154d4fbb2e19ca416d2d33c770616c75c45f031c7b167f7",
+    JOURNAL_SOURCE: "de9ae2b8943e8a539f01809537590cacf8676b6b54256d2f6497094792fa6b73",
+}
+
+
+def cmake_relative_path(path: PurePath, root: PurePath) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def split_compiler_command(value: str, *, windows: bool) -> list[str]:
+    try:
+        configured = shlex.split(value, posix=not windows)
+    except ValueError as error:
+        raise RuntimeError("C++ compiler command is invalid") from error
+    if windows:
+        configured = [
+            (
+                token[1:-1]
+                if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}
+                else token
+            )
+            for token in configured
+        ]
+    return configured
+
+
+def configured_compiler(
+    *,
+    environment: Mapping[str, str] | None = None,
+    which=shutil.which,
+) -> list[str]:
+    if environment is None:
+        environment = os.environ
+    windows = os.name == "nt"
+    default = "cl.exe" if windows else "c++"
+    configured = split_compiler_command(
+        environment.get("CXX", default), windows=windows
+    )
+    if not configured or which(configured[0]) is None:
+        raise RuntimeError(f"C++ compiler is unavailable: {configured!r}")
+    return configured
+
+
+def explicit_compiler(value: str) -> list[str]:
+    compiler = Path(value)
+    if not compiler.is_absolute() or not compiler.is_file():
+        raise RuntimeError("hosted C++ compiler is unavailable")
+    if os.name != "nt" and not os.access(compiler, os.X_OK):
+        raise RuntimeError("hosted C++ compiler is unavailable")
+    return [str(compiler)]
+
+
+def is_msvc_frontend(configured: list[str]) -> bool:
+    executable = configured[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
+    return executable in {"cl", "cl.exe", "clang-cl", "clang-cl.exe"}
+
+
+def native_adapter_source() -> Path:
+    if os.name == "nt":
+        return ADAPTER_WINDOWS
+    if sys.platform == "darwin":
+        return ADAPTER_MACOS
+    return ADAPTER_POSIX
+
+
+def compiler_command(
+    output: Path,
+    *,
+    configured: list[str] | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> list[str]:
+    if configured is None:
+        configured = configured_compiler()
+    if environment is None:
+        environment = os.environ
+
+    executable = configured[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
+    nlohmann_include = environment.get("NLOHMANN_JSON_INCLUDE_DIR")
+    mbedtls_include = environment.get("MBEDTLS_INCLUDE_DIR")
+    mbedcrypto_library = environment.get("MBEDCRYPTO_LIBRARY")
+    sources = [
+        JOURNAL_SOURCE,
+        DURABLE_SOURCE,
+        ADAPTER_COMMON,
+        native_adapter_source(),
+        TEST_SUPPORT,
+        PUBLIC_SEAM,
+    ]
+
+    if executable in {"cl", "cl.exe", "clang-cl", "clang-cl.exe"}:
+        command = [
+            *configured,
+            "/nologo",
+            "/std:c++17",
+            "/W4",
+            "/WX",
+            "/EHsc",
+            f"/D{TESTING_DEFINITION}",
+            f"/I{INCLUDE_ROOT}",
+            f"/I{INTERNAL_INCLUDE_ROOT}",
+            f"/I{TEST_INCLUDE_ROOT}",
+        ]
+        if nlohmann_include:
+            command.append(f"/I{nlohmann_include}")
+        if mbedtls_include:
+            command.append(f"/I{mbedtls_include}")
+        if not mbedcrypto_library:
+            raise RuntimeError(
+                "MBEDCRYPTO_LIBRARY is required for the MSVC public seam"
+            )
+        command.extend(
+            [
+                f"/Fo{output.parent}{os.sep}",
+                f"/Fd{output.with_suffix('.pdb')}",
+                *(str(source) for source in sources),
+                mbedcrypto_library,
+                f"/Fe:{output}",
+            ]
+        )
+        return command
+
+    command = [
+        *configured,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-pedantic",
+        "-pthread",
+        f"-D{TESTING_DEFINITION}",
+        "-I",
+        str(INCLUDE_ROOT),
+        "-I",
+        str(INTERNAL_INCLUDE_ROOT),
+        "-I",
+        str(TEST_INCLUDE_ROOT),
+    ]
+    if nlohmann_include:
+        command.extend(["-I", nlohmann_include])
+    if mbedtls_include:
+        command.extend(["-I", mbedtls_include])
+    command.extend(
+        [
+            *(str(source) for source in sources),
+            mbedcrypto_library or "-lmbedcrypto",
+            "-o",
+            str(output),
+        ]
+    )
+    return command
+
+
+def compile_only_command(
+    source: Path,
+    output: Path,
+    *,
+    configured: list[str],
+    system_includes: tuple[str, ...] = (),
+) -> list[str]:
+    executable = configured[0].replace("\\", "/").rsplit("/", 1)[-1].lower()
+    if executable in {"cl", "cl.exe", "clang-cl", "clang-cl.exe"}:
+        command = [
+            *configured,
+            "/nologo",
+            "/std:c++17",
+            "/EHsc",
+            f"/U{TESTING_DEFINITION}",
+            f"/I{INCLUDE_ROOT}",
+            "/c",
+            str(source),
+            f"/Fo{output}",
+        ]
+        command.extend(f"/I{include}" for include in system_includes)
+        return command
+    command = [
+        *configured,
+        "-std=c++17",
+        f"-U{TESTING_DEFINITION}",
+        "-I",
+        str(INCLUDE_ROOT),
+        "-c",
+        str(source),
+        "-o",
+        str(output),
+    ]
+    system_include_flags = [
+        token for include in system_includes for token in ("-isystem", include)
+    ]
+    command[2:2] = system_include_flags
+    return command
+
+
+def require_private_authority_construction(
+    directory: Path,
+    *,
+    configured: list[str],
+    system_includes: tuple[str, ...] = (),
+    runner=subprocess.run,
+) -> str | None:
+    positive_source = directory / "published_journal_positive_control.cpp"
+    positive_output = directory / "published_journal_positive_control.obj"
+    positive_source.write_text(
+        """
+#include "lemon/residency/durable_journal.h"
+#include "platform/durable_file_adapter.h"
+#include <type_traits>
+using lemon::residency::PublishedJournal;
+static_assert(std::is_move_constructible_v<PublishedJournal>);
+static_assert(!std::is_copy_constructible_v<PublishedJournal>);
+namespace lemon::residency::detail {
+enum class DurablePreflightTestFault { MacroOffNameCollision };
+class DurableJournalTestFactory {};
+inline constexpr int make_platform_durable_file_adapter_for_test = 0;
+inline constexpr int make_durable_journal_for_test = 0;
+}
+""",
+        encoding="utf-8",
+    )
+    try:
+        positive = runner(
+            compile_only_command(
+                positive_source,
+                positive_output,
+                configured=configured,
+                system_includes=(str(INTERNAL_INCLUDE_ROOT), *system_includes),
+            ),
+            cwd=directory,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=PROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return COMPILATION_TIMED_OUT
+    except (OSError, UnicodeError):
+        return COMPILER_UNAVAILABLE
+    if positive.returncode != 0:
+        return COMPILATION_FAILED
+
+    adversaries = {
+        "default": """
+#include "lemon/residency/durable_journal.h"
+using lemon::residency::PublishedJournal;
+PublishedJournal forged;
+""",
+        "root": """
+#include "lemon/residency/durable_journal.h"
+#include <string>
+using lemon::residency::PublishedJournal;
+PublishedJournal forged(std::string("root"));
+""",
+        "copy": """
+#include "lemon/residency/durable_journal.h"
+using lemon::residency::PublishedJournal;
+PublishedJournal copy(const PublishedJournal &value) { return value; }
+""",
+        "export": """
+#include "lemon/residency/durable_journal.h"
+#include <utility>
+using namespace lemon::residency;
+PublishedJournal forge(ExactSchemaExportCandidate value) {
+    return PublishedJournal(std::move(value));
+}
+""",
+        "record": """
+#include "lemon/residency/durable_journal.h"
+using namespace lemon::residency;
+PublishedJournal forge(const ParsedJournalRecord &value) {
+    return PublishedJournal(value);
+}
+""",
+        "history": """
+#include "lemon/residency/durable_journal.h"
+using namespace lemon::residency;
+PublishedJournal forge(JournalHistory &&value) {
+    return PublishedJournal(static_cast<JournalHistory &&>(value));
+}
+""",
+        "root_candidate": """
+#include "lemon/residency/durable_journal.h"
+using namespace lemon::residency;
+PublishedJournal forge(const AuthorityRootCandidate &value) {
+    return PublishedJournal(value);
+}
+""",
+        "adapter": """
+#include "lemon/residency/durable_journal.h"
+#include <memory>
+struct ForgedAdapter {};
+using lemon::residency::PublishedJournal;
+PublishedJournal forge(std::shared_ptr<ForgedAdapter> value) {
+    return PublishedJournal(value);
+}
+""",
+        "public_access": """
+#include "lemon/residency/durable_journal.h"
+namespace lemon::residency {
+class PublishedJournalAccess {
+public:
+    static PublishedJournal forge() { return PublishedJournal(); }
+};
+}
+""",
+        "public_test_access": """
+#include "lemon/residency/durable_journal.h"
+#include <memory>
+#include <utility>
+struct ForgedAdapter {};
+namespace lemon::residency {
+class DurableJournalTestAccess {
+public:
+    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
+        return DurableJournal(std::move(adapter), JournalLimits{});
+    }
+};
+}
+""",
+        "detail_access": """
+#include "lemon/residency/durable_journal.h"
+#include <memory>
+#include <utility>
+struct ForgedAdapter {};
+namespace lemon::residency::detail {
+class DurableJournalAccess {
+public:
+    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
+        return DurableJournal(std::move(adapter), JournalLimits{});
+    }
+};
+}
+""",
+        "detail_test_access": """
+#include "lemon/residency/durable_journal.h"
+#include <memory>
+#include <utility>
+struct ForgedAdapter {};
+namespace lemon::residency::detail {
+class DurableJournalTestAccess {
+public:
+    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
+        return DurableJournal(std::move(adapter), JournalLimits{});
+    }
+};
+}
+""",
+        "journal_default": """
+#include "lemon/residency/durable_journal.h"
+using lemon::residency::DurableJournal;
+DurableJournal forged;
+""",
+        "journal_copy": """
+#include "lemon/residency/durable_journal.h"
+using lemon::residency::DurableJournal;
+DurableJournal copy(const DurableJournal &value) { return value; }
+""",
+        "exact_test_factory": """
+#include "lemon/residency/durable_journal.h"
+#include <memory>
+#include <utility>
+struct ForgedAdapter {};
+namespace lemon::residency::detail {
+class DurableJournalTestFactory {
+public:
+    static DurableJournal forge(std::unique_ptr<::ForgedAdapter> adapter) {
+        return DurableJournal(std::move(adapter), JournalLimits{});
+    }
+};
+}
+""",
+    }
+    for name, source_text in adversaries.items():
+        source = directory / f"forged_published_journal_{name}.cpp"
+        output = directory / f"forged_published_journal_{name}.obj"
+        source.write_text(source_text, encoding="utf-8")
+        try:
+            completed = runner(
+                compile_only_command(
+                    source,
+                    output,
+                    configured=configured,
+                    system_includes=system_includes,
+                ),
+                cwd=REPO_ROOT,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=PROCESS_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return COMPILATION_TIMED_OUT
+        except (OSError, UnicodeError):
+            return COMPILER_UNAVAILABLE
+        if completed.returncode == 0:
+            return CONTRACT_ASSERTION_FAILED
+    return None
+
+
+def require_platform_source_contract() -> None:
+    adapter_header = strip_cpp_comments_and_literals(
+        ADAPTER_HEADER.read_text(encoding="utf-8")
+    )
+    common = strip_cpp_comments_and_literals(ADAPTER_COMMON.read_text(encoding="utf-8"))
+    posix = strip_cpp_comments_and_literals(ADAPTER_POSIX.read_text(encoding="utf-8"))
+    windows = strip_cpp_comments_and_literals(
+        ADAPTER_WINDOWS.read_text(encoding="utf-8")
+    )
+    macos = strip_cpp_comments_and_literals(ADAPTER_MACOS.read_text(encoding="utf-8"))
+    durable = DURABLE_SOURCE.read_text(encoding="utf-8")
+    durable_header_raw = DURABLE_HEADER.read_text(encoding="utf-8")
+    durable_header = strip_cpp_comments_preserve_literals(durable_header_raw)
+    durable_header_code = strip_cpp_comments_and_literals(durable_header_raw)
+
+    require_exact_struct_shape(
+        adapter_header,
+        "DurableFixedNamespaceResult",
+        (
+            "DurableFileResult result;",
+            "bool journal_present;",
+            "bool root_present;",
+            "bool journal_stage_present;",
+            "bool root_stage_present;",
+            "bool lock_present;",
+        ),
+    )
+    require_exact_struct_shape(
+        adapter_header,
+        "DurableReadChunkResult",
+        (
+            "DurableFileResult result;",
+            "std::string bytes;",
+            "bool end_of_file = false;",
+        ),
+    )
+    if (
+        re.search(
+            r"\bclass\s+DurableReadChannel\s*\{(?P<body>.*?)\n\};",
+            adapter_header,
+            re.DOTALL,
+        )
+        is None
+        or re.search(
+            r"\bvirtual\s+DurableReadChunkResult\s+read_some\s*"
+            r"\(\s*std::size_t\s+max_bytes\s*\)\s*=\s*0\s*;",
+            adapter_header,
+        )
+        is None
+        or re.search(
+            r"\bvirtual\s+DurableFileResult\s+close\s*\(\s*\)\s*=\s*0\s*;",
+            adapter_header,
+        )
+        is None
+    ):
+        raise AssertionError("durable bounded-read channel shape drifted")
+    if (
+        re.search(
+            r"\bvirtual\s+DurableFixedNamespaceResult\s+"
+            r"inspect_fixed_namespace\s*\(\s*\)\s*=\s*0\s*;",
+            adapter_header,
+        )
+        is None
+    ):
+        raise AssertionError("durable adapter omits fixed-namespace inspection")
+
+    fixed_constants = {
+        "durable_journal_data_filename": "journal.jsonl",
+        "durable_journal_root_filename": "authority-root.json",
+        "durable_journal_lock_filename": "authority.lock",
+    }
+    for constant, value in fixed_constants.items():
+        declaration = re.compile(
+            rf"inline\s+constexpr\s+std::string_view\s+{constant}\s*=\s*\"{re.escape(value)}\"\s*;"
+        )
+        if declaration.search(durable_header) is None:
+            raise AssertionError(
+                f"missing fixed authority filename contract {constant}"
+            )
+        narrated = f'// inline constexpr std::string_view {constant} = "{value}";\n'
+        if declaration.search(strip_cpp_comments_preserve_literals(narrated)):
+            raise AssertionError("fixed-name scanner accepted a commented declaration")
+    published_match = re.search(
+        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
+        durable_header_code,
+        re.DOTALL,
+    )
+    if published_match is None:
+        raise AssertionError("PublishedJournal public declaration is unavailable")
+    require_published_journal_public_shape(durable_header_code)
+    require_durable_journal_public_shape(durable_header_code)
+    require_trusted_replay_floor_public_shape(durable_header_code)
+    if re.search(
+        r"\b(?:static\s+)?PublishedJournal\s+[A-Za-z_]\w*\s*\(",
+        durable_header_code,
+    ) or re.search(
+        r"\bstd\s*::\s*optional\s*<\s*PublishedJournal\s*>\s+" r"[A-Za-z_]\w*\s*\(",
+        durable_header_code,
+    ):
+        raise AssertionError("public header exposes an authority-minting factory")
+    friend_declarations = re.findall(r"\bfriend\b[^;]*;", published_match.group("body"))
+    if friend_declarations != ["friend class DurableJournal;"]:
+        raise AssertionError("PublishedJournal has a forgeable friend graph")
+    testing_friend = "friend class detail::DurableJournalTestFactory;"
+    if durable_header_code.count(testing_friend) != 1 or not exactly_macro_guarded(
+        durable_header_code,
+        testing_friend,
+        TESTING_DEFINITION,
+    ):
+        raise AssertionError("DurableJournal test factory is not macro-confined")
+    unguarded_factory_mutant = f"""
+#ifdef {TESTING_DEFINITION}
+#endif
+{testing_friend}
+#ifdef OTHER_GUARD
+#endif
+"""
+    if exactly_macro_guarded(
+        unguarded_factory_mutant,
+        testing_friend,
+        TESTING_DEFINITION,
+    ):
+        raise AssertionError("test-factory scanner crossed an early endif")
+    unguarded_declaration_mutant = f"""
+#ifdef {TESTING_DEFINITION}
+#endif
+namespace detail {{ class DurableJournalTestFactory; }}
+#ifdef OTHER_GUARD
+#endif
+"""
+    if exactly_macro_guarded_region(
+        unguarded_declaration_mutant,
+        TESTING_DEFINITION,
+        ("namespace detail", "class DurableJournalTestFactory;"),
+    ):
+        raise AssertionError("test-factory declaration scanner crossed endif")
+    for forbidden in (
+        "DurableFileAdapter",
+        "make_durable_journal_for_test",
+        "from_adapter",
+        "testing_adapter",
+    ):
+        if forbidden in durable_header_code:
+            raise AssertionError("public durable journal exposes adapter injection")
+    if not exactly_macro_guarded_region(
+        durable_header_code,
+        TESTING_DEFINITION,
+        ("class DurableJournalTestFactory;",),
+    ):
+        raise AssertionError("test-factory declaration is not macro-confined")
+    require_exact_enum_members(
+        durable_header_code,
+        "DurableJournalStatus",
+        (
+            "Published",
+            "ConflictBeforeWrite",
+            "UnsupportedStorage",
+            "CorruptOrRollback",
+            "LimitExceeded",
+            "RecoveryRequired",
+        ),
+    )
+    require_exact_enum_members(
+        durable_header_code,
+        "ExactSchemaExportStatus",
+        (
+            "ExportedCandidate",
+            "QuiescenceRequired",
+            "ConflictBeforeRead",
+            "RecoveryRequired",
+            "UnsupportedStorage",
+            "CorruptOrRollback",
+            "SchemaMismatch",
+            "LimitExceeded",
+        ),
+    )
+    require_exact_enum_members(
+        durable_header_code,
+        "JournalQuiescence",
+        ("Unconfirmed", "Confirmed"),
+    )
+    enum_mutant = """
+enum class DurableJournalStatus {
+    Published, ConflictBeforeWrite, UnsupportedStorage, CorruptOrRollback,
+    LimitExceeded, RecoveryRequired, ForgedSuccess
+};
+"""
+    try:
+        require_exact_enum_members(
+            enum_mutant,
+            "DurableJournalStatus",
+            (
+                "Published",
+                "ConflictBeforeWrite",
+                "UnsupportedStorage",
+                "CorruptOrRollback",
+                "LimitExceeded",
+                "RecoveryRequired",
+            ),
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("status scanner accepted an extra public outcome")
+    quiescence_mutant = """
+enum class JournalQuiescence { Unconfirmed, Confirmed, Assumed };
+"""
+    try:
+        require_exact_enum_members(
+            quiescence_mutant,
+            "JournalQuiescence",
+            ("Unconfirmed", "Confirmed"),
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("quiescence scanner accepted an extra public state")
+    require_exact_struct_shape(
+        durable_header_code,
+        "DurableJournalResult",
+        (
+            "DurableJournalStatus status;",
+            "std::optional<PublishedJournal> journal;",
+            "bool published() const noexcept;",
+        ),
+    )
+    require_exact_struct_shape(
+        durable_header_code,
+        "ExactSchemaExportCandidate",
+        (
+            "SchemaVersion schema;",
+            "std::string journal_bytes;",
+            "std::string authority_root_bytes;",
+        ),
+    )
+    require_exact_struct_shape(
+        durable_header_code,
+        "ExactSchemaExportResult",
+        (
+            "ExactSchemaExportStatus status;",
+            "std::optional<ExactSchemaExportCandidate> candidate;",
+            "bool exported() const noexcept;",
+        ),
+    )
+    diagnostic_mutant = durable_header_code.replace(
+        "DurableJournalStatus status;",
+        "DurableJournalStatus status; std::string diagnostic;",
+        1,
+    )
+    if diagnostic_mutant == durable_header_code:
+        raise AssertionError("public diagnostic mutant was unavailable")
+    try:
+        require_exact_struct_shape(
+            diagnostic_mutant,
+            "DurableJournalResult",
+            (
+                "DurableJournalStatus status;",
+                "std::optional<PublishedJournal> journal;",
+                "bool published() const noexcept;",
+            ),
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("public result scanner accepted diagnostics")
+    combined_code = f"{common}\n{posix}\n{windows}\n{macos}\n{strip_cpp_comments_and_literals(durable)}"
+    if "atomic_replace_file" in combined_code or "copy_file" in combined_code:
+        raise AssertionError("durable adapter uses a forbidden copy fallback")
+    durable_code = strip_cpp_comments_and_literals(durable)
+    if "parse_authority_root_candidate" not in durable_code:
+        raise AssertionError("persistence bypassed the TASK-019 root parser")
+    if "inspect_fixed_namespace" not in durable_code:
+        raise AssertionError("persistence bypassed fixed-namespace inspection")
+    if "nlohmann" in durable_code or "parse_json" in durable_code:
+        raise AssertionError("persistence duplicated TASK-019 JSON parsing")
+    require_task019_live_contract(durable_code)
+    require_compaction_prefix_binding(durable_code)
+    require_directory_lineage_fence_registry(durable_code)
+    require_final_authority_revalidation(durable_code)
+    for path, expected in TASK019_HASHES.items():
+        observed = hashlib.sha256(path.read_bytes()).hexdigest()
+        if observed != expected:
+            raise AssertionError("TASK-019 pure codec bytes changed during TASK-020")
+
+    require_tokens(
+        posix,
+        (
+            "openat",
+            "renameat",
+            "fsync",
+            "flock",
+            "O_APPEND",
+            "O_CLOEXEC",
+            "O_NOFOLLOW",
+            "AT_SYMLINK_NOFOLLOW",
+            "LOCK_EX",
+            "EINTR",
+            "S_ISREG",
+            "st_ino",
+            "st_dev",
+            "st_nlink",
+            "ftruncate",
+            "O_DIRECTORY",
+            "close",
+            "read",
+        ),
+        "POSIX durable adapter",
+    )
+    if "atomic_replace_file" in posix:
+        raise AssertionError("POSIX adapter reused generic replacement")
+
+    require_tokens(
+        windows,
+        (
+            "CreateFileW",
+            "WriteFile",
+            "ReadFile",
+            "FlushFileBuffers",
+            "CloseHandle",
+            "LockFileEx",
+            "UnlockFileEx",
+            "MoveFileExW",
+            "MOVEFILE_REPLACE_EXISTING",
+            "MOVEFILE_WRITE_THROUGH",
+            "SetFilePointerEx",
+            "SetEndOfFile",
+            "MAXDWORD",
+            "OPEN_ALWAYS",
+            "ERROR_ALREADY_EXISTS",
+            "OVERLAPPED",
+            "FILE_SHARE_READ",
+            "FILE_SHARE_WRITE",
+            "FILE_FLAG_OPEN_REPARSE_POINT",
+            "FILE_ATTRIBUTE_REPARSE_POINT",
+            "FILE_ATTRIBUTE_DIRECTORY",
+            "GetFileInformationByHandleEx",
+            "FileIdInfo",
+            "FileAttributeTagInfo",
+            "FILE_ID_INFO",
+            "FILE_ATTRIBUTE_TAG_INFO",
+        ),
+        "Windows durable adapter",
+    )
+    require_absent_tokens(
+        windows,
+        (
+            "MOVEFILE_COPY_ALLOWED",
+            "FILE_ATTRIBUTE_TEMPORARY",
+            "FILE_FLAG_DELETE_ON_CLOSE",
+            "FILE_FLAG_OVERLAPPED",
+            "FILE_SHARE_DELETE",
+        ),
+        "Windows durable adapter",
+    )
+
+    require_tokens(
+        macos,
+        (
+            "F_FULLFSYNC",
+            "fcntl",
+            "fsync",
+            "renameat",
+            "flock",
+            "openat",
+            "fstatat",
+            "O_NOFOLLOW",
+            "O_DIRECTORY",
+            "AT_SYMLINK_NOFOLLOW",
+            "LOCK_EX",
+            "EINTR",
+            "S_ISREG",
+            "st_ino",
+            "st_dev",
+            "st_nlink",
+            "close",
+            "O_APPEND",
+            "O_CLOEXEC",
+            "ftruncate",
+        ),
+        "macOS durable adapter",
+    )
+    if "F_BARRIERFSYNC" in macos:
+        raise AssertionError("macOS adapter substituted a barrier for persistence")
+    require_call_argument(macos, "fcntl", "F_FULLFSYNC", "macOS regular-file policy")
+    require_call_arguments(
+        windows,
+        "MoveFileExW",
+        ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
+        "Windows root replacement",
+    )
+    require_call_arguments(
+        windows,
+        "LockFileEx",
+        ("LOCKFILE_EXCLUSIVE_LOCK", "MAXDWORD", "MAXDWORD"),
+        "Windows whole-file lock",
+    )
+    require_call_argument(posix, "flock", "LOCK_EX", "POSIX authority lock")
+    require_call_argument(macos, "flock", "LOCK_EX", "macOS authority lock")
+    for platform_source, label in (
+        (posix, "POSIX durable adapter"),
+        (macos, "macOS durable adapter"),
+    ):
+        require_call_arguments_unordered(
+            platform_source,
+            "openat",
+            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
+            f"{label} journal append",
+        )
+        require_call_argument(
+            platform_source,
+            "open",
+            "O_DIRECTORY",
+            f"{label} authority directory",
+        )
+        require_call_argument(
+            platform_source,
+            "fstatat",
+            "AT_SYMLINK_NOFOLLOW",
+            f"{label} stable lock identity",
+        )
+        require_call_expression(platform_source, "renameat", label)
+    require_call_arguments_unordered(
+        windows,
+        "CreateFileW",
+        ("OPEN_ALWAYS", "FILE_SHARE_READ", "FILE_SHARE_WRITE"),
+        "Windows stable authority lock",
+    )
+    if re.search(r"\bOVERLAPPED\s+\w+\s*(?:\{\s*\}|=\s*\{\s*\})", windows) is None:
+        raise AssertionError("Windows authority lock OVERLAPPED is not zeroed")
+    require_call_argument(
+        windows,
+        "GetFileInformationByHandleEx",
+        "FileIdInfo",
+        "Windows composite authority identity",
+    )
+    all_adapter_sources = f"{common}\n{posix}\n{windows}\n{macos}"
+    helper_declarations = {
+        "retry_interrupted": (
+            "DurableFileResult retry_interrupted(DurableInterruptibleCall &call);"
+        ),
+        "write_all": (
+            "DurableFileResult write_all(DurableFileChannel &channel, "
+            "std::string_view bytes);"
+        ),
+        "flush_retrying_interrupts": (
+            "DurableFileResult flush_retrying_interrupts("
+            "DurableFileChannel &channel);"
+        ),
+        "truncate_retrying_interrupts": (
+            "DurableFileResult truncate_retrying_interrupts("
+            "DurableFileChannel &channel, std::size_t bytes);"
+        ),
+        "close_once": ("DurableFileResult close_once(DurableFileChannel &channel);"),
+        "write_flush_close": (
+            "DurableFileResult write_flush_close(DurableFileChannel &channel, "
+            "std::string_view bytes);"
+        ),
+        "truncate_flush_close": (
+            "DurableFileResult truncate_flush_close("
+            "DurableFileChannel &channel, std::size_t bytes);"
+        ),
+        "close_read_once": (
+            "DurableFileResult close_read_once(DurableReadChannel &channel);"
+        ),
+    }
+    for helper, declaration in helper_declarations.items():
+        require_unique_helper_definition(
+            adapter_header,
+            all_adapter_sources,
+            helper,
+            declaration,
+            "durable adapter",
+        )
+    require_unique_helper_definition(
+        adapter_header,
+        all_adapter_sources,
+        "read_bounded_close",
+        "DurableReadResult read_bounded_close(DurableReadChannel &channel, "
+        "std::size_t max_bytes);",
+        "durable adapter",
+        return_type="DurableReadResult",
+    )
+    for platform_source, label in (
+        (posix, "POSIX durable adapter"),
+        (windows, "Windows durable adapter"),
+        (macos, "macOS durable adapter"),
+    ):
+        combined_platform = f"{common}\n{platform_source}"
+        for required_call in (
+            "write_flush_close",
+            "truncate_flush_close",
+        ):
+            require_each_override_call(
+                combined_platform,
+                "DurableFileAdapter",
+                "preflight_capabilities",
+                required_call,
+                f"{label} capability probe",
+            )
+        for entry, required_calls in (
+            ("append_journal", ("write_flush_close",)),
+            ("truncate_journal", ("truncate_flush_close",)),
+            ("read_root", ("read_bounded_close",)),
+            ("read_journal", ("read_bounded_close",)),
+            ("create_journal", ("write_flush_close",)),
+            ("replace_journal", ("write_flush_close",)),
+            ("replace_root", ("write_flush_close",)),
+        ):
+            for required_call in required_calls:
+                require_each_override_call_exactly_once(
+                    combined_platform,
+                    "DurableFileAdapter",
+                    entry,
+                    required_call,
+                    label,
+                )
+        for entry in ("create_journal", "append_journal"):
+            require_each_override_call_result_propagated(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "write_flush_close",
+                label,
+            )
+        require_each_override_call_result_propagated(
+            combined_platform,
+            "DurableFileAdapter",
+            "truncate_journal",
+            "truncate_flush_close",
+            label,
+        )
+        for entry in ("replace_journal", "replace_root"):
+            require_each_override_call_result_propagated(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "write_flush_close",
+                label,
+            )
+        for entry in ("read_root", "read_journal"):
+            require_each_override_call_result_propagated(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "read_bounded_close",
+                label,
+            )
+        require_each_override_call_result_propagated(
+            combined_platform,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "write_flush_close",
+            f"{label} capability probe",
+            minimum_calls=2,
+        )
+        require_each_override_call_result_propagated(
+            combined_platform,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "truncate_flush_close",
+            f"{label} capability probe",
+        )
+    for platform_source, platform, label in (
+        (posix, "posix", "POSIX durable adapter"),
+        (macos, "posix", "macOS durable adapter"),
+        (windows, "windows", "Windows durable adapter"),
+    ):
+        require_post_replace_verification(platform_source, platform, label)
+        require_post_replace_verification_mutants(platform_source, platform, label)
+    require_windows_bound_directory_factory(windows)
+    require_windows_bound_directory_factory_mutants(windows)
+    require_transaction_helper_contract(all_adapter_sources)
+    require_bounded_read_helper_contract(f"{adapter_header}\n{all_adapter_sources}")
+    require_close_read_once_contract(all_adapter_sources)
+    for platform_source, label in (
+        (posix, "POSIX durable adapter"),
+        (macos, "macOS durable adapter"),
+    ):
+        combined_platform = f"{common}\n{platform_source}"
+        require_retrying_posix_flock(
+            platform_source,
+            "lock_file_retrying_interrupts",
+            "LOCK_EX",
+            f"{label} acquisition",
+        )
+        require_retrying_posix_flock(
+            platform_source,
+            "unlock_file_retrying_interrupts",
+            "LOCK_UN",
+            f"{label} release",
+        )
+        require_retrying_posix_flock(
+            platform_source,
+            "lock_directory_retrying_interrupts",
+            "LOCK_EX",
+            f"{label} directory acquisition",
+        )
+        require_retrying_posix_flock(
+            platform_source,
+            "unlock_directory_retrying_interrupts",
+            "LOCK_UN",
+            f"{label} directory release",
+        )
+        require_retrying_posix_flock_mutant(
+            platform_source,
+            "lock_directory_retrying_interrupts",
+            "LOCK_EX",
+            f"{label} directory acquisition",
+        )
+        require_retrying_posix_flock_mutant(
+            platform_source,
+            "unlock_directory_retrying_interrupts",
+            "LOCK_UN",
+            f"{label} directory release",
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            "lock_file_retrying_interrupts",
+            label,
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "unlock_authority",
+            "unlock_file_retrying_interrupts",
+            label,
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            "lock_directory_retrying_interrupts",
+            label,
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "unlock_authority",
+            "unlock_directory_retrying_interrupts",
+            label,
+        )
+        require_each_override_result_call_checked(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            "lock_file_retrying_interrupts",
+            label,
+        )
+        require_each_override_result_call_checked(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            "lock_directory_retrying_interrupts",
+            label,
+        )
+        require_each_override_result_call_checked(
+            combined_platform,
+            "DurableFileAdapter",
+            "unlock_authority",
+            "unlock_directory_retrying_interrupts",
+            label,
+        )
+        require_posix_unlock_result_mapping(combined_platform, label)
+        require_each_override_ordered_calls(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            (
+                "lock_directory_retrying_interrupts",
+                "openat",
+                "lock_file_retrying_interrupts",
+            ),
+            label,
+        )
+        require_each_override_ordered_calls(
+            combined_platform,
+            "DurableFileAdapter",
+            "unlock_authority",
+            (
+                "unlock_file_retrying_interrupts",
+                "close",
+                "unlock_directory_retrying_interrupts",
+            ),
+            label,
+        )
+        require_posix_live_lock_rebinding(combined_platform, label)
+        require_posix_lock_path_binding_mutants(combined_platform, label)
+        require_retrying_directory_sync(platform_source, label)
+        require_each_override_call_arguments(
+            combined_platform,
+            "DurableFileAdapter",
+            "append_journal",
+            "openat",
+            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
+            label,
+        )
+        require_each_override_call(
+            combined_platform,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "renameat",
+            f"{label} capability probe replacement",
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "renameat",
+            f"{label} capability probe replacement",
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "sync_directory_retrying_interrupts",
+            f"{label} capability probe namespace durability",
+        )
+        require_each_override_directory_sync_binding(
+            combined_platform,
+            "preflight_capabilities",
+            f"{label} capability probe namespace durability",
+        )
+        require_each_override_result_call_checked(
+            combined_platform,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "sync_directory_retrying_interrupts",
+            f"{label} capability probe namespace durability",
+        )
+        require_each_override_call_arguments(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            "fstatat",
+            ("AT_SYMLINK_NOFOLLOW",),
+            label,
+        )
+        require_unique_function_call_arguments(
+            combined_platform,
+            "make_platform_durable_file_adapter",
+            "open",
+            ("O_DIRECTORY",),
+            label,
+        )
+        require_each_override_fail_closed_checks(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            ("fstat", "fstatat", "S_ISREG", "st_nlink", "st_dev", "st_ino"),
+            f"{label} stable lock",
+        )
+        require_each_override_ordered_calls(
+            combined_platform,
+            "DurableFileAdapter",
+            "lock_authority",
+            ("lock_file_retrying_interrupts", "fstat", "fstatat"),
+            f"{label} stable lock",
+        )
+        for entry in (
+            "read_root",
+            "read_journal",
+            "create_journal",
+            "append_journal",
+            "truncate_journal",
+            "replace_journal",
+            "replace_root",
+        ):
+            require_each_override_call_arguments(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "openat",
+                ("O_CLOEXEC", "O_NOFOLLOW"),
+                f"{label} fixed-child open",
+            )
+            require_each_override_call(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "fstat",
+                f"{label} fixed-child open",
+            )
+            require_each_override_pattern(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                r"\bS_ISREG\s*\(",
+                f"{label} fixed-child open",
+            )
+            require_each_override_fail_closed_checks(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                ("fstat", "S_ISREG"),
+                f"{label} fixed-child open",
+            )
+        for entry in ("preflight_capabilities", "inspect_fixed_namespace"):
+            require_each_override_call_arguments(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "fstatat",
+                ("AT_SYMLINK_NOFOLLOW",),
+                f"{label} fixed-child preflight",
+            )
+            require_each_override_pattern(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                r"\bS_ISREG\s*\(",
+                f"{label} fixed-child preflight",
+            )
+            require_each_override_fail_closed_checks(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                ("fstatat", "S_ISREG"),
+                f"{label} fixed-child preflight",
+            )
+    require_each_override_call_arguments(
+        f"{common}\n{macos}",
+        "DurableFileChannel",
+        "flush",
+        "fcntl",
+        ("F_FULLFSYNC",),
+        "macOS durable adapter",
+    )
+    combined_windows = f"{common}\n{windows}"
+    require_windows_composite_identity(combined_windows)
+    require_each_override_call_arguments(
+        combined_windows,
+        "DurableFileAdapter",
+        "lock_authority",
+        "CreateFileW",
+        (
+            "FILE_SHARE_READ",
+            "FILE_SHARE_WRITE",
+            "OPEN_ALWAYS",
+            "FILE_FLAG_OPEN_REPARSE_POINT",
+        ),
+        "Windows durable adapter",
+    )
+    require_each_override_call_arguments(
+        combined_windows,
+        "DurableFileAdapter",
+        "preflight_capabilities",
+        "MoveFileExW",
+        ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
+        "Windows durable adapter capability probe",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableFileAdapter",
+        "preflight_capabilities",
+        "MoveFileExW",
+        "Windows durable adapter capability probe",
+    )
+    require_each_override_call_arguments(
+        combined_windows,
+        "DurableFileAdapter",
+        "lock_authority",
+        "LockFileEx",
+        ("LOCKFILE_EXCLUSIVE_LOCK", "MAXDWORD", "MAXDWORD"),
+        "Windows durable adapter",
+    )
+    require_each_override_pattern(
+        combined_windows,
+        "DurableFileAdapter",
+        "lock_authority",
+        r"\bOVERLAPPED\s+\w+\s*(?:\{\s*\}|=\s*\{\s*\})",
+        "Windows zeroed lock OVERLAPPED",
+    )
+    require_windows_lock_overlapped_binding(combined_windows)
+    require_each_override_minimum_call_argument(
+        combined_windows,
+        "DurableFileAdapter",
+        "lock_authority",
+        "GetFileInformationByHandleEx",
+        "FileIdInfo",
+        2,
+        "Windows stable lock identity",
+    )
+    require_each_override_fail_closed_checks(
+        combined_windows,
+        "DurableFileAdapter",
+        "lock_authority",
+        (
+            "LockFileEx",
+            "VolumeSerialNumber",
+            "FileId",
+            "NumberOfLinks",
+        ),
+        "Windows durable adapter lock",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableFileAdapter",
+        "lock_authority",
+        "LockFileEx",
+        "Windows durable adapter lock",
+    )
+    require_windows_unlock_result_mapping(combined_windows)
+    require_each_override_ordered_calls(
+        combined_windows,
+        "DurableFileAdapter",
+        "unlock_authority",
+        ("UnlockFileEx", "CloseHandle"),
+        "Windows durable adapter unlock",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableFileAdapter",
+        "unlock_authority",
+        "UnlockFileEx",
+        "Windows durable adapter unlock",
+    )
+    for entry in (
+        "lock_authority",
+        "preflight_capabilities",
+        "inspect_fixed_namespace",
+        "read_root",
+        "read_journal",
+        "create_journal",
+        "append_journal",
+        "truncate_journal",
+        "replace_journal",
+        "replace_root",
+    ):
+        require_each_override_call_arguments(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            "CreateFileW",
+            ("FILE_FLAG_OPEN_REPARSE_POINT",),
+            "Windows fixed-child open",
+        )
+        require_each_override_call_arguments(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            "GetFileInformationByHandleEx",
+            ("FileAttributeTagInfo",),
+            "Windows fixed-child open",
+        )
+        require_each_override_pattern(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            r"\bFILE_ATTRIBUTE_REPARSE_POINT\b",
+            "Windows fixed-child open",
+        )
+        require_each_override_fail_closed_checks(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            (
+                "GetFileInformationByHandleEx",
+                "FILE_ATTRIBUTE_REPARSE_POINT",
+                "FILE_ATTRIBUTE_DIRECTORY",
+            ),
+            "Windows fixed-child open",
+        )
+    for entry in ("replace_journal", "replace_root"):
+        require_each_override_call_arguments(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            "MoveFileExW",
+            ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
+            "Windows durable adapter",
+        )
+        require_each_override_ordered_calls(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            (
+                "write_flush_close",
+                "MoveFileExW",
+            ),
+            "Windows durable adapter",
+        )
+        require_each_override_call_exactly_once(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            "MoveFileExW",
+            "Windows durable adapter",
+        )
+    for entry, required_calls in (
+        ("lock_authority", ("openat", "fstat", "fstatat")),
+        ("authority_identity", ("fstat",)),
+        ("append_journal", ("openat",)),
+        ("replace_journal", ("renameat",)),
+        ("replace_root", ("renameat",)),
+    ):
+        for required_call in required_calls:
+            require_each_override_call(
+                f"{common}\n{posix}",
+                "DurableFileAdapter",
+                entry,
+                required_call,
+                "POSIX durable adapter",
+            )
+            require_each_override_call(
+                f"{common}\n{macos}",
+                "DurableFileAdapter",
+                entry,
+                required_call,
+                "macOS durable adapter",
+            )
+    for platform_source, label, flush_call in (
+        (posix, "POSIX durable adapter", "fsync"),
+        (macos, "macOS durable adapter", "fcntl"),
+    ):
+        combined_platform = f"{common}\n{platform_source}"
+        require_each_override_write_count_mapping(combined_platform, "posix", label)
+        require_each_override_read_count_mapping(combined_platform, "posix", label)
+        require_each_override_retryable_result_mapping(
+            combined_platform,
+            "DurableFileChannel",
+            "flush",
+            flush_call,
+            "EINTR",
+            label,
+        )
+        require_each_override_retryable_result_mapping(
+            combined_platform,
+            "DurableFileChannel",
+            "truncate",
+            "ftruncate",
+            "EINTR",
+            label,
+        )
+        require_each_override_close_result_mapping(combined_platform, "close", label)
+        require_each_override_close_result_mapping(
+            combined_platform, "close", label, base="DurableReadChannel"
+        )
+        for entry, required_call in (
+            ("write_some", "write"),
+            ("flush", flush_call),
+            ("truncate", "ftruncate"),
+        ):
+            require_each_override_call(
+                combined_platform,
+                "DurableFileChannel",
+                entry,
+                required_call,
+                label,
+            )
+            require_each_override_call_exactly_once(
+                combined_platform,
+                "DurableFileChannel",
+                entry,
+                required_call,
+                label,
+            )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileChannel",
+            "close",
+            "close",
+            label,
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableReadChannel",
+            "read_some",
+            "read",
+            label,
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableReadChannel",
+            "close",
+            "close",
+            label,
+        )
+        require_each_override_call_exactly_once(
+            combined_platform,
+            "DurableFileAdapter",
+            "unlock_authority",
+            "close",
+            label,
+        )
+        require_each_override_omits_calls(
+            combined_platform,
+            "DurableFileAdapter",
+            "replace_journal",
+            ("ftruncate", "truncate_retrying_interrupts"),
+            label,
+        )
+        require_each_override_omits_calls(
+            combined_platform,
+            "DurableFileAdapter",
+            "truncate_journal",
+            ("renameat",),
+            label,
+        )
+        for entry in ("replace_journal", "replace_root"):
+            require_each_override_directory_sync_binding(
+                combined_platform,
+                entry,
+                f"{label} parent namespace durability",
+            )
+            require_each_override_result_call_checked(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "sync_directory_retrying_interrupts",
+                f"{label} parent namespace durability",
+            )
+            require_each_override_fail_closed_checks(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                ("renameat",),
+                f"{label} replacement",
+            )
+            require_each_override_ordered_calls(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                (
+                    "write_flush_close",
+                    "renameat",
+                    "sync_directory_retrying_interrupts",
+                ),
+                f"{label} parent namespace durability",
+            )
+            require_each_override_call_exactly_once(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "renameat",
+                f"{label} parent namespace durability",
+            )
+            require_each_override_call_exactly_once(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                "sync_directory_retrying_interrupts",
+                f"{label} parent namespace durability",
+            )
+            require_each_override_omits_calls(
+                combined_platform,
+                "DurableFileAdapter",
+                entry,
+                ("fsync",),
+                f"{label} parent namespace durability",
+            )
+    for entry, required_calls in (
+        ("lock_authority", ("CreateFileW", "LockFileEx")),
+        ("authority_identity", ("GetFileInformationByHandleEx",)),
+        ("append_journal", ("CreateFileW",)),
+        ("replace_journal", ("MoveFileExW",)),
+        ("replace_root", ("MoveFileExW",)),
+        ("unlock_authority", ("UnlockFileEx",)),
+    ):
+        for required_call in required_calls:
+            require_each_override_call(
+                f"{common}\n{windows}",
+                "DurableFileAdapter",
+                entry,
+                required_call,
+                "Windows durable adapter",
+            )
+    for entry, required_call in (
+        ("write_some", "WriteFile"),
+        ("flush", "FlushFileBuffers"),
+        ("truncate", "SetEndOfFile"),
+    ):
+        require_each_override_call(
+            combined_windows,
+            "DurableFileChannel",
+            entry,
+            required_call,
+            "Windows durable adapter",
+        )
+        require_each_override_call_exactly_once(
+            combined_windows,
+            "DurableFileChannel",
+            entry,
+            required_call,
+            "Windows durable adapter",
+        )
+    require_each_override_write_count_mapping(
+        combined_windows, "windows", "Windows durable adapter"
+    )
+    require_windows_write_override_shape(combined_windows, "Windows durable adapter")
+    indirect_write_mutant = combined_windows.replace(
+        "DWORD written = 0;",
+        """const auto indirect_write = &::WriteFile;
+        DWORD ignored = 0;
+        indirect_write(handle_, bytes.data(), request, &ignored, nullptr);
+        DWORD written = 0;""",
+        1,
+    )
+    if indirect_write_mutant == combined_windows:
+        raise AssertionError("Windows write shape mutant was not materialized")
+    try:
+        require_windows_write_override_shape(indirect_write_mutant, "mutant")
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted an indirect Windows write")
+    namespace_marker = "namespace lemon::residency::detail {"
+    overload_prefix, overload_separator, overload_suffix = combined_windows.rpartition(
+        namespace_marker
+    )
+    if not overload_separator:
+        raise AssertionError("Windows namespace marker is unavailable")
+    overload_mutant = overload_prefix + """
+BOOL WriteFile(HANDLE, const char *, DWORD request,
+               DWORD *written, std::nullptr_t) {
+    *written = request;
+    return TRUE;
+}
+""" + overload_separator + overload_suffix
+    try:
+        require_each_override_write_count_mapping(overload_mutant, "windows", "mutant")
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted a redirected Windows write")
+    success_macro_mutant = combined_windows.replace(
+        "#define NOMINMAX",
+        "#define NOMINMAX\n#define Succeeded Interrupted",
+        1,
+    )
+    if success_macro_mutant == combined_windows:
+        raise AssertionError("Windows success macro mutant was not materialized")
+    try:
+        require_each_override_write_count_mapping(
+            success_macro_mutant, "windows", "mutant"
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted a shadowed Windows success")
+    require_each_override_read_count_mapping(
+        combined_windows, "windows", "Windows durable adapter"
+    )
+    require_each_override_retryable_result_mapping(
+        combined_windows,
+        "DurableFileChannel",
+        "flush",
+        "FlushFileBuffers",
+        "ERROR_OPERATION_ABORTED",
+        "Windows durable adapter",
+    )
+    for primitive in ("SetFilePointerEx", "SetEndOfFile"):
+        require_each_override_retryable_result_mapping(
+            combined_windows,
+            "DurableFileChannel",
+            "truncate",
+            primitive,
+            "ERROR_OPERATION_ABORTED",
+            "Windows durable adapter",
+        )
+    require_each_override_close_result_mapping(
+        combined_windows, "CloseHandle", "Windows durable adapter"
+    )
+    require_each_override_close_result_mapping(
+        combined_windows,
+        "CloseHandle",
+        "Windows durable adapter",
+        base="DurableReadChannel",
+    )
+    require_each_override_call(
+        combined_windows,
+        "DurableFileChannel",
+        "truncate",
+        "SetFilePointerEx",
+        "Windows durable adapter",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableFileChannel",
+        "truncate",
+        "SetFilePointerEx",
+        "Windows durable adapter",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableFileChannel",
+        "close",
+        "CloseHandle",
+        "Windows durable adapter",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableReadChannel",
+        "read_some",
+        "ReadFile",
+        "Windows durable adapter",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableReadChannel",
+        "close",
+        "CloseHandle",
+        "Windows durable adapter",
+    )
+    require_each_override_call_exactly_once(
+        combined_windows,
+        "DurableFileAdapter",
+        "unlock_authority",
+        "CloseHandle",
+        "Windows durable adapter",
+    )
+    require_each_override_omits_calls(
+        combined_windows,
+        "DurableFileAdapter",
+        "replace_journal",
+        (
+            "SetFilePointerEx",
+            "SetEndOfFile",
+            "truncate_retrying_interrupts",
+        ),
+        "Windows durable adapter",
+    )
+    for entry in ("replace_journal", "replace_root"):
+        require_each_override_fail_closed_checks(
+            combined_windows,
+            "DurableFileAdapter",
+            entry,
+            ("MoveFileExW",),
+            "Windows durable adapter replacement",
+        )
+    require_each_override_omits_calls(
+        combined_windows,
+        "DurableFileAdapter",
+        "truncate_journal",
+        ("MoveFileExW",),
+        "Windows durable adapter",
+    )
+
+    narration = """
+// fsync renameat flock F_FULLFSYNC MoveFileExW FlushFileBuffers
+const char *claims = "openat LockFileEx MOVEFILE_WRITE_THROUGH";
+"""
+    if any(
+        token in strip_cpp_comments_and_literals(narration)
+        for token in ("fsync", "MoveFileExW", "LockFileEx", "F_FULLFSYNC")
+    ):
+        raise AssertionError("source-shape scanner accepted narrated platform tokens")
+    spliced_narration = "// narrated fsync \\\nMoveFileExW LockFileEx F_FULLFSYNC\n"
+    if any(
+        token in strip_cpp_comments_and_literals(spliced_narration)
+        for token in ("fsync", "MoveFileExW", "LockFileEx", "F_FULLFSYNC")
+    ):
+        raise AssertionError("source scanner ignored C++ line splicing")
+    try:
+        require_call_expression(
+            "DurableFileResult write_all(Channel &, Bytes) { return {}; }",
+            "write_all",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("shared-loop scanner accepted a dead definition")
+    inactive_mutant = """
+#if 0
+write_all(channel, bytes);
+openat(directory, name, O_APPEND | O_CLOEXEC | O_NOFOLLOW);
+#endif
+"""
+    inactive_code = strip_cpp_comments_and_literals(inactive_mutant)
+    if "write_all" in inactive_code or "openat" in inactive_code:
+        raise AssertionError("source scanner accepted inactive preprocessor code")
+    wrong_posix_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void append_journal() override { openat(directory, name, O_RDONLY); }
+};
+void append_journal(int) {
+    openat(directory, name, O_APPEND | O_CLOEXEC | O_NOFOLLOW);
+}
+"""
+    try:
+        require_each_override_call_arguments(
+            wrong_posix_mutant,
+            "DurableFileAdapter",
+            "append_journal",
+            "openat",
+            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted dead POSIX flags")
+    unsafe_posix_child_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void read_root() override {
+        openat(directory, name, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    }
+};
+void dead_safety_check() {
+    fstat(file, &metadata);
+    if (!S_ISREG(metadata.st_mode)) { refuse(); }
+}
+"""
+    for probe in (
+        lambda: require_each_override_call(
+            unsafe_posix_child_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            "fstat",
+            "mutant",
+        ),
+        lambda: require_each_override_pattern(
+            unsafe_posix_child_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            r"\bS_ISREG\s*\(",
+            "mutant",
+        ),
+    ):
+        try:
+            probe()
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted a dead POSIX safety check")
+    ignored_posix_validation_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void read_root() override {
+        openat(directory, name, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+        fstat(file, &metadata);
+        (void)S_ISREG(metadata.st_mode);
+    }
+};
+"""
+    try:
+        require_each_override_fail_closed_checks(
+            ignored_posix_validation_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            ("fstat", "S_ISREG"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted ignored POSIX validation")
+    inverted_posix_validation_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void read_root() override {
+        if (fstat(file, &metadata) == 0) { return Succeeded; }
+        if (S_ISREG(metadata.st_mode)) { return Succeeded; }
+        return FailedBeforeEffect;
+    }
+};
+"""
+    try:
+        require_each_override_fail_closed_checks(
+            inverted_posix_validation_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            ("fstat", "S_ISREG"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted inverted POSIX validation")
+    transitive_overload_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void append_journal() override { do_append(0); }
+};
+void do_append(int) { openat(directory, name, O_RDONLY); }
+void do_append() {
+    openat(directory, name, O_APPEND | O_CLOEXEC | O_NOFOLLOW);
+}
+"""
+    try:
+        require_each_override_call_arguments(
+            transitive_overload_mutant,
+            "DurableFileAdapter",
+            "append_journal",
+            "openat",
+            ("O_APPEND", "O_CLOEXEC", "O_NOFOLLOW"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner unioned transitive overloads")
+    retrying_lock_control = """
+class LockCall final : public DurableInterruptibleCall {
+public:
+    explicit LockCall(int lock_fd) : lock_fd_(lock_fd) {}
+    DurableFileResult attempt() override {
+        if (flock(lock_fd_, LOCK_EX) != 0) {
+            if (errno == EINTR) { return Interrupted; }
+            return FailedBeforeEffect;
+        }
+        return Succeeded;
+    }
+private:
+    int lock_fd_;
+};
+DurableFileResult lock_file_retrying_interrupts(int lock_fd) {
+    LockCall call(lock_fd);
+    return retry_interrupted(call);
+}
+"""
+    require_retrying_posix_flock(
+        retrying_lock_control,
+        "lock_file_retrying_interrupts",
+        "LOCK_EX",
+        "control",
+    )
+    unrelated_lock_retry_mutant = """
+class UnrelatedCall final : public DurableInterruptibleCall {
+public:
+    DurableFileResult attempt() override { return FailedBeforeEffect; }
+};
+DurableFileResult lock_file_retrying_interrupts(int lock_fd) {
+    flock(lock_fd, LOCK_EX);
+    UnrelatedCall call;
+    return retry_interrupted(call);
+}
+"""
+    try:
+        require_retrying_posix_flock(
+            unrelated_lock_retry_mutant,
+            "lock_file_retrying_interrupts",
+            "LOCK_EX",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted unrelated flock retry")
+    ignored_posix_lock_mutants = (
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult lock_authority() override {
+        lock_file_retrying_interrupts(lock_fd);
+        return Succeeded;
+    }
+};
+""",
+            "lock_authority",
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult unlock_authority() override {
+        unlock_file_retrying_interrupts(lock_fd);
+        close(lock_fd);
+        return Succeeded;
+    }
+};
+""",
+            "unlock_authority",
+        ),
+    )
+    for mutant, entry in ignored_posix_lock_mutants:
+        try:
+            if entry == "lock_authority":
+                require_each_override_result_call_checked(
+                    mutant,
+                    "DurableFileAdapter",
+                    entry,
+                    "lock_file_retrying_interrupts",
+                    "mutant",
+                )
+            else:
+                require_posix_unlock_result_mapping(mutant, "mutant")
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted ignored POSIX lock result")
+    lock_identity_mutants = (
+        """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult lock_authority() override {
+        lock_file_retrying_interrupts(lock_fd);
+        if (fstat(lock_fd, &opened) != 0) { return FailedBeforeEffect; }
+        if (fstatat(directory, lock_name, &current,
+                    AT_SYMLINK_NOFOLLOW) != 0) { return FailedBeforeEffect; }
+        if (!S_ISREG(current.st_mode)) { return FailedBeforeEffect; }
+        return Succeeded;
+    }
+};
+""",
+        """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult lock_authority() override {
+        lock_file_retrying_interrupts(lock_fd);
+        if (fstat(lock_fd, &opened) != 0) { return FailedBeforeEffect; }
+        if (fstatat(directory, lock_name, &current,
+                    AT_SYMLINK_NOFOLLOW) != 0) { return FailedBeforeEffect; }
+        if (!S_ISREG(current.st_mode)) { return FailedBeforeEffect; }
+        if (current.st_nlink == 0 || current.st_dev != opened.st_dev) {
+            return FailedBeforeEffect;
+        }
+        return Succeeded;
+    }
+};
+""",
+    )
+    for mutant in lock_identity_mutants:
+        try:
+            require_each_override_fail_closed_checks(
+                mutant,
+                "DurableFileAdapter",
+                "lock_authority",
+                ("fstat", "fstatat", "S_ISREG", "st_nlink", "st_dev", "st_ino"),
+                "mutant",
+            )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted split stable lock")
+    wrong_windows_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void lock_authority() override {
+        OVERLAPPED live;
+        CreateFileW(path, GENERIC_WRITE, FILE_SHARE_DELETE, nullptr,
+                    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        LockFileEx(handle, 0, 0, 1, 1, &live);
+    }
+};
+void lock_authority(int) {
+    OVERLAPPED unused{};
+    CreateFileW(path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
+               &unused);
+}
+"""
+    for probe in (
+        lambda: require_each_override_call_arguments(
+            wrong_windows_mutant,
+            "DurableFileAdapter",
+            "lock_authority",
+            "CreateFileW",
+            (
+                "FILE_SHARE_READ",
+                "FILE_SHARE_WRITE",
+                "OPEN_ALWAYS",
+                "FILE_FLAG_OPEN_REPARSE_POINT",
+            ),
+            "mutant",
+        ),
+        lambda: require_each_override_call_arguments(
+            wrong_windows_mutant,
+            "DurableFileAdapter",
+            "lock_authority",
+            "LockFileEx",
+            ("LOCKFILE_EXCLUSIVE_LOCK", "MAXDWORD", "MAXDWORD"),
+            "mutant",
+        ),
+        lambda: require_each_override_pattern(
+            wrong_windows_mutant,
+            "DurableFileAdapter",
+            "lock_authority",
+            r"\bOVERLAPPED\s+\w+\s*(?:\{\s*\}|=\s*\{\s*\})",
+            "mutant",
+        ),
+        lambda: require_windows_lock_overlapped_binding(wrong_windows_mutant),
+    ):
+        try:
+            probe()
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted dead Windows flags")
+    ignored_windows_lock_mutants = (
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult lock_authority() override {
+        OVERLAPPED lock_overlapped{};
+        LockFileEx(lock, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
+                   &lock_overlapped);
+        return Succeeded;
+    }
+};
+""",
+            "lock_authority",
+            ("LockFileEx",),
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult unlock_authority() override {
+        UnlockFileEx(lock, 0, MAXDWORD, MAXDWORD, &lock_overlapped);
+        CloseHandle(lock);
+        return Succeeded;
+    }
+};
+""",
+            "unlock_authority",
+            ("UnlockFileEx", "CloseHandle"),
+        ),
+    )
+    for mutant, entry, predicates in ignored_windows_lock_mutants:
+        try:
+            if entry == "unlock_authority":
+                require_windows_unlock_result_mapping(mutant)
+            else:
+                require_each_override_fail_closed_checks(
+                    mutant,
+                    "DurableFileAdapter",
+                    entry,
+                    predicates,
+                    "mutant",
+                )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted ignored Windows lock result")
+    missing_windows_identity_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableIdentityResult authority_identity() override {
+        FILE_ID_INFO directory_identity{};
+        GetFileInformationByHandleEx(directory, FileIdInfo,
+                                     &directory_identity,
+                                     sizeof(directory_identity));
+        return make_identity(directory_identity);
+    }
+};
+"""
+    try:
+        require_windows_composite_identity(missing_windows_identity_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted incomplete Windows identity")
+    missing_windows_lock_comparison_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult lock_authority() override {
+        if (!LockFileEx(lock, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD,
+                        &lock_overlapped)) { return FailedBeforeEffect; }
+        if (!GetFileInformationByHandleEx(lock, FileIdInfo, &opened,
+                                          sizeof(opened))) {
+            return FailedBeforeEffect;
+        }
+        if (!GetFileInformationByHandleEx(current, FileIdInfo, &current_info,
+                                          sizeof(current_info))) {
+            return FailedBeforeEffect;
+        }
+        return Succeeded;
+    }
+};
+"""
+    try:
+        require_each_override_fail_closed_checks(
+            missing_windows_lock_comparison_mutant,
+            "DurableFileAdapter",
+            "lock_authority",
+            ("VolumeSerialNumber", "FileId", "NumberOfLinks"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted stale Windows lock identity")
+    unsafe_windows_child_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void read_root() override {
+        CreateFileW(path, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                    FILE_ATTRIBUTE_NORMAL, nullptr);
+    }
+};
+void dead_safety_check() {
+    CreateFileW(path, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    FILE_ATTRIBUTE_TAG_INFO info{};
+    GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info,
+                                 sizeof(info));
+    if (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) { refuse(); }
+}
+"""
+    for probe in (
+        lambda: require_each_override_call_arguments(
+            unsafe_windows_child_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            "CreateFileW",
+            ("FILE_FLAG_OPEN_REPARSE_POINT",),
+            "mutant",
+        ),
+        lambda: require_each_override_call_arguments(
+            unsafe_windows_child_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            "GetFileInformationByHandleEx",
+            ("FileAttributeTagInfo",),
+            "mutant",
+        ),
+        lambda: require_each_override_pattern(
+            unsafe_windows_child_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            r"\bFILE_ATTRIBUTE_REPARSE_POINT\b",
+            "mutant",
+        ),
+    ):
+        try:
+            probe()
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted a dead Windows safety check")
+    ignored_windows_validation_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void read_root() override {
+        CreateFileW(path, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                    FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+        FILE_ATTRIBUTE_TAG_INFO info{};
+        GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info,
+                                     sizeof(info));
+        (void)(info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT);
+        (void)(info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+    }
+};
+"""
+    try:
+        require_each_override_fail_closed_checks(
+            ignored_windows_validation_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            (
+                "GetFileInformationByHandleEx",
+                "FILE_ATTRIBUTE_REPARSE_POINT",
+                "FILE_ATTRIBUTE_DIRECTORY",
+            ),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted ignored Windows validation")
+    inverted_windows_validation_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void read_root() override {
+        if (GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info,
+                                         sizeof(info))) {
+            return Succeeded;
+        }
+        if (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+            return Succeeded;
+        }
+        if (info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            return Succeeded;
+        }
+        return FailedBeforeEffect;
+    }
+};
+"""
+    try:
+        require_each_override_fail_closed_checks(
+            inverted_windows_validation_mutant,
+            "DurableFileAdapter",
+            "read_root",
+            (
+                "GetFileInformationByHandleEx",
+                "FILE_ATTRIBUTE_REPARSE_POINT",
+                "FILE_ATTRIBUTE_DIRECTORY",
+            ),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted inverted Windows validation")
+    wrong_replace_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void replace_root() override {
+        MoveFileExW(stage, root, MOVEFILE_COPY_ALLOWED);
+    }
+};
+void replace_root(int) {
+    MoveFileExW(stage, root,
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+}
+"""
+    try:
+        require_each_override_call_arguments(
+            wrong_replace_mutant,
+            "DurableFileAdapter",
+            "replace_root",
+            "MoveFileExW",
+            ("MOVEFILE_REPLACE_EXISTING", "MOVEFILE_WRITE_THROUGH"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted dead replacement flags")
+    in_place_compaction_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void replace_journal() override {
+        ftruncate(journal, exact_size);
+        renameat(directory, harmless, directory, harmless);
+    }
+};
+"""
+    try:
+        require_each_override_omits_calls(
+            in_place_compaction_mutant,
+            "DurableFileAdapter",
+            "replace_journal",
+            ("ftruncate", "truncate_retrying_interrupts"),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted in-place compaction")
+    replacement_tail_repair_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void truncate_journal() override {
+        MoveFileExW(stage, journal,
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+    }
+};
+"""
+    try:
+        require_each_override_omits_calls(
+            replacement_tail_repair_mutant,
+            "DurableFileAdapter",
+            "truncate_journal",
+            ("MoveFileExW",),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted replacement tail repair")
+    ordering_mutants = (
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void append_journal() override {
+        flush_retrying_interrupts(channel);
+        write_all(channel, bytes);
+        close_once(channel);
+    }
+};
+""",
+            "append_journal",
+            ("write_all", "flush_retrying_interrupts", "close_once"),
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void replace_root() override {
+        renameat(directory, stage, directory, root);
+        write_all(channel, bytes);
+        flush_retrying_interrupts(channel);
+        close_once(channel);
+        fsync(directory);
+    }
+};
+""",
+            "replace_root",
+            (
+                "write_all",
+                "flush_retrying_interrupts",
+                "close_once",
+                "renameat",
+                "sync_directory_retrying_interrupts",
+            ),
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void truncate_journal() override {
+        flush_retrying_interrupts(channel);
+        truncate_retrying_interrupts(channel, boundary);
+        close_once(channel);
+    }
+};
+""",
+            "truncate_journal",
+            (
+                "truncate_retrying_interrupts",
+                "flush_retrying_interrupts",
+                "close_once",
+            ),
+        ),
+    )
+    for mutant, entry, calls in ordering_mutants:
+        try:
+            require_each_override_ordered_calls(
+                mutant,
+                "DurableFileAdapter",
+                entry,
+                calls,
+                "mutant",
+            )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted unsafe durability order")
+    duplicate_mutation_mutants = (
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void replace_root() override {
+        renameat(directory, stage, directory, root);
+        write_all(channel, bytes);
+        flush_retrying_interrupts(channel);
+        close_once(channel);
+        renameat(directory, stage, directory, root);
+        sync_directory_retrying_interrupts(directory);
+    }
+};
+""",
+            "replace_root",
+            "renameat",
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void truncate_journal() override {
+        truncate_retrying_interrupts(channel, boundary);
+        truncate_retrying_interrupts(channel, boundary);
+        flush_retrying_interrupts(channel);
+        close_once(channel);
+    }
+};
+""",
+            "truncate_journal",
+            "truncate_retrying_interrupts",
+        ),
+    )
+    for mutant, entry, call in duplicate_mutation_mutants:
+        try:
+            require_each_override_call_exactly_once(
+                mutant,
+                "DurableFileAdapter",
+                entry,
+                call,
+                "mutant",
+            )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted duplicate mutation")
+    wrong_macos_mutant = """
+class LiveChannel final : public DurableFileChannel {
+public:
+    void flush() override { fsync(file); }
+};
+void flush(int) { fcntl(file, F_FULLFSYNC); }
+"""
+    try:
+        require_each_override_call_arguments(
+            wrong_macos_mutant,
+            "DurableFileChannel",
+            "flush",
+            "fcntl",
+            ("F_FULLFSYNC",),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted dead macOS persistence")
+    missing_linux_flush_mutant = """
+class LiveChannel final : public DurableFileChannel {
+public:
+    void flush() override { return_success(); }
+};
+void unused_flush() { fsync(file); }
+"""
+    try:
+        require_each_override_call(
+            missing_linux_flush_mutant,
+            "DurableFileChannel",
+            "flush",
+            "fsync",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted a non-durable Linux flush")
+    native_read_controls = (
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(max_bytes, '\0');
+        const auto count = read(file, buffer.data(), max_bytes);
+        if (count < 0) {
+            if (errno == EINTR) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), count), count == 0};
+    }
+};
+""",
+            "posix",
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const auto request = std::min(max_bytes, std::size_t(MAXDWORD));
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0};
+    }
+};
+""",
+            "windows",
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const DWORD request = static_cast<DWORD>(
+            std::min(max_bytes, std::size_t(MAXDWORD)));
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0};
+    }
+};
+""",
+            "windows",
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const DWORD request = static_cast<DWORD>(
+            std::min(std::size_t(MAXDWORD), max_bytes));
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0};
+    }
+};
+""",
+            "windows",
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const std::uint32_t request = static_cast<std::uint32_t>(std::min(
+            max_bytes, std::numeric_limits<std::uint32_t>::max()));
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0};
+    }
+};
+""",
+            "windows",
+        ),
+    )
+    for control, platform in native_read_controls:
+        require_each_override_read_count_mapping(control, platform, "control")
+
+    unsafe_narrowed_read_requests = (
+        "static_cast<DWORD>(max_bytes)",
+        "std::min(static_cast<DWORD>(max_bytes), MAXDWORD)",
+        (
+            "static_cast<DWORD>(std::min("
+            "max_bytes, std::numeric_limits<std::size_t>::max()))"
+        ),
+        "static_cast<DWORD>(std::min(max_bytes, std::size_t(MAXDWORD) + 1))",
+        "static_cast<DWORD>(std::min(max_bytes, 0x100000000ULL))",
+    )
+    for request_expression in unsafe_narrowed_read_requests:
+        narrowed_read_mutant = f"""
+class LiveReadChannel final : public DurableReadChannel {{
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {{
+        const DWORD request = {request_expression};
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {{
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }}
+        return {{Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0}};
+    }}
+}};
+"""
+        try:
+            require_each_override_read_count_mapping(
+                narrowed_read_mutant, "windows", "mutant"
+            )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted unsafe narrowed read")
+
+    native_result_mutants = (
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        write(file, bytes.data(), bytes.size());
+        return {Succeeded, bytes.size()};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        read(file, buffer, max_bytes);
+        return {Succeeded, std::string(buffer, max_bytes), false};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(max_bytes * 1000, '\0');
+        const auto count =
+            read(file, buffer.data(), std::min(max_bytes, sizeof(buffer)));
+        if (count < 0) {
+            if (errno == EINTR) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), count), count == 0};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(max_bytes * 1000, '\0');
+        const auto count = read(file, buffer.data(), max_bytes * 1000);
+        if (count < 0) {
+            if (errno == EINTR) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), count), count == 0};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(max_bytes, '\0');
+        const auto count = read(file, buffer.data(), max_bytes);
+        if (count < 0) {
+            if (errno == EINTR) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), count), count < max_bytes};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(max_bytes, '\0');
+        const auto count = read(file, buffer.data(), max_bytes);
+        if (count < 0) {
+            if (errno == EINTR) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), count), true};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(1073741824, '\0');
+        const auto count = read(file, buffer.data(), 1073741824);
+        if (count < 0) {
+            if (errno == EINTR) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), count), count == 0};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "posix", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const auto request = std::min(max_bytes, std::size_t(MAXDWORD));
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count), false};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const auto request = max_bytes * 1000;
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        const auto request = std::min(max_bytes, std::size_t(MAXDWORD));
+        std::string buffer(request, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), request, &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count < request};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult flush() override { fsync(file); return Succeeded; }
+};
+""",
+            lambda source: require_each_override_retryable_result_mapping(
+                source,
+                "DurableFileChannel",
+                "flush",
+                "fsync",
+                "EINTR",
+                "mutant",
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        DWORD read_count = 0;
+        ReadFile(file, buffer, max_bytes, &read_count, nullptr);
+        return {Succeeded, std::string(buffer, max_bytes), false};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveReadChannel final : public DurableReadChannel {
+public:
+    DurableReadChunkResult read_some(std::size_t max_bytes) override {
+        std::string buffer(1073741824, '\0');
+        DWORD read_count = 0;
+        if (!ReadFile(file, buffer.data(), 1073741824,
+                      &read_count, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return FailedBeforeEffect;
+        }
+        return {Succeeded, std::string(buffer.data(), read_count),
+                read_count == 0};
+    }
+};
+""",
+            lambda source: require_each_override_read_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult truncate() override {
+        ftruncate(file, boundary);
+        return Succeeded;
+    }
+};
+""",
+            lambda source: require_each_override_retryable_result_mapping(
+                source,
+                "DurableFileChannel",
+                "truncate",
+                "ftruncate",
+                "EINTR",
+                "mutant",
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult close() override { close(file); return Succeeded; }
+};
+""",
+            lambda source: require_each_override_close_result_mapping(
+                source, "close", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult flush() override {
+        fcntl(file, F_FULLFSYNC);
+        return Succeeded;
+    }
+};
+""",
+            lambda source: require_each_override_retryable_result_mapping(
+                source,
+                "DurableFileChannel",
+                "flush",
+                "fcntl",
+                "EINTR",
+                "mutant",
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        ::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr);
+        return {Succeeded, bytes.size()};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        const auto WriteFile = [](auto &&...) { return FALSE; };
+        DWORD written = 0;
+        if (!WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = ::GetLastError();
+            return {::lemon::residency::detail::DurableFileResult{
+                        ::lemon::residency::detail::DurableFileStatus::
+                            EffectMayHaveOccurred,
+                        ::std::to_string(error)},
+                    0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+#define WriteFile(...) FALSE
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = ::GetLastError();
+            return {::lemon::residency::detail::DurableFileResult{
+                        ::lemon::residency::detail::DurableFileStatus::
+                            EffectMayHaveOccurred,
+                        ::std::to_string(error)},
+                    0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+%:define EffectMayHaveOccurred Interrupted
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = ::GetLastError();
+            return {::lemon::residency::detail::DurableFileResult{
+                        ::lemon::residency::detail::DurableFileStatus::
+                            EffectMayHaveOccurred,
+                        ::std::to_string(error)},
+                    0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+struct RetryStatus {
+    inline static constexpr auto EffectMayHaveOccurred =
+        ::lemon::residency::detail::DurableFileStatus::Interrupted;
+};
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        using DurableFileStatus = RetryStatus;
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = ::GetLastError();
+            return {DurableFileResult{
+                        DurableFileStatus::EffectMayHaveOccurred,
+                        std::to_string(error)},
+                    0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = GetLastError();
+            throw error;
+            return {make_windows_result(
+                        DurableFileStatus::EffectMayHaveOccurred, error),
+                    0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr) &&
+            should_report()) {
+            const auto error = GetLastError();
+            return {make_windows_result(EffectMayHaveOccurred, error), 0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = GetLastError();
+            return error == ERROR_OPERATION_ABORTED
+                       ? DurableWriteResult{Interrupted, 0}
+                       : DurableWriteResult{EffectMayHaveOccurred, 0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            const auto error = GetLastError();
+            return (EffectMayHaveOccurred, interrupted_write_failure(error));
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            if (GetLastError() == ERROR_DISK_FULL) {
+                return {EffectMayHaveOccurred, 0};
+            }
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            switch (GetLastError()) {
+            case ERROR_OPERATION_ABORTED:
+                return Interrupted;
+            default:
+                return {EffectMayHaveOccurred, 0};
+            }
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        const auto retry = Interrupted;
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            return retry;
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            return {EffectMayHaveOccurred, 0};
+        }
+        if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            return {FailedBeforeEffect, 0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableWriteResult write_some(std::string_view bytes) override {
+        DWORD written = 0;
+        if (!::WriteFile(file, bytes.data(), bytes.size(), &written, nullptr)) {
+            if (GetLastError() == ERROR_OPERATION_ABORTED) return Interrupted;
+            return {EffectMayHaveOccurred, 0};
+        }
+        return {Succeeded, written};
+    }
+};
+""",
+            lambda source: require_each_override_write_count_mapping(
+                source, "windows", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult flush() override {
+        FlushFileBuffers(file);
+        return Succeeded;
+    }
+};
+""",
+            lambda source: require_each_override_retryable_result_mapping(
+                source,
+                "DurableFileChannel",
+                "flush",
+                "FlushFileBuffers",
+                "ERROR_OPERATION_ABORTED",
+                "mutant",
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult truncate() override {
+        SetFilePointerEx(file, boundary, nullptr, FILE_BEGIN);
+        SetEndOfFile(file);
+        return Succeeded;
+    }
+};
+""",
+            lambda source: require_each_override_retryable_result_mapping(
+                source,
+                "DurableFileChannel",
+                "truncate",
+                "SetEndOfFile",
+                "ERROR_OPERATION_ABORTED",
+                "mutant",
+            ),
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    DurableFileResult close() override { CloseHandle(file); return Succeeded; }
+};
+""",
+            lambda source: require_each_override_close_result_mapping(
+                source, "CloseHandle", "mutant"
+            ),
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult replace_root() override {
+        renameat(directory, stage, directory, root);
+        return Succeeded;
+    }
+};
+""",
+            lambda source: require_each_override_fail_closed_checks(
+                source,
+                "DurableFileAdapter",
+                "replace_root",
+                ("renameat",),
+                "mutant",
+            ),
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult replace_root() override {
+        MoveFileExW(stage, root,
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+        return Succeeded;
+    }
+};
+""",
+            lambda source: require_each_override_fail_closed_checks(
+                source,
+                "DurableFileAdapter",
+                "replace_root",
+                ("MoveFileExW",),
+                "mutant",
+            ),
+        ),
+    )
+    for mutant, probe in native_result_mutants:
+        try:
+            probe(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted ignored native result")
+    transaction_helper_control = """
+DurableFileResult write_flush_close(DurableFileChannel &channel,
+                                    std::string_view bytes) {
+    const auto write_result = write_all(channel, bytes);
+    const auto flush_result = flush_retrying_interrupts(channel);
+    const auto close_result = close_once(channel);
+    if (write_result.effect_may_have_occurred()) {
+        return {DurableFileStatus::EffectMayHaveOccurred, {}};
+    }
+    return combine_results(write_result, flush_result, close_result);
+}
+DurableFileResult truncate_flush_close(DurableFileChannel &channel,
+                                       std::size_t bytes) {
+    const auto truncate_result = truncate_retrying_interrupts(channel, bytes);
+    const auto flush_result = flush_retrying_interrupts(channel);
+    const auto close_result = close_once(channel);
+    if (truncate_result.effect_may_have_occurred()) {
+        return {DurableFileStatus::EffectMayHaveOccurred, {}};
+    }
+    return combine_results(truncate_result, flush_result, close_result);
+}
+"""
+    require_transaction_helper_contract(transaction_helper_control)
+    bounded_read_control = """
+inline constexpr std::size_t durable_read_chunk_bytes = 64 * 1024;
+DurableReadResult read_bounded_close(DurableReadChannel &channel,
+                                     std::size_t max_bytes) {
+    std::string retained;
+    const auto requested = std::min(
+        max_bytes + 1 - retained.size(), durable_read_chunk_bytes);
+    const auto read_result = channel.read_some(requested);
+    const bool interrupted =
+        read_result.result.status == DurableFileStatus::Interrupted;
+    const bool truncated = !read_result.end_of_file;
+    const auto close_result = close_read_once(channel);
+    if (!close_result.succeeded()) {
+        return {close_result, {}, false};
+    }
+    return {read_result.result, read_result.bytes,
+            truncated && !interrupted};
+}
+"""
+    require_bounded_read_helper_contract(bounded_read_control)
+    unbounded_read_mutant = """
+inline constexpr std::size_t durable_read_chunk_bytes = 64 * 1024;
+DurableReadResult read_bounded_close(DurableReadChannel &channel,
+                                     std::size_t max_bytes) {
+    (void)max_bytes;
+    const auto read_result = channel.read_some(SIZE_MAX);
+    const bool interrupted =
+        read_result.result.status == DurableFileStatus::Interrupted;
+    const bool truncated = !read_result.end_of_file;
+    const auto close_result = close_read_once(channel);
+    if (!close_result.succeeded()) {
+        return {close_result, {}, false};
+    }
+    return {read_result.result, read_result.bytes,
+            truncated && !interrupted};
+}
+"""
+    try:
+        require_bounded_read_helper_contract(unbounded_read_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted an unbounded native read")
+    inflated_chunk_mutant = bounded_read_control.replace(
+        "durable_read_chunk_bytes);", "durable_read_chunk_bytes * 2);", 1
+    )
+    try:
+        require_bounded_read_helper_contract(inflated_chunk_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted an inflated read chunk")
+    aggregate_result_control = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult append_journal(std::string_view bytes) override {
+        return write_flush_close(channel, bytes);
+    }
+};
+"""
+    require_each_override_call_result_propagated(
+        aggregate_result_control,
+        "DurableFileAdapter",
+        "append_journal",
+        "write_flush_close",
+        "control",
+    )
+    ignored_transaction_helper_mutant = """
+DurableFileResult write_flush_close(DurableFileChannel &channel,
+                                    std::string_view bytes) {
+    const auto write_result = write_all(channel, bytes);
+    const auto flush_result = flush_retrying_interrupts(channel);
+    const auto close_result = close_once(channel);
+    return succeeded();
+}
+DurableFileResult truncate_flush_close(DurableFileChannel &channel,
+                                       std::size_t bytes) {
+    const auto truncate_result = truncate_retrying_interrupts(channel, bytes);
+    const auto flush_result = flush_retrying_interrupts(channel);
+    const auto close_result = close_once(channel);
+    return succeeded();
+}
+"""
+    try:
+        require_transaction_helper_contract(ignored_transaction_helper_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted ignored transaction results")
+    ignored_aggregate_result_mutants = (
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult append_journal(std::string_view bytes) override {
+        write_flush_close(channel, bytes);
+        return succeeded();
+    }
+};
+""",
+            "append_journal",
+            "write_flush_close",
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult truncate_journal(std::size_t bytes) override {
+        const auto ignored = truncate_flush_close(channel, bytes);
+        return succeeded();
+    }
+};
+""",
+            "truncate_journal",
+            "truncate_flush_close",
+        ),
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableReadResult read_root(std::size_t max_bytes) override {
+        const auto ignored = close_once(channel);
+        return {succeeded(), bytes, false};
+    }
+};
+""",
+            "read_root",
+            "close_once",
+        ),
+    )
+    for mutant, entry, call in ignored_aggregate_result_mutants:
+        try:
+            require_each_override_call_result_propagated(
+                mutant, "DurableFileAdapter", entry, call, "mutant"
+            )
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted ignored aggregate result")
+    missing_namespace_sync_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void replace_journal() override {
+        renameat(directory, stage, directory, journal);
+    }
+};
+void unused_namespace_sync() { fsync(directory); }
+"""
+    try:
+        require_each_override_call(
+            missing_namespace_sync_mutant,
+            "DurableFileAdapter",
+            "replace_journal",
+            "sync_directory_retrying_interrupts",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted an unsynced namespace")
+    retrying_namespace_control = """
+class DirectorySyncCall final : public DurableInterruptibleCall {
+public:
+    explicit DirectorySyncCall(int directory_fd)
+        : directory_fd_(directory_fd) {}
+    DurableFileResult attempt() override {
+        if (fsync(directory_fd_) != 0) {
+            if (errno == EINTR) { return Interrupted; }
+            return FailedBeforeEffect;
+        }
+        return Succeeded;
+    }
+private:
+    int directory_fd_;
+};
+DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
+    DirectorySyncCall call(directory_fd);
+    return retry_interrupted(call);
+}
+"""
+    require_retrying_directory_sync(retrying_namespace_control, "control")
+    invalid_namespace_helpers = (
+        """
+class UnrelatedCall final : public DurableInterruptibleCall {
+public:
+    DurableFileResult attempt() override { return FailedBeforeEffect; }
+};
+DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
+    UnrelatedCall call;
+    retry_interrupted(call);
+    return fsync(directory_fd);
+}
+""",
+        """
+class DirectorySyncCall final : public DurableInterruptibleCall {
+public:
+    explicit DirectorySyncCall(int directory_fd)
+        : directory_fd_(directory_fd) {}
+    DurableFileResult attempt() override {
+        fsync(directory_fd_);
+        return Succeeded;
+    }
+private:
+    int directory_fd_;
+};
+DurableFileResult sync_directory_retrying_interrupts(int directory_fd) {
+    DirectorySyncCall call(directory_fd);
+    return retry_interrupted(call);
+}
+""",
+    )
+    for mutant in invalid_namespace_helpers:
+        try:
+            require_retrying_directory_sync(mutant, "mutant")
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted unsafe directory fsync")
+    wrong_directory_sync_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult replace_root() override {
+        renameat(authority_fd, stage, authority_fd, root);
+        sync_directory_retrying_interrupts(unrelated_fd);
+        return Succeeded;
+    }
+};
+"""
+    try:
+        require_each_override_directory_sync_binding(
+            wrong_directory_sync_mutant, "replace_root", "mutant"
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted the wrong namespace fd")
+    ignored_directory_sync_result_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    DurableFileResult replace_root() override {
+        renameat(authority_fd, stage, authority_fd, root);
+        sync_directory_retrying_interrupts(authority_fd);
+        return Succeeded;
+    }
+};
+"""
+    try:
+        require_each_override_result_call_checked(
+            ignored_directory_sync_result_mutant,
+            "DurableFileAdapter",
+            "replace_root",
+            "sync_directory_retrying_interrupts",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted ignored namespace sync")
+    overlapped_lock_mutant = """
+CreateFileW(path, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+            OPEN_ALWAYS, FILE_FLAG_OVERLAPPED, nullptr);
+"""
+    try:
+        require_absent_tokens(
+            overlapped_lock_mutant,
+            ("FILE_FLAG_OVERLAPPED",),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted an overlapped lock handle")
+    lying_preflight_mutant = """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void preflight_capabilities() override { return_success(); }
+    void replace_root() override {
+        write_all(channel, bytes);
+        flush_retrying_interrupts(channel);
+        truncate_retrying_interrupts(channel, 0);
+        close_once(channel);
+        renameat(directory, stage, directory, root);
+        fsync(directory);
+    }
+};
+"""
+    try:
+        require_each_override_call(
+            lying_preflight_mutant,
+            "DurableFileAdapter",
+            "preflight_capabilities",
+            "write_all",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted a declarative preflight")
+    unrelated_channel_mutant = """
+class LiveChannel final : public DurableFileChannel {
+public:
+    void flush() override { fsync(file); }
+};
+class UnusedChannel final : public DurableFileChannel {
+public:
+    void flush() override { fcntl(file, F_FULLFSYNC); }
+};
+"""
+    try:
+        require_each_override_call_arguments(
+            unrelated_channel_mutant,
+            "DurableFileChannel",
+            "flush",
+            "fcntl",
+            ("F_FULLFSYNC",),
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner borrowed an unrelated channel policy")
+    helper_overload_mutant_header = """
+DurableFileResult write_all(DurableFileChannel &channel,
+                            std::string_view bytes);
+"""
+    helper_overload_mutant_source = """
+DurableFileResult write_all(DurableFileChannel &channel,
+                            std::string_view bytes) { return {}; }
+DurableFileResult write_all(DurableFileChannel &channel,
+                            const char *bytes) { return {}; }
+"""
+    try:
+        require_unique_helper_definition(
+            helper_overload_mutant_header,
+            helper_overload_mutant_source,
+            "write_all",
+            "DurableFileResult write_all(DurableFileChannel &channel, "
+            "std::string_view bytes);",
+            "mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("source scanner accepted an overloaded shared helper")
+    duplicate_close_mutants = (
+        (
+            """
+class LiveAdapter final : public DurableFileAdapter {
+public:
+    void append_journal() override {
+        close_once(channel);
+        close_once(channel);
+    }
+};
+""",
+            "DurableFileAdapter",
+            "append_journal",
+            "close_once",
+        ),
+        (
+            """
+class LiveChannel final : public DurableFileChannel {
+public:
+    void close() override {
+        close(fd);
+        close(fd);
+    }
+};
+""",
+            "DurableFileChannel",
+            "close",
+            "close",
+        ),
+    )
+    for mutant, base, entry, call in duplicate_close_mutants:
+        try:
+            require_each_override_call_exactly_once(mutant, base, entry, call, "mutant")
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted a duplicate close")
+
+
+def strip_cpp_comments_and_literals(source: str) -> str:
+    source = normalize_cpp_line_splices(source)
+    source = strip_inactive_cpp_blocks(source)
+    pattern = re.compile(
+        r"//[^\n]*|/\*.*?\*/|R\"(?P<tag>[^ ()\\\t\r\n]{0,16})\(.*?\)(?P=tag)\"|\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'",
+        re.DOTALL,
+    )
+    return pattern.sub(lambda match: "\n" * match.group(0).count("\n"), source)
+
+
+def normalize_cpp_declaration(declaration: str) -> str:
+    normalized = re.sub(r"\s+", " ", declaration.strip())
+    normalized = re.sub(r"\s*([(),;&=])\s*", r"\1", normalized)
+    return normalized
+
+
+def exactly_macro_guarded(source: str, token: str, macro: str) -> bool:
+    pattern = re.compile(
+        rf"(?m)^\s*#\s*ifdef\s+{re.escape(macro)}\s*$"
+        rf"(?:\s*\n)*\s*{re.escape(token)}\s*$"
+        r"(?:\s*\n)*\s*#\s*endif\s*$"
+    )
+    return pattern.search(source) is not None
+
+
+def exactly_macro_guarded_region(
+    source: str,
+    macro: str,
+    tokens: tuple[str, ...],
+) -> bool:
+    pattern = re.compile(
+        rf"(?ms)^\s*#\s*ifdef\s+{re.escape(macro)}\s*$"
+        r"(?P<body>.*?)"
+        r"^\s*#\s*endif\s*$"
+    )
+    matches = []
+    for match in pattern.finditer(source):
+        body = match.group("body")
+        if re.search(r"(?m)^\s*#\s*(?:if|ifdef|ifndef|else|elif|endif)\b", body):
+            continue
+        if all(token in body for token in tokens):
+            matches.append(match)
+    return len(matches) == 1
+
+
+def require_single_public_section(body: str, label: str) -> None:
+    if len(re.findall(r"\bpublic\s*:", body)) != 1:
+        raise AssertionError(f"{label} has multiple public surfaces")
+    if re.search(r"\bprotected\s*:", body):
+        raise AssertionError(f"{label} exposes a protected construction surface")
+
+
+def private_class_surface(body: str, label: str) -> str:
+    if len(re.findall(r"\bprivate\s*:", body)) != 1:
+        raise AssertionError(f"{label} private construction surface drifted")
+    private = re.search(r"\bprivate\s*:(?P<private>.*)\Z", body, re.DOTALL)
+    if private is None:
+        raise AssertionError(f"{label} private construction surface is unavailable")
+    return private.group("private")
+
+
+def require_private_construction_path(body: str, name: str) -> tuple[str, str]:
+    private = private_class_surface(body, name)
+    constructors = tuple(
+        re.finditer(
+            rf"\bexplicit\s+{re.escape(name)}\s*"
+            r"\((?P<parameters>[^;{}]*)\)\s*(?:noexcept\s*)?;",
+            private,
+        )
+    )
+    if len(constructors) != 1 or constructors[0].group("parameters").strip() in {
+        "",
+        "void",
+    }:
+        raise AssertionError(f"{name} private construction path drifted")
+    member = re.search(
+        r"(?m)^\s*(?!#|friend\b|class\b|struct\b|enum\b|using\b|explicit\b)"
+        r"[^;()]+\s+[A-Za-z_]\w*\s*(?:=[^;]+|\{[^;]*\})?;\s*$",
+        private,
+    )
+    if member is None:
+        raise AssertionError(f"{name} has no private construction state")
+    return private, constructors[0].group(0)
+
+
+def require_published_journal_public_shape(source: str) -> None:
+    match = re.search(
+        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("PublishedJournal public declaration is unavailable")
+    body = match.group("body")
+    require_single_public_section(body, "PublishedJournal")
+    public_match = re.search(
+        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
+        body,
+        re.DOTALL,
+    )
+    if public_match is None:
+        raise AssertionError("PublishedJournal public surface is unavailable")
+    declarations = tuple(
+        normalize_cpp_declaration(declaration + ";")
+        for declaration in public_match.group("public").split(";")
+        if declaration.strip()
+    )
+    expected = tuple(
+        normalize_cpp_declaration(declaration)
+        for declaration in (
+            "PublishedJournal() = delete;",
+            "PublishedJournal(const PublishedJournal &) = delete;",
+            "PublishedJournal &operator=(const PublishedJournal &) = delete;",
+            "PublishedJournal(PublishedJournal &&) noexcept;",
+            "PublishedJournal &operator=(PublishedJournal &&) noexcept;",
+            "~PublishedJournal();",
+            "bool available() const noexcept;",
+            "std::string_view root_bytes() const noexcept;",
+            "std::string_view journal_id() const noexcept;",
+            "std::uint64_t tip_sequence() const noexcept;",
+        )
+    )
+    if declarations != expected:
+        raise AssertionError("PublishedJournal public construction surface drifted")
+    _, private_constructor = require_private_construction_path(body, "PublishedJournal")
+    insertion = match.start("body") + public_match.end("public")
+    extra_constructor_mutant = (
+        source[:insertion] + " PublishedJournal(int); " + source[insertion:]
+    )
+    mutated = re.search(
+        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
+        extra_constructor_mutant,
+        re.DOTALL,
+    )
+    if mutated is None:
+        raise AssertionError("PublishedJournal mutant was unavailable")
+    mutated_public = re.search(
+        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
+        mutated.group("body"),
+        re.DOTALL,
+    )
+    if mutated_public is None:
+        raise AssertionError("PublishedJournal mutant public surface was unavailable")
+    mutated_declarations = tuple(
+        normalize_cpp_declaration(declaration + ";")
+        for declaration in mutated_public.group("public").split(";")
+        if declaration.strip()
+    )
+    if mutated_declarations == expected:
+        raise AssertionError("PublishedJournal audit accepted an extra constructor")
+    try:
+        require_single_public_section(
+            body + "\npublic:\nPublishedJournal(int);\n",
+            "PublishedJournal mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("PublishedJournal audit accepted a second public section")
+
+    missing_private_constructor = source.replace(private_constructor, "", 1)
+    missing_match = re.search(
+        r"class\s+PublishedJournal\s*\{(?P<body>.*?)\n\};",
+        missing_private_constructor,
+        re.DOTALL,
+    )
+    try:
+        require_private_construction_path(
+            missing_match.group("body"), "PublishedJournal"
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("PublishedJournal audit accepted no minting path")
+
+
+def require_durable_journal_public_shape(source: str) -> None:
+    match = re.search(
+        r"class\s+DurableJournal\s*\{(?P<body>.*?)\n\};",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("DurableJournal public declaration is unavailable")
+    require_single_public_section(match.group("body"), "DurableJournal")
+    public_match = re.search(
+        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
+        match.group("body"),
+        re.DOTALL,
+    )
+    if public_match is None:
+        raise AssertionError("DurableJournal public surface is unavailable")
+    declarations = tuple(
+        normalize_cpp_declaration(declaration + ";")
+        for declaration in public_match.group("public").split(";")
+        if declaration.strip()
+    )
+    expected = tuple(
+        normalize_cpp_declaration(declaration)
+        for declaration in (
+            "DurableJournal() = delete;",
+            "DurableJournal(const DurableJournal &) = delete;",
+            "DurableJournal &operator=(const DurableJournal &) = delete;",
+            "DurableJournal(DurableJournal &&) noexcept;",
+            "DurableJournal &operator=(DurableJournal &&) noexcept;",
+            "~DurableJournal();",
+            "static DurableJournal native(std::filesystem::path directory, JournalLimits limits);",
+            "DurableJournalResult create_new(TrustedReplayFloor floor, const ParsedJournalRecord &genesis, const RecoveryOriginVerifier *verifier = nullptr);",
+            "DurableJournalResult recover_existing(TrustedReplayFloor floor, const RecoveryOriginVerifier *verifier = nullptr);",
+            "DurableJournalResult append_and_publish(PublishedJournal &&authority, const ParsedJournalRecord &candidate, const RecoveryOriginVerifier *verifier = nullptr);",
+            "DurableJournalResult compact_physical(PublishedJournal &&authority);",
+            "ExactSchemaExportResult export_exact_schema_candidate(const PublishedJournal &authority, SchemaVersion target, JournalQuiescence quiescence);",
+        )
+    )
+    if declarations != expected:
+        raise AssertionError("DurableJournal public authority surface drifted")
+    private, private_constructor = require_private_construction_path(
+        match.group("body"), "DurableJournal"
+    )
+    if re.findall(r"\bfriend\b[^;]*;", private) != [
+        "friend class detail::DurableJournalTestFactory;"
+    ]:
+        raise AssertionError("DurableJournal has a forgeable friend graph")
+    mint_declarations = tuple(
+        re.finditer(
+            r"\bDurableJournalResult\s+mint_published\s*"
+            r"\((?P<parameters>[^;{}]*)\)\s*;",
+            private,
+        )
+    )
+    if len(mint_declarations) != 1:
+        raise AssertionError("DurableJournal private mint sink drifted")
+    mint_parameters = split_cpp_arguments(mint_declarations[0].group("parameters"))
+    if (
+        len(mint_parameters) != 3
+        or re.search(r"\bJournalHistory\s*&&\s*[A-Za-z_]\w*\b", mint_parameters[0])
+        is None
+        or re.search(
+            r"\bAuthorityRootCandidate\s*(?:&&\s*)?[A-Za-z_]\w*\b",
+            mint_parameters[1],
+        )
+        is None
+        or re.search(r"\b(?:persistence|state)[A-Za-z_]*\b", mint_parameters[2]) is None
+    ):
+        raise AssertionError("DurableJournal private mint sink shape drifted")
+    minting_mutant = source.replace(
+        "~DurableJournal();",
+        "~DurableJournal(); static PublishedJournal from_record(const ParsedJournalRecord &);",
+        1,
+    )
+    if minting_mutant == source:
+        raise AssertionError("DurableJournal minting mutant was unavailable")
+    mutated_match = re.search(
+        r"class\s+DurableJournal\s*\{(?P<body>.*?)\n\};",
+        minting_mutant,
+        re.DOTALL,
+    )
+    mutated_public = re.search(
+        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
+        mutated_match.group("body"),
+        re.DOTALL,
+    )
+    mutated_declarations = tuple(
+        normalize_cpp_declaration(declaration + ";")
+        for declaration in mutated_public.group("public").split(";")
+        if declaration.strip()
+    )
+    if mutated_declarations == expected:
+        raise AssertionError("DurableJournal audit accepted a minting factory")
+    try:
+        require_single_public_section(
+            match.group("body")
+            + "\npublic:\nDurableJournalResult mint(const ParsedJournalRecord &);\n",
+            "DurableJournal mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("DurableJournal audit accepted a second public section")
+
+    missing_private_constructor = source.replace(private_constructor, "", 1)
+    missing_match = re.search(
+        r"class\s+DurableJournal\s*\{(?P<body>.*?)\n\};",
+        missing_private_constructor,
+        re.DOTALL,
+    )
+    try:
+        require_private_construction_path(missing_match.group("body"), "DurableJournal")
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("DurableJournal audit accepted no construction path")
+
+
+def require_trusted_replay_floor_public_shape(source: str) -> None:
+    match = re.search(
+        r"class\s+TrustedReplayFloor\s*\{(?P<body>.*?)\n\};",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("TrustedReplayFloor public declaration is unavailable")
+    require_single_public_section(match.group("body"), "TrustedReplayFloor")
+    public_match = re.search(
+        r"\bpublic\s*:(?P<public>.*?)(?:\bprivate\s*:|\bprotected\s*:)",
+        match.group("body"),
+        re.DOTALL,
+    )
+    if public_match is None:
+        raise AssertionError("TrustedReplayFloor public surface is unavailable")
+    declarations = tuple(
+        normalize_cpp_declaration(declaration + ";")
+        for declaration in public_match.group("public").split(";")
+        if declaration.strip()
+    )
+    expected = tuple(
+        normalize_cpp_declaration(declaration)
+        for declaration in (
+            "TrustedReplayFloor() = delete;",
+            "static TrustedReplayFloor uninitialized();",
+            "static TrustedReplayFloor exact_root(std::string root);",
+        )
+    )
+    if declarations != expected:
+        raise AssertionError("TrustedReplayFloor public construction surface drifted")
+    private, private_constructor = require_private_construction_path(
+        match.group("body"), "TrustedReplayFloor"
+    )
+    friend_declarations = re.findall(r"\bfriend\b[^;]*;", private)
+    if friend_declarations != ["friend class DurableJournal;"]:
+        raise AssertionError("TrustedReplayFloor has a forgeable friend graph")
+    try:
+        require_single_public_section(
+            match.group("body") + "\npublic:\nTrustedReplayFloor(int);\n",
+            "TrustedReplayFloor mutant",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError(
+            "TrustedReplayFloor audit accepted a second public section"
+        )
+
+    missing_private_constructor = source.replace(private_constructor, "", 1)
+    missing_match = re.search(
+        r"class\s+TrustedReplayFloor\s*\{(?P<body>.*?)\n\};",
+        missing_private_constructor,
+        re.DOTALL,
+    )
+    try:
+        require_private_construction_path(
+            missing_match.group("body"), "TrustedReplayFloor"
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("TrustedReplayFloor audit accepted no state constructor")
+
+
+def require_exact_struct_shape(
+    source: str,
+    name: str,
+    expected: tuple[str, ...],
+) -> None:
+    match = re.search(
+        rf"struct\s+{re.escape(name)}\s*\{{(?P<body>.*?)\}}\s*;",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"{name} public declaration is unavailable")
+    declarations = tuple(
+        normalize_cpp_declaration(declaration + ";")
+        for declaration in match.group("body").split(";")
+        if declaration.strip()
+    )
+    normalized_expected = tuple(
+        normalize_cpp_declaration(declaration) for declaration in expected
+    )
+    if declarations != normalized_expected:
+        raise AssertionError(f"{name} public result shape drifted")
+
+
+def require_exact_enum_members(
+    source: str,
+    name: str,
+    expected: tuple[str, ...],
+) -> None:
+    match = re.search(
+        rf"enum\s+class\s+{re.escape(name)}(?:\s*:\s*[^{{]+)?\s*\{{(?P<body>.*?)\}}\s*;",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"{name} public enum is unavailable")
+    members = tuple(
+        re.match(r"\s*([A-Za-z_]\w*)", member).group(1)
+        for member in match.group("body").split(",")
+        if member.strip()
+    )
+    if members != expected:
+        raise AssertionError(f"{name} public outcomes drifted")
+
+
+def strip_cpp_comments_preserve_literals(source: str) -> str:
+    source = normalize_cpp_line_splices(source)
+    source = strip_inactive_cpp_blocks(source)
+    pattern = re.compile(r"//[^\n]*|/\*.*?\*/", re.DOTALL)
+    return pattern.sub(lambda match: "\n" * match.group(0).count("\n"), source)
+
+
+def normalize_cpp_line_splices(source: str) -> str:
+    return re.sub(r"\\\r?\n", "", source)
+
+
+def strip_inactive_cpp_blocks(source: str) -> str:
+    pattern = re.compile(r"(?ms)^\s*#\s*if\s+(?:0|false)\b.*?^\s*#\s*endif\b[^\n]*")
+    previous = None
+    while source != previous:
+        previous = source
+        source = pattern.sub(lambda match: "\n" * match.group(0).count("\n"), source)
+    return source
+
+
+def require_call_argument(source: str, call: str, argument: str, label: str) -> None:
+    pattern = re.compile(
+        rf"\b{re.escape(call)}\s*\([^;]*\b{re.escape(argument)}\b[^;]*\)"
+    )
+    if pattern.search(source) is None:
+        raise AssertionError(f"{label} omitted {call}(...{argument}...)")
+
+
+def require_call_arguments(
+    source: str,
+    call: str,
+    arguments: tuple[str, ...],
+    label: str,
+) -> None:
+    for match in re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", source):
+        call_arguments = match.group("args")
+        search_from = 0
+        for argument in arguments:
+            found_at = call_arguments.find(argument, search_from)
+            if found_at < 0:
+                break
+            search_from = found_at + len(argument)
+        else:
+            return
+    raise AssertionError(f"{label} omitted ordered arguments {arguments}")
+
+
+def require_call_arguments_unordered(
+    source: str,
+    call: str,
+    arguments: tuple[str, ...],
+    label: str,
+) -> None:
+    for match in re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", source):
+        call_arguments = match.group("args")
+        if all(argument in call_arguments for argument in arguments):
+            return
+    raise AssertionError(f"{label} omitted call arguments {arguments}")
+
+
+def require_call_expression(source: str, call: str, label: str) -> None:
+    pattern = re.compile(rf"\b{re.escape(call)}\s*\([^;{{}}]*\)\s*;")
+    if pattern.search(source) is None:
+        raise AssertionError(f"{label} does not call the shared {call} seam")
+
+
+def function_bodies(source: str, function: str) -> list[str]:
+    declaration = re.compile(
+        rf"\b{re.escape(function)}\s*\([^;{{}}]*\)\s*"
+        r"(?:const\s*)?(?:noexcept\s*)?(?:override\s*)?\{"
+    )
+    bodies: list[str] = []
+    for match in declaration.finditer(source):
+        opening = match.end() - 1
+        depth = 1
+        index = opening + 1
+        while index < len(source) and depth:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+            index += 1
+        if depth == 0:
+            bodies.append(source[opening + 1 : index - 1])
+    return bodies
+
+
+def class_blocks(source: str, base: str) -> list[tuple[str, str]]:
+    declaration = re.compile(
+        rf"\bclass\s+(?P<name>[A-Za-z_]\w*)\s*(?:final\s*)?:\s*"
+        rf"public\s+(?:detail\s*::\s*)?{re.escape(base)}\s*\{{"
+    )
+    blocks: list[tuple[str, str]] = []
+    for match in declaration.finditer(source):
+        opening = match.end() - 1
+        depth = 1
+        index = opening + 1
+        while index < len(source) and depth:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+            index += 1
+        if depth == 0:
+            blocks.append((match.group("name"), source[opening + 1 : index - 1]))
+    return blocks
+
+
+def qualified_function_bodies(
+    source: str,
+    class_name: str,
+    function: str,
+) -> list[str]:
+    declaration = re.compile(
+        rf"\b{re.escape(class_name)}\s*::\s*{re.escape(function)}\s*"
+        r"\([^;{}]*\)\s*(?:const\s*)?(?:noexcept\s*)?\{"
+    )
+    bodies: list[str] = []
+    for match in declaration.finditer(source):
+        opening = match.end() - 1
+        depth = 1
+        index = opening + 1
+        while index < len(source) and depth:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+            index += 1
+        if depth == 0:
+            bodies.append(source[opening + 1 : index - 1])
+    return bodies
+
+
+def overriding_method_bodies(source: str, base: str, function: str) -> list[str]:
+    bodies: list[str] = []
+    for class_name, class_body in class_blocks(source, base):
+        declaration = re.compile(
+            rf"\b{re.escape(function)}\s*\([^;{{}}]*\)\s*"
+            r"[^;{}]*\boverride\b[^;{}]*(?P<end>[;{])"
+        )
+        for match in declaration.finditer(class_body):
+            if match.group("end") == "{":
+                opening = match.end() - 1
+                depth = 1
+                index = opening + 1
+                while index < len(class_body) and depth:
+                    if class_body[index] == "{":
+                        depth += 1
+                    elif class_body[index] == "}":
+                        depth -= 1
+                    index += 1
+                if depth == 0:
+                    bodies.append(class_body[opening + 1 : index - 1])
+            else:
+                bodies.extend(qualified_function_bodies(source, class_name, function))
+    return bodies
+
+
+def require_unique_helper_definition(
+    header: str,
+    source: str,
+    function: str,
+    declaration: str,
+    label: str,
+    return_type: str = "DurableFileResult",
+) -> None:
+    header_matches = re.findall(
+        rf"[^;{{}}]*\b{re.escape(function)}\s*\([^;{{}}]*\)\s*;",
+        header,
+    )
+    expected = normalize_cpp_declaration(declaration)
+    if (
+        len(header_matches) != 1
+        or normalize_cpp_declaration(header_matches[0]) != expected
+    ):
+        raise AssertionError(f"{label} helper declaration drifted")
+    bodies = function_bodies(source, function)
+    if len(bodies) != 1:
+        raise AssertionError(f"{label} helper is overloaded or multiply defined")
+    definition = re.compile(
+        rf"\b{re.escape(return_type)}\s+{re.escape(function)}\s*"
+        r"\([^;{}]*\)\s*(?:noexcept\s*)?\{"
+    )
+    if len(definition.findall(source)) != 1:
+        raise AssertionError(f"{label} helper definition signature drifted")
+
+
+def require_transaction_helper_contract(source: str) -> None:
+    for helper, operation in (
+        ("write_flush_close", "write_all"),
+        ("truncate_flush_close", "truncate_retrying_interrupts"),
+    ):
+        bodies = function_bodies(source, helper)
+        if len(bodies) != 1:
+            raise AssertionError(f"durable adapter {helper} definition drifted")
+        body = bodies[0]
+        ordered_calls = (operation, "flush_retrying_interrupts", "close_once")
+        positions: list[int] = []
+        results: list[str] = []
+        for call in ordered_calls:
+            matches = list(
+                re.finditer(
+                    rf"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
+                    rf"(?P<result>[A-Za-z_]\w*)\s*=\s*"
+                    rf"{re.escape(call)}\s*\(",
+                    body,
+                )
+            )
+            if len(matches) != 1:
+                raise AssertionError(
+                    f"durable adapter {helper} does not capture {call} once"
+                )
+            positions.append(matches[0].start())
+            results.append(matches[0].group("result"))
+        if positions != sorted(positions):
+            raise AssertionError(f"durable adapter {helper} operation order drifted")
+        if re.search(r"\breturn\b", body[: positions[-1]]) is not None:
+            raise AssertionError(
+                f"durable adapter {helper} can bypass its checked close"
+            )
+        returned = re.findall(r"\breturn\b(?P<value>[^;]*);", body[positions[-1] :])
+        if not any(all(result in value for result in results) for value in returned):
+            raise AssertionError(
+                f"durable adapter {helper} does not combine every result"
+            )
+        if not any(
+            token in body
+            for token in ("effect_may_have_occurred", "EffectMayHaveOccurred")
+        ):
+            raise AssertionError(
+                f"durable adapter {helper} does not preserve indeterminate effects"
+            )
+
+
+def require_bounded_read_helper_contract(source: str) -> None:
+    if (
+        re.search(
+            r"\binline\s+constexpr\s+std::size_t\s+"
+            r"durable_read_chunk_bytes\s*=\s*64\s*\*\s*1024\s*;",
+            source,
+        )
+        is None
+    ):
+        raise AssertionError("durable bounded-read chunk cap drifted")
+    bodies = function_bodies(source, "read_bounded_close")
+    if len(bodies) != 1:
+        raise AssertionError("durable bounded-read helper definition drifted")
+    body = bodies[0]
+    read = re.search(
+        r"\b(?:const\s+)?(?:auto|DurableReadChunkResult)\s+"
+        r"(?P<result>[A-Za-z_]\w*)\s*=\s*"
+        r"(?:[A-Za-z_]\w*\s*\.\s*)?read_some\s*\(",
+        body,
+    )
+    close = re.search(
+        r"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
+        r"(?P<result>[A-Za-z_]\w*)\s*=\s*close_read_once\s*\(",
+        body,
+    )
+    if read is None or close is None or read.start() >= close.start():
+        raise AssertionError("durable bounded-read helper omits read then close")
+    if (
+        len(re.findall(r"\bread_some\s*\(", body)) != 1
+        or len(re.findall(r"\bclose_read_once\s*\(", body)) != 1
+    ):
+        raise AssertionError("durable bounded-read helper call count drifted")
+    read_arguments = call_argument_lists(body, "read_some")
+    if len(read_arguments) != 1 or len(read_arguments[0]) != 1:
+        raise AssertionError("durable bounded-read request shape drifted")
+    requested = read_arguments[0][0].strip()
+    if (
+        "max_bytes" not in requested
+        and re.search(
+            rf"\b(?:const\s+)?(?:auto|std::size_t)\s+{re.escape(requested)}\s*="
+            r"[^;]*\bmax_bytes\b",
+            body[: read.start()],
+        )
+        is None
+    ):
+        raise AssertionError("durable bounded read is not capped by max_bytes")
+    requested_assignment = re.search(
+        rf"\b(?:const\s+)?(?:auto|std::size_t)\s+{re.escape(requested)}\s*="
+        r"\s*(?P<value>[^;]+);",
+        body[: read.start()],
+        re.DOTALL,
+    )
+    if requested_assignment is None:
+        raise AssertionError("durable bounded-read request is not assigned")
+    minimums = call_argument_lists(requested_assignment.group("value"), "min")
+    if (
+        len(minimums) != 1
+        or len(minimums[0]) != 2
+        or normalized_cpp_expression(minimums[0][1]) != "durable_read_chunk_bytes"
+        or "max_bytes" not in minimums[0][0]
+        or "retained.size()" not in normalized_cpp_expression(minimums[0][0])
+    ):
+        raise AssertionError("durable bounded read omits its fixed chunk cap")
+    if re.search(r"\breturn\b", body[: close.start()]) is not None:
+        raise AssertionError("durable bounded-read helper can bypass close")
+    if not all(
+        token in body
+        for token in ("max_bytes", "end_of_file", "Interrupted", "truncated")
+    ):
+        raise AssertionError("durable bounded-read helper omits bounded EOF flow")
+    close_result = close.group("result")
+    if (
+        not any(
+            close_result in condition
+            and re.search(rf"\breturn\b[^;]*\b{re.escape(close_result)}\b", statement)
+            for condition, statement in fail_closed_if_branches(body[close.start() :])
+        )
+        and re.search(
+            rf"\breturn\b[^;]*\b{re.escape(close_result)}\b[^;]*;",
+            body[close.start() :],
+        )
+        is None
+    ):
+        raise AssertionError("durable bounded-read helper ignores close result")
+
+
+def require_close_read_once_contract(source: str) -> None:
+    bodies = function_bodies(source, "close_read_once")
+    if len(bodies) != 1:
+        raise AssertionError("durable read-close helper definition drifted")
+    body = bodies[0]
+    if (
+        len(re.findall(r"\bclose\s*\(", body)) != 1
+        or re.fullmatch(r"\s*return\s+\w+\s*\.\s*close\s*\(\s*\)\s*;\s*", body) is None
+        or "retry_interrupted" in body
+    ):
+        raise AssertionError("durable read-close helper does not close once")
+
+
+def require_unique_function_call_arguments(
+    source: str,
+    function: str,
+    call: str,
+    arguments: tuple[str, ...],
+    label: str,
+) -> None:
+    bodies = function_bodies(source, function)
+    if len(bodies) != 1:
+        raise AssertionError(f"{label} {function} is overloaded or multiply defined")
+    matches = re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", bodies[0])
+    if not any(
+        all(argument in match.group("args") for argument in arguments)
+        for match in matches
+    ):
+        raise AssertionError(f"{label} {function} omits {call}{arguments}")
+
+
+def require_each_override_call(
+    source: str,
+    base: str,
+    entry: str,
+    required_call: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies or any(
+        re.search(rf"\b{re.escape(required_call)}\s*\(", body) is None
+        for body in bodies
+    ):
+        raise AssertionError(
+            f"{label} {base}::{entry} does not directly call {required_call}"
+        )
+
+
+def require_each_override_call_exactly_once(
+    source: str,
+    base: str,
+    entry: str,
+    required_call: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        count = len(re.findall(rf"\b{re.escape(required_call)}\s*\(", body))
+        if count != 1:
+            raise AssertionError(
+                f"{label} {base}::{entry} calls {required_call} {count} times"
+            )
+
+
+def require_each_override_call_result_propagated(
+    source: str,
+    base: str,
+    entry: str,
+    call: str,
+    label: str,
+    minimum_calls: int = 1,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        calls = list(re.finditer(rf"\b{re.escape(call)}\s*\(", body))
+        if len(calls) < minimum_calls:
+            raise AssertionError(f"{label} {base}::{entry} omits {call}")
+        direct_returns = {
+            match.start("call")
+            for match in re.finditer(
+                rf"\breturn\s+(?P<call>{re.escape(call)})\s*\(", body
+            )
+        }
+        assignments = list(
+            re.finditer(
+                rf"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
+                rf"(?P<result>[A-Za-z_]\w*)\s*=\s*"
+                rf"(?P<call>{re.escape(call)})\s*\(",
+                body,
+            )
+        )
+        assigned_calls = {match.start("call") for match in assignments}
+        if any(
+            call_match.start() not in direct_returns | assigned_calls
+            for call_match in calls
+        ):
+            raise AssertionError(f"{label} {base}::{entry} discards {call}'s result")
+        for assignment in assignments:
+            result = assignment.group("result")
+            suffix = body[assignment.end() :]
+            if re.search(rf"\breturn\s+{re.escape(result)}\s*;", suffix):
+                continue
+            if not any(
+                result in condition
+                and re.search(rf"\breturn\s+{re.escape(result)}\s*;", statement)
+                for condition, statement in fail_closed_if_branches(suffix)
+            ):
+                raise AssertionError(
+                    f"{label} {base}::{entry} does not propagate {call}'s result"
+                )
+
+
+def require_each_override_omits_calls(
+    source: str,
+    base: str,
+    entry: str,
+    forbidden_calls: tuple[str, ...],
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        present = [
+            call
+            for call in forbidden_calls
+            if re.search(rf"\b{re.escape(call)}\s*\(", body)
+        ]
+        if present:
+            raise AssertionError(f"{label} {base}::{entry} uses {present}")
+
+
+def require_each_override_ordered_calls(
+    source: str,
+    base: str,
+    entry: str,
+    calls: tuple[str, ...],
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        search_from = 0
+        for call in calls:
+            match = re.search(rf"\b{re.escape(call)}\s*\(", body[search_from:])
+            if match is None:
+                raise AssertionError(f"{label} {base}::{entry} omits ordered {calls}")
+            search_from += match.end()
+
+
+def require_each_override_call_arguments(
+    source: str,
+    base: str,
+    entry: str,
+    call: str,
+    arguments: tuple[str, ...],
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        matches = re.finditer(rf"\b{re.escape(call)}\s*\((?P<args>[^;]*)\)", body)
+        if not any(
+            all(argument in match.group("args") for argument in arguments)
+            for match in matches
+        ):
+            raise AssertionError(f"{label} {base}::{entry} omits {call}{arguments}")
+
+
+def require_each_override_pattern(
+    source: str,
+    base: str,
+    entry: str,
+    pattern: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies or any(re.search(pattern, body) is None for body in bodies):
+        raise AssertionError(f"{label} {base}::{entry} omits required shape")
+
+
+def matching_delimiter(
+    source: str,
+    opening: int,
+    open_character: str,
+    close_character: str,
+) -> int:
+    depth = 1
+    index = opening + 1
+    while index < len(source) and depth:
+        if source[index] == open_character:
+            depth += 1
+        elif source[index] == close_character:
+            depth -= 1
+        index += 1
+    if depth:
+        raise AssertionError("C++ source has an unbalanced delimiter")
+    return index - 1
+
+
+def fail_closed_if_branches(body: str) -> tuple[tuple[str, str], ...]:
+    branches: list[tuple[str, str]] = []
+    for match in re.finditer(r"\bif\s*\(", body):
+        opening = body.find("(", match.start())
+        closing = matching_delimiter(body, opening, "(", ")")
+        statement_start = closing + 1
+        while statement_start < len(body) and body[statement_start].isspace():
+            statement_start += 1
+        if statement_start == len(body):
+            continue
+        if body[statement_start] == "{":
+            statement_end = matching_delimiter(body, statement_start, "{", "}")
+            statement = body[statement_start + 1 : statement_end]
+        else:
+            statement_end = body.find(";", statement_start)
+            if statement_end < 0:
+                continue
+            statement = body[statement_start : statement_end + 1]
+        if re.search(r"\breturn\b", statement):
+            branches.append((body[opening + 1 : closing], statement))
+    return tuple(branches)
+
+
+def branch_returns_non_success(statement: str) -> bool:
+    returns = re.findall(r"\breturn\b(?P<value>[^;]*);", statement)
+    return bool(returns) and all(
+        "succeeded" not in returned.lower() and "success" not in returned.lower()
+        for returned in returns
+    )
+
+
+def condition_rejects_predicate(condition: str, predicate: str) -> bool:
+    compact = re.sub(r"\s+", "", condition)
+    if predicate not in condition:
+        return False
+    if predicate in (
+        "fstat",
+        "fstatat",
+        "fsync",
+        "fcntl",
+        "ftruncate",
+        "close",
+        "renameat",
+        "flock",
+    ):
+        if re.search(rf"{predicate}\([^;]*\)==(?:0|true)", compact):
+            return False
+        return bool(
+            re.search(
+                rf"(?:!(?:::)?{predicate}\(|{predicate}\([^;]*\)(?:!=0|<0|==-1))",
+                compact,
+            )
+            or re.fullmatch(rf"(?:::)?{predicate}\([^;]*\)", compact)
+        )
+    if predicate == "S_ISREG":
+        return bool(
+            re.search(r"!S_ISREG\(", compact)
+            or re.search(r"S_ISREG\([^;]*\)==(?:0|false)", compact)
+        )
+    if predicate in (
+        "GetFileInformationByHandleEx",
+        "WriteFile",
+        "ReadFile",
+        "LockFileEx",
+        "UnlockFileEx",
+        "FlushFileBuffers",
+        "SetFilePointerEx",
+        "SetEndOfFile",
+        "CloseHandle",
+        "MoveFileExW",
+    ):
+        return bool(
+            re.search(rf"!(?:::)?{predicate}\(", compact)
+            or re.search(rf"{predicate}\([^;]*\)==(?:0|FALSE|false)", compact)
+        )
+    if predicate in ("FILE_ATTRIBUTE_REPARSE_POINT", "FILE_ATTRIBUTE_DIRECTORY"):
+        return not bool(
+            re.search(rf"{predicate}[^;]*(?:==0|==false|==FALSE)", compact)
+            or re.search(rf"!\([^;]*{predicate}", compact)
+        )
+    if predicate == "st_nlink":
+        return bool(re.search(r"st_nlink(?:==0|!=1|<1)", compact))
+    if predicate in ("st_dev", "st_ino"):
+        return "!=" in compact
+    if predicate in ("VolumeSerialNumber", "FileId"):
+        return "!=" in compact or "memcmp(" in compact
+    if predicate == "NumberOfLinks":
+        return bool(re.search(r"NumberOfLinks(?:==0|<1)", compact))
+    return False
+
+
+def require_each_override_fail_closed_checks(
+    source: str,
+    base: str,
+    entry: str,
+    predicates: tuple[str, ...],
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        branches = fail_closed_if_branches(body)
+        missing = [
+            predicate
+            for predicate in predicates
+            if not any(
+                condition_rejects_predicate(condition, predicate)
+                and branch_returns_non_success(statement)
+                for condition, statement in branches
+            )
+        ]
+        if missing:
+            raise AssertionError(
+                f"{label} {base}::{entry} does not fail closed on {missing}"
+            )
+
+
+def require_retrying_directory_sync(source: str, label: str) -> None:
+    helper = "sync_directory_retrying_interrupts"
+    signature = re.compile(
+        rf"\bDurableFileResult\s+{helper}\s*\(\s*int\s+directory_fd\s*\)\s*\{{"
+    )
+    helper_bodies = function_bodies(source, helper)
+    if len(signature.findall(source)) != 1 or len(helper_bodies) != 1:
+        raise AssertionError(f"{label} directory-sync helper shape drifted")
+    helper_body = helper_bodies[0]
+    if len(re.findall(r"\bretry_interrupted\s*\(", helper_body)) != 1:
+        raise AssertionError(f"{label} directory sync does not retry exactly once")
+
+    bindings = 0
+    for class_name, class_body in class_blocks(source, "DurableInterruptibleCall"):
+        attempts = function_bodies(class_body, "attempt")
+        if len(attempts) != 1:
+            continue
+        attempt = attempts[0]
+        if (
+            len(re.findall(r"\bfsync\s*\(\s*directory_fd_\s*\)", attempt)) != 1
+            or not any(
+                condition_rejects_predicate(condition, "fsync")
+                and branch_returns_non_success(statement)
+                for condition, statement in fail_closed_if_branches(attempt)
+            )
+            or not any(
+                "errno" in condition
+                and "EINTR" in condition
+                and "Interrupted" in statement
+                for condition, statement in fail_closed_if_branches(attempt)
+            )
+            or "Succeeded" not in attempt
+            or not any(
+                status in attempt
+                for status in (
+                    "FailedBeforeEffect",
+                    "EffectMayHaveOccurred",
+                    "Unsupported",
+                )
+            )
+        ):
+            continue
+        constructor = re.compile(
+            rf"\bexplicit\s+{re.escape(class_name)}\s*"
+            r"\(\s*int\s+directory_fd\s*\)\s*:\s*"
+            r"directory_fd_\s*\(\s*directory_fd\s*\)"
+        )
+        if constructor.search(class_body) is None:
+            continue
+        for instance in re.finditer(
+            rf"\b{re.escape(class_name)}\s+(?P<name>[A-Za-z_]\w*)\s*"
+            r"[({]\s*directory_fd\s*[)}]",
+            helper_body,
+        ):
+            variable = instance.group("name")
+            if re.search(
+                rf"\bretry_interrupted\s*\(\s*{re.escape(variable)}\s*\)",
+                helper_body,
+            ):
+                bindings += 1
+    if bindings != 1:
+        raise AssertionError(f"{label} directory fsync is not bound to its retry")
+
+
+def require_retrying_posix_flock(
+    source: str,
+    helper: str,
+    flag: str,
+    label: str,
+) -> None:
+    signature = re.compile(
+        rf"\bDurableFileResult\s+{re.escape(helper)}\s*"
+        r"\(\s*int\s+(?P<parameter>[A-Za-z_]\w*)\s*\)\s*\{"
+    )
+    signatures = tuple(signature.finditer(source))
+    helper_bodies = function_bodies(source, helper)
+    if len(signatures) != 1 or len(helper_bodies) != 1:
+        raise AssertionError(f"{label} flock helper shape drifted")
+    parameter = signatures[0].group("parameter")
+    member = f"{parameter}_"
+    helper_body = helper_bodies[0]
+    if len(re.findall(r"\bretry_interrupted\s*\(", helper_body)) != 1:
+        raise AssertionError(f"{label} flock does not retry exactly once")
+    bindings = 0
+    for class_name, class_body in class_blocks(source, "DurableInterruptibleCall"):
+        attempts = function_bodies(class_body, "attempt")
+        if len(attempts) != 1:
+            continue
+        attempt = attempts[0]
+        flock_pattern = (
+            rf"\bflock\s*\(\s*{re.escape(member)}\s*,\s*" rf"{re.escape(flag)}\s*\)"
+        )
+        attempt_branches = fail_closed_if_branches(attempt)
+        expected_failures = {
+            f"flock({member},{flag})!=0",
+            f"::flock({member},{flag})!=0",
+        }
+        failure_branches = tuple(
+            statement
+            for condition, statement in attempt_branches
+            if compact_cpp(condition) in expected_failures
+        )
+        returns = re.findall(r"\breturn\b(?P<value>[^;]*);", attempt)
+        final_return = normalized_cpp_expression(returns[-1]) if returns else ""
+        if (
+            len(re.findall(flock_pattern, attempt)) != 1
+            or len(failure_branches) != 1
+            or not branch_returns_non_success(failure_branches[0])
+            or not any(
+                compact_cpp(condition) == "errno==EINTR" and "Interrupted" in statement
+                for condition, statement in attempt_branches
+            )
+            or len(returns) < 3
+            or final_return
+            not in {"Succeeded", "make_result(DurableFileStatus::Succeeded)"}
+        ):
+            continue
+        constructor = re.compile(
+            rf"\bexplicit\s+{re.escape(class_name)}\s*"
+            rf"\(\s*int\s+{re.escape(parameter)}\s*\)\s*:\s*"
+            rf"{re.escape(member)}\s*\(\s*{re.escape(parameter)}\s*\)"
+        )
+        if constructor.search(class_body) is None:
+            continue
+        for instance in re.finditer(
+            rf"\b{re.escape(class_name)}\s+(?P<name>[A-Za-z_]\w*)\s*"
+            rf"[({{]\s*{re.escape(parameter)}\s*[)}})]",
+            helper_body,
+        ):
+            variable = instance.group("name")
+            if re.search(
+                rf"\bretry_interrupted\s*\(\s*{re.escape(variable)}\s*\)",
+                helper_body,
+            ):
+                bindings += 1
+    if bindings != 1:
+        raise AssertionError(f"{label} flock is not bound to its retry")
+
+
+def require_retrying_posix_flock_mutant(
+    source: str,
+    helper: str,
+    flag: str,
+    label: str,
+) -> None:
+    def disable_flock(body: str) -> str:
+        pattern = re.compile(
+            rf"if\s*\(\s*(?P<failure>::flock\s*\([^;]*?{re.escape(flag)}\s*\)"
+            r"\s*!=\s*0)\s*\)"
+        )
+        mutated, replacements = pattern.subn(
+            r"if (false && \g<failure>)", body, count=1
+        )
+        if replacements != 1:
+            raise AssertionError(f"{label} dead-flock mutant drifted")
+        return mutated
+
+    mutant = replace_unique_function_body(source, helper, disable_flock)
+    try:
+        require_retrying_posix_flock(mutant, helper, flag, label)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError(f"{label} accepted a dead flock predicate")
+
+
+def require_posix_live_lock_rebinding(source: str, label: str) -> None:
+    bodies = overriding_method_bodies(
+        source, "DurableFileAdapter", "authority_identity"
+    )
+    if len(bodies) != 1:
+        raise AssertionError(f"{label} authority identity override drifted")
+    body = bodies[0]
+    if (
+        len(call_argument_lists(body, "fstat")) != 2
+        or len(call_argument_lists(body, "fstatat")) != 1
+    ):
+        raise AssertionError(f"{label} does not re-read the live lock name")
+    fstatat_arguments = call_argument_lists(body, "fstatat")[0]
+    if (
+        len(fstatat_arguments) != 4
+        or "directory_fd_" not in fstatat_arguments[0]
+        or "lock_name" not in fstatat_arguments[1]
+        or "current_lock_information" not in fstatat_arguments[2]
+        or "AT_SYMLINK_NOFOLLOW" not in fstatat_arguments[3]
+    ):
+        raise AssertionError(f"{label} live lock lookup can follow another path")
+    required_predicates = (
+        r"!\s*S_ISREG\s*\(\s*lock_information\.st_mode\s*\)",
+        r"!\s*S_ISREG\s*\(\s*current_lock_information\.st_mode\s*\)",
+        r"lock_information\.st_nlink\s*==\s*0",
+        r"current_lock_information\.st_nlink\s*==\s*0",
+        r"lock_information\.st_dev\s*!=\s*current_lock_information\.st_dev",
+        r"lock_information\.st_ino\s*!=\s*current_lock_information\.st_ino",
+    )
+    branches = fail_closed_if_branches(body)
+    if any(
+        not any(
+            re.search(predicate, condition) and branch_returns_non_success(statement)
+            for condition, statement in branches
+        )
+        for predicate in required_predicates
+    ):
+        raise AssertionError(f"{label} does not reject a rebound live lock path")
+
+
+def require_posix_lock_path_binding_mutants(source: str, label: str) -> None:
+    def rejected(mutant: str, name: str) -> None:
+        try:
+            require_each_override_call_exactly_once(
+                mutant,
+                "DurableFileAdapter",
+                "lock_authority",
+                "lock_directory_retrying_interrupts",
+                label,
+            )
+            require_posix_live_lock_rebinding(mutant, label)
+        except AssertionError:
+            return
+        raise AssertionError(f"{label} accepted {name} lock-path mutant")
+
+    def lock_file_only(body: str) -> str:
+        return body.replace(
+            "lock_directory_retrying_interrupts(directory_fd_)",
+            "make_result(DurableFileStatus::Succeeded)",
+            1,
+        )
+
+    rejected(
+        replace_unique_override_body(source, "lock_authority", lock_file_only),
+        "lock-file-only",
+    )
+
+    def held_descriptor_only(body: str) -> str:
+        live_lookup = """struct stat current_lock_information {};
+        if (::fstatat(directory_fd_, lock_name.data(),
+                      &current_lock_information, AT_SYMLINK_NOFOLLOW) != 0) {
+            return {make_errno_result(DurableFileStatus::Unsupported, errno),
+                    {}};
+        }"""
+        mutated = body.replace(
+            live_lookup,
+            "const auto current_lock_information = lock_information;",
+            1,
+        )
+        if mutated == body or "::fstatat(" in mutated:
+            raise AssertionError(f"{label} held-descriptor mutant drifted")
+        return mutated
+
+    rejected(
+        replace_unique_override_body(
+            source, "authority_identity", held_descriptor_only
+        ),
+        "held-descriptor-only",
+    )
+
+    def inode_only(body: str) -> str:
+        return body.replace(
+            "lock_information.st_dev != current_lock_information.st_dev",
+            "false",
+            1,
+        )
+
+    rejected(
+        replace_unique_override_body(source, "authority_identity", inode_only),
+        "partial-identity",
+    )
+
+
+def require_windows_lock_overlapped_binding(source: str) -> None:
+    bodies = overriding_method_bodies(source, "DurableFileAdapter", "lock_authority")
+    if not bodies:
+        raise AssertionError("Windows lock override is unavailable")
+    for body in bodies:
+        calls = list(re.finditer(r"\bLockFileEx\s*\(", body))
+        if len(calls) != 1:
+            raise AssertionError("Windows lock does not call LockFileEx exactly once")
+        opening = body.find("(", calls[0].start())
+        closing = matching_delimiter(body, opening, "(", ")")
+        arguments = body[opening + 1 : closing]
+        variable_match = re.search(r"&\s*(?P<name>[A-Za-z_]\w*)\s*$", arguments)
+        if variable_match is None:
+            raise AssertionError("Windows lock omits its OVERLAPPED argument")
+        variable = variable_match.group("name")
+        if (
+            re.search(
+                rf"\bOVERLAPPED\s+{re.escape(variable)}\s*" r"(?:\{\s*\}|=\s*\{\s*\})",
+                body[: calls[0].start()],
+            )
+            is None
+        ):
+            raise AssertionError("Windows LockFileEx OVERLAPPED is not zeroed")
+
+
+def require_each_override_result_call_checked(
+    source: str,
+    base: str,
+    entry: str,
+    call: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        assignment = re.search(
+            rf"\b(?:const\s+)?(?:auto|DurableFileResult)\s+"
+            rf"(?P<result>[A-Za-z_]\w*)\s*=\s*{re.escape(call)}\s*\(",
+            body,
+        )
+        if assignment is None:
+            raise AssertionError(f"{label} does not capture {call}'s result")
+        result = assignment.group("result")
+        if not any(
+            result in condition
+            and (
+                re.search(
+                    rf"!\s*{re.escape(result)}\s*\.\s*succeeded\s*\(",
+                    condition,
+                )
+                or re.search(
+                    rf"{re.escape(result)}[^=]*(?:!=\s*DurableFileStatus::Succeeded|\.status\s*!=)",
+                    condition,
+                )
+            )
+            and branch_returns_non_success(statement)
+            for condition, statement in fail_closed_if_branches(
+                body[assignment.start() :]
+            )
+        ):
+            raise AssertionError(f"{label} ignores {call}'s result")
+
+
+def require_posix_unlock_result_mapping(source: str, label: str) -> None:
+    bodies = overriding_method_bodies(source, "DurableFileAdapter", "unlock_authority")
+    if not bodies:
+        raise AssertionError(f"{label} unlock override is unavailable")
+    for body in bodies:
+        unlock = re.search(
+            r"\b(?:const\s+)?auto\s+(?P<result>[A-Za-z_]\w*)\s*=\s*"
+            r"unlock_file_retrying_interrupts\s*\(",
+            body,
+        )
+        close = re.search(
+            r"\b(?:const\s+)?(?:auto|int)\s+(?P<result>[A-Za-z_]\w*)\s*=\s*"
+            r"(?:::)?close\s*\(",
+            body,
+        )
+        if unlock is None or close is None or not unlock.start() < close.start():
+            raise AssertionError(f"{label} does not capture unlock then close")
+        unlock_result = unlock.group("result")
+        close_result = close.group("result")
+        if not any(
+            unlock_result in condition
+            and close_result in condition
+            and (
+                f"!{unlock_result}.succeeded(" in re.sub(r"\s+", "", condition)
+                or f"{unlock_result}.status!=" in re.sub(r"\s+", "", condition)
+            )
+            and bool(
+                re.search(
+                    rf"\b{re.escape(close_result)}\s*(?:!=\s*0|<\s*0)",
+                    condition,
+                )
+            )
+            and branch_returns_non_success(statement)
+            for condition, statement in fail_closed_if_branches(body[unlock.start() :])
+        ):
+            raise AssertionError(f"{label} does not propagate unlock/close failure")
+
+
+def require_windows_unlock_result_mapping(source: str) -> None:
+    bodies = overriding_method_bodies(source, "DurableFileAdapter", "unlock_authority")
+    if not bodies:
+        raise AssertionError("Windows unlock override is unavailable")
+    for body in bodies:
+        unlock = re.search(
+            r"\b(?:const\s+)?(?:auto|BOOL|bool)\s+"
+            r"(?P<result>[A-Za-z_]\w*)\s*=\s*UnlockFileEx\s*\(",
+            body,
+        )
+        close = re.search(
+            r"\b(?:const\s+)?(?:auto|BOOL|bool)\s+"
+            r"(?P<result>[A-Za-z_]\w*)\s*=\s*CloseHandle\s*\(",
+            body,
+        )
+        if unlock is None or close is None or not unlock.start() < close.start():
+            raise AssertionError("Windows unlock does not capture unlock then close")
+        unlock_result = unlock.group("result")
+        close_result = close.group("result")
+        if not any(
+            bool(re.search(rf"!\s*{re.escape(unlock_result)}\b", condition))
+            and bool(re.search(rf"!\s*{re.escape(close_result)}\b", condition))
+            and branch_returns_non_success(statement)
+            for condition, statement in fail_closed_if_branches(body[unlock.start() :])
+        ):
+            raise AssertionError("Windows unlock/close failure is ignored")
+
+
+def split_cpp_arguments(arguments: str) -> tuple[str, ...]:
+    parts: list[str] = []
+    start = 0
+    depths = {"(": 0, "[": 0, "{": 0}
+    pairs = {")": "(", "]": "[", "}": "{"}
+    for index, character in enumerate(arguments):
+        if character in depths:
+            depths[character] += 1
+        elif character in pairs:
+            depths[pairs[character]] -= 1
+        elif character == "," and not any(depths.values()):
+            parts.append(arguments[start:index].strip())
+            start = index + 1
+    parts.append(arguments[start:].strip())
+    return tuple(parts)
+
+
+def call_argument_lists(body: str, call: str) -> tuple[tuple[str, ...], ...]:
+    arguments: list[tuple[str, ...]] = []
+    for match in re.finditer(rf"\b{re.escape(call)}\s*\(", body):
+        opening = body.find("(", match.start())
+        closing = matching_delimiter(body, opening, "(", ")")
+        arguments.append(split_cpp_arguments(body[opening + 1 : closing]))
+    return tuple(arguments)
+
+
+def replace_unique_function_body(
+    source: str,
+    function: str,
+    transform,
+) -> str:
+    declaration = re.compile(
+        rf"\b{re.escape(function)}\s*\([^;{{}}]*\)\s*"
+        r"(?:const\s*)?(?:noexcept\s*)?(?:override\s*)?\{"
+    )
+    matches = tuple(declaration.finditer(source))
+    if len(matches) != 1:
+        raise AssertionError(f"{function} mutation target is not unique")
+    opening = matches[0].end() - 1
+    closing = matching_delimiter(source, opening, "{", "}")
+    body = source[opening + 1 : closing]
+    transformed = transform(body)
+    if transformed == body:
+        raise AssertionError(f"{function} mutation did not change its body")
+    return source[: opening + 1] + transformed + source[closing:]
+
+
+def replace_unique_bool_function_body(
+    source: str,
+    function: str,
+    transform,
+) -> str:
+    declaration = re.compile(
+        rf"\bbool\s+{re.escape(function)}\s*\([^;{{}}]*\)\s*"
+        r"(?:const\s*)?(?:noexcept\s*)?\{"
+    )
+    matches = tuple(declaration.finditer(source))
+    if len(matches) != 1:
+        raise AssertionError(f"{function} bool mutation target is not unique")
+    opening = matches[0].end() - 1
+    closing = matching_delimiter(source, opening, "{", "}")
+    body = source[opening + 1 : closing]
+    transformed = transform(body)
+    if transformed == body:
+        raise AssertionError(f"{function} bool mutation did not change its body")
+    return source[: opening + 1] + transformed + source[closing:]
+
+
+def bool_function_bodies(source: str, function: str) -> tuple[str, ...]:
+    declaration = re.compile(
+        rf"\bbool\s+{re.escape(function)}\s*\([^;{{}}]*\)\s*"
+        r"(?:const\s*)?(?:noexcept\s*)?\{"
+    )
+    bodies: list[str] = []
+    for match in declaration.finditer(source):
+        opening = match.end() - 1
+        closing = matching_delimiter(source, opening, "{", "}")
+        bodies.append(source[opening + 1 : closing])
+    return tuple(bodies)
+
+
+def replace_unique_override_body(source: str, entry: str, transform) -> str:
+    declaration = re.compile(
+        rf"\b{re.escape(entry)}\s*\([^;{{}}]*\)\s*" r"[^;{}]*\boverride\b[^;{}]*\{"
+    )
+    matches = tuple(declaration.finditer(source))
+    if len(matches) != 1:
+        raise AssertionError(f"{entry} mutation target is not unique")
+    opening = matches[0].end() - 1
+    closing = matching_delimiter(source, opening, "{", "}")
+    body = source[opening + 1 : closing]
+    transformed = transform(body)
+    if transformed == body:
+        raise AssertionError(f"{entry} mutation did not change its body")
+    return source[: opening + 1] + transformed + source[closing:]
+
+
+def compact_cpp(expression: str) -> str:
+    return re.sub(r"\s+", "", expression)
+
+
+def cpp_object_expression(expression: str) -> str:
+    return re.sub(r"\.(?:data|c_str)\(\)$", "", compact_cpp(expression))
+
+
+def require_post_replace_verification(
+    source: str,
+    platform: str,
+    label: str,
+) -> None:
+    helper_bodies = function_bodies(source, "verify_replaced_target")
+    if len(helper_bodies) != 1:
+        raise AssertionError(f"{label} post-replace verifier is not unique")
+    helper = helper_bodies[0]
+    returns = re.findall(r"\breturn\b(?P<value>[^;]*);", helper, re.DOTALL)
+    if not returns or any(
+        "EffectMayHaveOccurred" not in value and "Succeeded" not in value
+        for value in returns
+    ):
+        raise AssertionError(f"{label} verifier does not fail effect-may")
+    if helper.count("DurableFileStatus::Succeeded") != 1:
+        raise AssertionError(f"{label} verifier maps a failure to success")
+    if any(
+        token in helper
+        for token in (
+            "DurableFileStatus::Unsupported",
+            "DurableFileStatus::FailedBeforeEffect",
+        )
+    ):
+        raise AssertionError(f"{label} verifier downgrades a replacement failure")
+    reads = call_argument_lists(helper, "read_bounded_close")
+    read_assignments = tuple(
+        re.finditer(
+            r"\b(?:const\s+)?(?:auto|DurableReadResult)\s+"
+            r"(?P<result>[A-Za-z_]\w*)\s*=\s*read_bounded_close\s*\(",
+            helper,
+        )
+    )
+    if (
+        len(reads) != 1
+        or len(read_assignments) != 1
+        or len(reads[0]) != 2
+        or compact_cpp(reads[0][1]) != "expected_bytes.size()"
+    ):
+        raise AssertionError(f"{label} verifier does not read exact bounded bytes")
+    read_result = read_assignments[0].group("result")
+    compared_views = tuple(
+        re.finditer(
+            r"\b(?:const\s+)?(?:auto|std::string_view)\s+"
+            r"(?P<view>[A-Za-z_]\w*)\s*=\s*std::string_view\s*\(\s*"
+            rf"{re.escape(read_result)}\s*\.\s*bytes\s*\.\s*data\s*\(\s*\)\s*,\s*"
+            rf"{re.escape(read_result)}\s*\.\s*bytes\s*\.\s*size\s*\(\s*\)\s*\)",
+            helper,
+        )
+    )
+    if len(compared_views) != 1:
+        raise AssertionError(f"{label} verifier does not compare observed bytes")
+    compared_view = compared_views[0].group("view")
+    if (
+        re.search(rf"\b{re.escape(read_result)}\s*\.\s*truncated\b", helper) is None
+        or re.search(rf"\b{re.escape(compared_view)}\s*!=\s*expected_bytes\b", helper)
+        is None
+    ):
+        raise AssertionError(f"{label} verifier ignores observed bounded bytes")
+
+    if platform == "posix":
+        opens = call_argument_lists(helper, "openat")
+        if len(opens) != 1 or not all(
+            token in "".join(opens[0])
+            for token in ("O_RDONLY", "O_CLOEXEC", "O_NOFOLLOW")
+        ):
+            raise AssertionError(f"{label} verifier follows an unsafe target")
+        if (
+            re.search(r"\bfstat\s*\(", helper) is None
+            or re.search(r"!\s*S_ISREG\s*\(", helper) is None
+            or re.search(r"\bst_nlink\s*!=\s*1\b", helper) is None
+            or re.search(
+                r"\bst_dev\s*!=\s*expected_identity\s*\.\s*device\b",
+                helper,
+            )
+            is None
+            or re.search(
+                r"\bst_ino\s*!=\s*expected_identity\s*\.\s*inode\b",
+                helper,
+            )
+            is None
+            or "close_open_descriptor" not in helper
+        ):
+            raise AssertionError(f"{label} verifier omits safe identity validation")
+    elif platform == "windows":
+        opens = call_argument_lists(helper, "CreateFileW")
+        if (
+            len(opens) != 1
+            or len(opens[0]) < 3
+            or not all(
+                token in "".join(opens[0])
+                for token in (
+                    "GENERIC_READ",
+                    "OPEN_EXISTING",
+                    "FILE_FLAG_OPEN_REPARSE_POINT",
+                )
+            )
+            or "FILE_SHARE_DELETE" in opens[0][2]
+        ):
+            raise AssertionError(f"{label} verifier follows an unsafe target")
+        for token in (
+            "FileAttributeTagInfo",
+            "FILE_ATTRIBUTE_REPARSE_POINT",
+            "FILE_ATTRIBUTE_DIRECTORY",
+            "FileStandardInfo",
+            "NumberOfLinks",
+            "FileIdInfo",
+            "same_file_identity",
+            "close_open_handle",
+        ):
+            if token not in helper:
+                raise AssertionError(f"{label} verifier omits safe identity validation")
+        if (
+            re.search(r"\bNumberOfLinks\s*!=\s*1\b", helper) is None
+            or re.search(
+                r"!\s*same_file_identity\s*\(\s*identity\s*,\s*"
+                r"expected_identity\s*\)",
+                helper,
+            )
+            is None
+        ):
+            raise AssertionError(f"{label} verifier ignores target identity")
+        identity_bodies = bool_function_bodies(source, "same_file_identity")
+        if len(identity_bodies) != 1:
+            raise AssertionError(f"{label} identity comparator is not unique")
+        identity_body = compact_cpp(identity_bodies[0])
+        expected_identity_return = (
+            "returnleft.VolumeSerialNumber==right.VolumeSerialNumber&&"
+            "std::memcmp(left.FileId.Identifier,right.FileId.Identifier,"
+            "sizeof(left.FileId.Identifier))==0;"
+        )
+        if expected_identity_return not in identity_body:
+            raise AssertionError(f"{label} compares an incomplete file identity")
+    else:
+        raise AssertionError(f"{label} verifier platform is unknown")
+
+    replacement_call = "renameat" if platform == "posix" else "MoveFileExW"
+    for entry in ("replace_journal", "replace_root"):
+        bodies = overriding_method_bodies(source, "DurableFileAdapter", entry)
+        if len(bodies) != 1:
+            raise AssertionError(f"{label} {entry} override is not unique")
+        body = bodies[0]
+        verifier_calls = call_argument_lists(body, "verify_replaced_target")
+        replacement_calls = call_argument_lists(body, replacement_call)
+        if len(verifier_calls) != 1 or len(replacement_calls) != 1:
+            raise AssertionError(f"{label} {entry} verifier call count drifted")
+        write_at = body.find("write_flush_close")
+        replace_at = body.find(replacement_call)
+        verify_at = body.find("verify_replaced_target")
+        if write_at < 0 or not write_at < replace_at < verify_at:
+            raise AssertionError(f"{label} {entry} verifies before replacement")
+        if (
+            re.search(r"\breturn\s+verify_replaced_target\s*\(", body[verify_at - 16 :])
+            is None
+        ):
+            raise AssertionError(f"{label} {entry} ignores verifier result")
+        verify = tuple(compact_cpp(value) for value in verifier_calls[0])
+        replacement = tuple(compact_cpp(value) for value in replacement_calls[0])
+        if platform == "posix":
+            sync_at = body.find("sync_directory_retrying_interrupts")
+            if not replace_at < sync_at < verify_at:
+                raise AssertionError(
+                    f"{label} {entry} verifies before namespace durability"
+                )
+            identity = re.search(
+                r"\bconst\s+[A-Za-z_]\w*FileIdentity\s+"
+                r"(?P<name>[A-Za-z_]\w*)\s*\{(?P<value>[^}]*)\}",
+                body,
+                re.DOTALL,
+            )
+            if (
+                identity is None
+                or identity.start() >= write_at
+                or "st_dev" not in identity.group("value")
+                or "st_ino" not in identity.group("value")
+                or len(verify) != 4
+                or len(replacement) != 4
+                or verify[0] != replacement[0]
+                or cpp_object_expression(verify[1])
+                != cpp_object_expression(replacement[3])
+                or verify[2] != identity.group("name")
+                or verify[3] != "bytes"
+            ):
+                raise AssertionError(
+                    f"{label} {entry} does not carry staged identity forward"
+                )
+        else:
+            identity = re.search(
+                r"\bFILE_ID_INFO\s+(?P<name>[A-Za-z_]\w*)\s*\{\s*\}",
+                body,
+            )
+            if identity is None or identity.start() >= write_at:
+                raise AssertionError(
+                    f"{label} {entry} does not capture staged identity"
+                )
+            identity_calls = [
+                arguments
+                for arguments in call_argument_lists(
+                    body[:write_at], "GetFileInformationByHandleEx"
+                )
+                if "FileIdInfo" in arguments
+                and any(
+                    compact_cpp(argument) == f"&{identity.group('name')}"
+                    for argument in arguments
+                )
+            ]
+            if (
+                len(identity_calls) != 1
+                or len(verify) != 3
+                or len(replacement) < 2
+                or cpp_object_expression(verify[0])
+                != cpp_object_expression(replacement[1])
+                or verify[1] != identity.group("name")
+                or verify[2] != "bytes"
+            ):
+                raise AssertionError(
+                    f"{label} {entry} does not carry staged identity forward"
+                )
+
+
+def require_post_replace_verification_mutants(
+    source: str,
+    platform: str,
+    label: str,
+) -> None:
+    def rejected(mutant: str, name: str) -> None:
+        try:
+            require_post_replace_verification(mutant, platform, f"{label} mutant")
+        except AssertionError:
+            return
+        raise AssertionError(f"{label} verifier accepted {name} mutant")
+
+    def missing(body: str) -> str:
+        return re.sub(
+            r"\breturn\s+verify_replaced_target\s*\([^;]*\)\s*;",
+            "return make_result(DurableFileStatus::Succeeded);",
+            body,
+            count=1,
+            flags=re.DOTALL,
+        )
+
+    rejected(
+        replace_unique_override_body(source, "replace_journal", missing),
+        "missing",
+    )
+
+    def early(body: str) -> str:
+        match = re.search(
+            r"\breturn\s+verify_replaced_target\s*\([^;]*\)\s*;",
+            body,
+            re.DOTALL,
+        )
+        if match is None:
+            return body
+        marker = "if (::renameat" if platform == "posix" else "if (!::MoveFileExW"
+        without = body[: match.start()] + body[match.end() :]
+        return without.replace(marker, match.group(0) + "\n" + marker, 1)
+
+    rejected(
+        replace_unique_override_body(source, "replace_journal", early),
+        "before-replace",
+    )
+
+    def identity_only(body: str) -> str:
+        if platform == "posix":
+            return re.sub(
+                r"information\s*\.\s*st_dev\s*!=\s*"
+                r"expected_identity\s*\.\s*device\s*\|\|\s*"
+                r"information\s*\.\s*st_ino\s*!=\s*"
+                r"expected_identity\s*\.\s*inode",
+                "false",
+                body,
+                count=1,
+            )
+        return re.sub(
+            r"!\s*same_file_identity\s*\(\s*identity\s*,\s*" r"expected_identity\s*\)",
+            "false",
+            body,
+            count=1,
+        )
+
+    rejected(
+        replace_unique_function_body(source, "verify_replaced_target", identity_only),
+        "content-only",
+    )
+
+    def content_only(body: str) -> str:
+        return re.sub(
+            r"observed_bytes\s*!=\s*expected_bytes",
+            "false",
+            body,
+            count=1,
+        )
+
+    rejected(
+        replace_unique_function_body(source, "verify_replaced_target", content_only),
+        "identity-only",
+    )
+
+    def unsafe(body: str) -> str:
+        token = "O_NOFOLLOW" if platform == "posix" else "FILE_FLAG_OPEN_REPARSE_POINT"
+        return body.replace(token, "0", 1)
+
+    rejected(
+        replace_unique_function_body(source, "verify_replaced_target", unsafe),
+        "unsafe-follow",
+    )
+
+    def unbounded(body: str) -> str:
+        return body.replace(
+            "expected_bytes.size()",
+            "std::numeric_limits<std::size_t>::max()",
+            1,
+        )
+
+    rejected(
+        replace_unique_function_body(source, "verify_replaced_target", unbounded),
+        "unbounded-read",
+    )
+
+    def downgraded(body: str) -> str:
+        return body.replace(
+            "DurableFileStatus::EffectMayHaveOccurred",
+            "DurableFileStatus::Succeeded",
+            1,
+        )
+
+    rejected(
+        replace_unique_function_body(source, "verify_replaced_target", downgraded),
+        "success-mapped-failure",
+    )
+
+    def rebound_observed_bytes(body: str) -> str:
+        return body.replace(
+            "std::string_view(observed.bytes.data(), observed.bytes.size())",
+            "std::string_view(expected_bytes.data(), expected_bytes.size())",
+            1,
+        )
+
+    rejected(
+        replace_unique_function_body(
+            source, "verify_replaced_target", rebound_observed_bytes
+        ),
+        "expected-bytes-rebind",
+    )
+
+    if platform == "windows":
+
+        def always_equal(_body: str) -> str:
+            return "\n    return true;\n"
+
+        rejected(
+            replace_unique_bool_function_body(
+                source, "same_file_identity", always_equal
+            ),
+            "always-equal-identity",
+        )
+
+        def volume_only(_body: str) -> str:
+            return (
+                "\n    return left.VolumeSerialNumber == " "right.VolumeSerialNumber;\n"
+            )
+
+        rejected(
+            replace_unique_bool_function_body(
+                source, "same_file_identity", volume_only
+            ),
+            "volume-only-identity",
+        )
+
+        def file_id_only(_body: str) -> str:
+            return (
+                "\n    return std::memcmp(left.FileId.Identifier, "
+                "right.FileId.Identifier, sizeof(left.FileId.Identifier)) == 0;\n"
+            )
+
+        rejected(
+            replace_unique_bool_function_body(
+                source, "same_file_identity", file_id_only
+            ),
+            "file-id-only-identity",
+        )
+
+        def delete_shared(body: str) -> str:
+            return body.replace(
+                "FILE_SHARE_READ | FILE_SHARE_WRITE",
+                "FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE",
+                1,
+            )
+
+        rejected(
+            replace_unique_function_body(
+                source, "verify_replaced_target", delete_shared
+            ),
+            "delete-shared-verifier",
+        )
+
+
+def require_windows_bound_directory_factory(source: str) -> None:
+    factory_bodies = function_bodies(source, "make_platform_durable_file_adapter")
+    if len(factory_bodies) != 1:
+        raise AssertionError("Windows adapter factory is not unique")
+    factory = factory_bodies[0]
+    opened_at = factory.find("CreateFileW")
+    attributes_at = factory.find("GetFileInformationByHandleEx")
+    final_at = factory.find("final_directory_path")
+    constructed_at = factory.rfind("make_unique<WindowsDurableFileAdapter>")
+    if not 0 <= opened_at < attributes_at < final_at < constructed_at:
+        raise AssertionError("Windows adapter binds its directory out of order")
+    opens = call_argument_lists(factory, "CreateFileW")
+    if len(opens) != 1 or not all(
+        token in "".join(opens[0])
+        for token in (
+            "directory.c_str()",
+            "OPEN_EXISTING",
+            "FILE_FLAG_BACKUP_SEMANTICS",
+            "FILE_FLAG_OPEN_REPARSE_POINT",
+        )
+    ):
+        raise AssertionError("Windows adapter does not open the caller directory")
+    if not all(
+        token in factory
+        for token in (
+            "FileAttributeTagInfo",
+            "FILE_ATTRIBUTE_REPARSE_POINT",
+            "FILE_ATTRIBUTE_DIRECTORY",
+            "std::move(*bound_directory)",
+            "INVALID_HANDLE_VALUE",
+        )
+    ):
+        raise AssertionError("Windows adapter does not validate its bound directory")
+    if len(re.findall(r"std::filesystem::path\s*\{\s*\}", factory)) < 2:
+        raise AssertionError("Windows adapter keeps an invalid caller path")
+    if re.search(
+        r"make_unique\s*<\s*WindowsDurableFileAdapter\s*>\s*" r"\(\s*directory\b",
+        factory,
+    ):
+        raise AssertionError("Windows adapter retains the caller-relative path")
+    final_bodies = function_bodies(source, "final_directory_path")
+    if len(final_bodies) != 1:
+        raise AssertionError("Windows final-directory resolver is not unique")
+    final_body = final_bodies[0]
+    if (
+        "FILE_NAME_NORMALIZED" not in final_body
+        or "VOLUME_NAME_DOS" not in final_body
+        or len(call_argument_lists(final_body, "GetFinalPathNameByHandleW")) < 2
+    ):
+        raise AssertionError("Windows adapter does not resolve a normalized path")
+    for arguments in call_argument_lists(final_body, "GetFinalPathNameByHandleW"):
+        if not any(compact_cpp(argument) == "flags" for argument in arguments):
+            raise AssertionError("Windows final-path call ignores normalized flags")
+
+
+def require_windows_bound_directory_factory_mutants(source: str) -> None:
+    def rejected(mutant: str, name: str) -> None:
+        try:
+            require_windows_bound_directory_factory(mutant)
+        except AssertionError:
+            return
+        raise AssertionError(f"Windows directory binding accepted {name} mutant")
+
+    def caller_path(body: str) -> str:
+        return body.replace(
+            "std::move(*bound_directory), directory_handle",
+            "directory, directory_handle",
+            1,
+        )
+
+    rejected(
+        replace_unique_function_body(
+            source, "make_platform_durable_file_adapter", caller_path
+        ),
+        "caller-path",
+    )
+
+    def unnormalized(body: str) -> str:
+        return body.replace("FILE_NAME_NORMALIZED", "0", 1)
+
+    rejected(
+        replace_unique_function_body(source, "final_directory_path", unnormalized),
+        "unnormalized-path",
+    )
+
+    def invalid_keeps_path(body: str) -> str:
+        return body.replace("std::filesystem::path{}", "directory", 1)
+
+    rejected(
+        replace_unique_function_body(
+            source, "make_platform_durable_file_adapter", invalid_keeps_path
+        ),
+        "invalid-caller-path",
+    )
+
+
+def require_each_override_directory_sync_binding(
+    source: str,
+    entry: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, "DurableFileAdapter", entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {entry} override")
+    for body in bodies:
+        renames = call_argument_lists(body, "renameat")
+        syncs = call_argument_lists(body, "sync_directory_retrying_interrupts")
+        if len(renames) != 1 or len(syncs) != 1:
+            raise AssertionError(f"{label} replacement/sync call count drifted")
+        rename = tuple(re.sub(r"\s+", "", argument) for argument in renames[0])
+        sync = tuple(re.sub(r"\s+", "", argument) for argument in syncs[0])
+        if (
+            len(rename) != 4
+            or len(sync) != 1
+            or rename[0] != rename[2]
+            or sync[0] != rename[0]
+        ):
+            raise AssertionError(f"{label} syncs a different authority directory")
+
+
+def require_each_override_minimum_call_argument(
+    source: str,
+    base: str,
+    entry: str,
+    call: str,
+    argument: str,
+    minimum: int,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        count = sum(
+            argument in arguments for arguments in call_argument_lists(body, call)
+        )
+        if count < minimum:
+            raise AssertionError(f"{label} omits repeated {call}({argument})")
+
+
+def require_windows_composite_identity(source: str) -> None:
+    bodies = overriding_method_bodies(
+        source, "DurableFileAdapter", "authority_identity"
+    )
+    if not bodies:
+        raise AssertionError("Windows authority identity override is unavailable")
+    for body in bodies:
+        declarations = re.findall(
+            r"\bFILE_ID_INFO\s+(?P<name>[A-Za-z_]\w*)\s*\{\s*\}", body
+        )
+        bound: list[str] = []
+        for arguments in call_argument_lists(body, "GetFileInformationByHandleEx"):
+            if "FileIdInfo" not in arguments or len(arguments) < 3:
+                continue
+            match = re.fullmatch(r"&\s*(?P<name>[A-Za-z_]\w*)", arguments[2])
+            if match is not None and match.group("name") in declarations:
+                bound.append(match.group("name"))
+        if len(set(bound)) < 2:
+            raise AssertionError("Windows identity omits directory or lock file ID")
+        returns = re.findall(r"\breturn\b(?P<value>[^;]*);", body)
+        if not any(all(name in value for name in set(bound)) for value in returns):
+            raise AssertionError("Windows identity does not bind both file IDs")
+
+
+def require_each_override_retryable_result_mapping(
+    source: str,
+    base: str,
+    entry: str,
+    primitive: str,
+    interruption_token: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, base, entry)
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete {base}::{entry} override")
+    for body in bodies:
+        branches = fail_closed_if_branches(body)
+        if not any(
+            condition_rejects_predicate(condition, primitive)
+            and branch_returns_non_success(statement)
+            for condition, statement in branches
+        ):
+            raise AssertionError(f"{label} ignores {primitive} failure")
+        if not any(
+            interruption_token in condition and "Interrupted" in statement
+            for condition, statement in branches
+        ):
+            raise AssertionError(
+                f"{label} does not classify {interruption_token} for retry"
+            )
+        if "Succeeded" not in body:
+            raise AssertionError(f"{label} has no explicit success result")
+
+
+def require_each_override_close_result_mapping(
+    source: str,
+    primitive: str,
+    label: str,
+    base: str = "DurableFileChannel",
+) -> None:
+    require_each_override_fail_closed_checks(
+        source,
+        base,
+        "close",
+        (primitive,),
+        label,
+    )
+    require_each_override_omits_calls(
+        source,
+        base,
+        "close",
+        ("retry_interrupted",),
+        label,
+    )
+    for body in overriding_method_bodies(source, base, "close"):
+        if "Succeeded" not in body:
+            raise AssertionError(f"{label} close has no explicit success result")
+
+
+def require_each_override_write_count_mapping(
+    source: str,
+    platform: str,
+    label: str,
+) -> None:
+    bodies = overriding_method_bodies(source, "DurableFileChannel", "write_some")
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete write_some override")
+    for body in bodies:
+        if platform == "posix":
+            assignment = re.search(
+                r"\b(?:const\s+)?(?:auto|ssize_t)\s+(?P<count>[A-Za-z_]\w*)\s*"
+                r"=\s*(?:::)?write\s*\(",
+                body,
+            )
+            interruption_token = "EINTR"
+            primitive = "write"
+        else:
+            assignment = re.search(
+                r"\b(?:DWORD|std::uint32_t|auto)\s+(?P<count>[A-Za-z_]\w*)\s*"
+                r"(?:=\s*0)?\s*;[^{}]*\bWriteFile\s*\([^;]*&\s*"
+                r"(?P=count)\b",
+                body,
+                re.DOTALL,
+            )
+            interruption_token = "ERROR_OPERATION_ABORTED"
+            primitive = "WriteFile"
+        if assignment is None:
+            raise AssertionError(f"{label} does not capture the OS write count")
+        count = assignment.group("count")
+        branches = fail_closed_if_branches(body)
+        if platform == "posix":
+            failure_is_checked = any(
+                count in condition
+                and bool(
+                    re.search(rf"\b{re.escape(count)}\s*(?:<\s*0|==\s*-1)", condition)
+                )
+                and branch_returns_non_success(statement)
+                for condition, statement in branches
+            )
+            if not any(
+                interruption_token in condition and "Interrupted" in statement
+                for condition, statement in branches
+            ):
+                raise AssertionError(
+                    f"{label} does not classify {interruption_token} for retry"
+                )
+        else:
+            if len(re.findall(r"\bWriteFile\b", source)) != 1:
+                raise AssertionError(
+                    f"{label} has an indirect, duplicate, or redirected Windows write"
+                )
+            macro_source = source.replace("%:", "#")
+            defined_macros = re.findall(
+                r"(?m)^\s*#\s*define\s+([A-Za-z_]\w*)\b", macro_source
+            )
+            if any(name != "NOMINMAX" for name in defined_macros):
+                raise AssertionError(f"{label} shadows the Windows write contract")
+
+            def direct_write_failure(condition: str) -> bool:
+                compact = re.sub(r"\s+", "", condition)
+                call = re.match(r"!::WriteFile\(", compact)
+                if call is None:
+                    return False
+                opening = compact.find("(", call.start())
+                return (
+                    matching_delimiter(compact, opening, "(", ")") == len(compact) - 1
+                )
+
+            failure_statements = [
+                statement
+                for condition, statement in branches
+                if direct_write_failure(condition)
+            ]
+            if len(failure_statements) != 1:
+                raise AssertionError(
+                    f"{label} does not have one fail-closed {primitive} branch"
+                )
+            failure_statement = failure_statements[0]
+            canonical_failure = re.fullmatch(
+                r"\s*const\s+auto\s+(?P<error>[A-Za-z_]\w*)\s*=\s*"
+                r"(?:::)?GetLastError\(\)\s*;\s*"
+                r"return\s+\{\s*::lemon::residency::detail::"
+                r"DurableFileResult\s*\{\s*::lemon::residency::detail::"
+                r"DurableFileStatus::\s*EffectMayHaveOccurred\s*,\s*"
+                r"::std::to_string\(\s*(?P=error)\s*\)\s*\}\s*,\s*"
+                r"0\s*\}\s*;\s*",
+                failure_statement,
+                re.DOTALL,
+            )
+            if canonical_failure is None:
+                raise AssertionError(
+                    f"{label} does not unconditionally classify {primitive} "
+                    "failure as uncertain"
+                )
+            if re.search(r"\bInterrupted\b", body):
+                raise AssertionError(
+                    f"{label} retries an uncertain {primitive} failure"
+                )
+            failure_is_checked = branch_returns_non_success(failure_statement)
+        if not failure_is_checked:
+            raise AssertionError(f"{label} ignores {primitive} failure")
+        if re.search(rf"\breturn\b[^;]*\b{re.escape(count)}\b[^;]*;", body) is None:
+            raise AssertionError(f"{label} does not return the OS write count")
+
+
+def require_windows_write_override_shape(source: str, label: str) -> None:
+    bodies = overriding_method_bodies(source, "DurableFileChannel", "write_some")
+    if len(bodies) != 1:
+        raise AssertionError(f"{label} has an ambiguous Windows write override")
+    actual = re.sub(r"\s+", "", bodies[0])
+    expected = re.sub(
+        r"\s+",
+        "",
+        """
+        const auto request = static_cast<DWORD>(
+            std::min(bytes.size(), std::size_t(MAXDWORD)));
+        DWORD written = 0;
+        if (!::WriteFile(handle_, bytes.data(), request, &written, nullptr)) {
+            const auto error = ::GetLastError();
+            return {::lemon::residency::detail::DurableFileResult{
+                        ::lemon::residency::detail::DurableFileStatus::
+                            EffectMayHaveOccurred,
+                        ::std::to_string(error)},
+                    0};
+        }
+        return {::lemon::residency::detail::DurableFileResult{
+                    ::lemon::residency::detail::DurableFileStatus::Succeeded,
+                    {}},
+                written};
+        """,
+    )
+    if actual != expected:
+        raise AssertionError(f"{label} Windows write override shape drifted")
+
+
+def require_each_override_read_count_mapping(
+    source: str,
+    platform: str,
+    label: str,
+) -> None:
+    def fixed_read_cap(expression: str) -> bool:
+        return bool(
+            re.fullmatch(
+                r"(?:"
+                r"(?:0[xX][0-9A-Fa-f]+|[0-9]+)[uUlL]*|"
+                r"MAXDWORD|"
+                r"sizeof\([^()]+\)|"
+                r"(?:std::)?size_t\((?:MAXDWORD|[0-9]+[uUlL]*)\)|"
+                r"static_cast<(?:std::)?size_t>\((?:MAXDWORD|[0-9]+[uUlL]*)\)|"
+                r"std::numeric_limits<(?:DWORD|std::uint32_t|std::size_t)>::max\(\)"
+                r")",
+                expression,
+            )
+        )
+
+    def capped_read_request(expression: str) -> bool:
+        narrowed = re.fullmatch(
+            r"static_cast<(?:DWORD|std::uint32_t)>\((?P<value>.*)\)",
+            expression,
+        )
+        if narrowed is not None:
+            expression = narrowed.group("value")
+        if expression == "max_bytes":
+            return narrowed is None
+        minimum = re.fullmatch(r"(?:std::)?min\((?P<arguments>.*)\)", expression)
+        if minimum is None:
+            return False
+        arguments = tuple(
+            re.sub(r"\s+", "", argument)
+            for argument in split_cpp_arguments(minimum.group("arguments"))
+        )
+        if len(arguments) != 2:
+            return False
+        if arguments[0] == "max_bytes":
+            cap = arguments[1]
+        elif arguments[1] == "max_bytes":
+            cap = arguments[0]
+        else:
+            return False
+        if not fixed_read_cap(cap):
+            return False
+        if narrowed is None:
+            return True
+        if cap in {
+            "MAXDWORD",
+            "size_t(MAXDWORD)",
+            "std::size_t(MAXDWORD)",
+            "static_cast<size_t>(MAXDWORD)",
+            "static_cast<std::size_t>(MAXDWORD)",
+            "std::numeric_limits<DWORD>::max()",
+            "std::numeric_limits<std::uint32_t>::max()",
+        }:
+            return True
+        literal = re.fullmatch(r"(?P<value>0[xX][0-9A-Fa-f]+|[0-9]+)(?:[uUlL]*)", cap)
+        if literal is None:
+            return False
+        base = 16 if literal.group("value").lower().startswith("0x") else 10
+        return int(literal.group("value"), base) <= 0xFFFFFFFF
+
+    bodies = overriding_method_bodies(source, "DurableReadChannel", "read_some")
+    if not bodies:
+        raise AssertionError(f"{label} has no concrete read_some override")
+    for body in bodies:
+        if platform == "posix":
+            assignment = re.search(
+                r"\b(?:const\s+)?(?:auto|ssize_t)\s+"
+                r"(?P<count>[A-Za-z_]\w*)\s*=\s*(?:::)?read\s*\(",
+                body,
+            )
+            interruption_token = "EINTR"
+            primitive = "read"
+        else:
+            assignment = re.search(
+                r"\b(?:DWORD|std::uint32_t|auto)\s+"
+                r"(?P<count>[A-Za-z_]\w*)\s*(?:=\s*0)?\s*;"
+                r"[^{}]*\bReadFile\s*\([^;]*&\s*(?P=count)\b",
+                body,
+                re.DOTALL,
+            )
+            interruption_token = "ERROR_OPERATION_ABORTED"
+            primitive = "ReadFile"
+        if assignment is None:
+            raise AssertionError(f"{label} does not capture the OS read count")
+        count = assignment.group("count")
+        calls = call_argument_lists(body, primitive)
+        if len(calls) != 1:
+            raise AssertionError(f"{label} native read call count drifted")
+        arguments = calls[0]
+        if len(arguments) < 3:
+            raise AssertionError(f"{label} native read arguments drifted")
+        buffer_expression = re.sub(r"\s+", "", arguments[1])
+        request_expression = re.sub(r"\s+", "", arguments[2])
+        request_bound = capped_read_request(request_expression)
+        request_name = re.fullmatch(r"[A-Za-z_]\w*", request_expression)
+        request_initializer = ""
+        if request_name is not None:
+            declaration = re.search(
+                rf"\b(?:const\s+)?(?:auto|std::size_t|DWORD|std::uint32_t)\s+"
+                rf"{re.escape(request_name.group(0))}\s*=\s*(?P<value>[^;]+);",
+                body[: assignment.start()],
+            )
+            if declaration is not None:
+                request_initializer = re.sub(r"\s+", "", declaration.group("value"))
+                request_bound = capped_read_request(request_initializer)
+        if not request_bound:
+            raise AssertionError(f"{label} native read is not capped by max_bytes")
+        buffer_match = re.search(r"(?P<name>[A-Za-z_]\w*)", buffer_expression)
+        if buffer_match is None:
+            raise AssertionError(f"{label} native read buffer is unavailable")
+        buffer_name = buffer_match.group("name")
+        allocation_bound = False
+        allocation = re.search(
+            rf"\b(?:std::string|std::vector\s*<[^;>]+>)\s+"
+            rf"{re.escape(buffer_name)}\s*\(",
+            body[: assignment.start()],
+        )
+        if allocation is not None:
+            opening = body.find("(", allocation.start())
+            closing = matching_delimiter(body, opening, "(", ")")
+            allocation_arguments = split_cpp_arguments(body[opening + 1 : closing])
+            allocation_bound = bool(allocation_arguments) and (
+                re.sub(r"\s+", "", allocation_arguments[0])
+                in {request_expression, request_initializer or request_expression}
+            )
+        if allocation is not None and not allocation_bound:
+            raise AssertionError(f"{label} native read buffer is not request-bounded")
+        if allocation is None and (
+            f"sizeof({buffer_name})" not in request_expression
+            and f"sizeof({buffer_name})" not in request_initializer
+        ):
+            raise AssertionError(f"{label} native read buffer is not request-bounded")
+        branches = fail_closed_if_branches(body)
+        if platform == "posix":
+            failure_is_checked = any(
+                count in condition
+                and bool(
+                    re.search(
+                        rf"\b{re.escape(count)}\s*(?:<\s*0|==\s*-1)",
+                        condition,
+                    )
+                )
+                and branch_returns_non_success(statement)
+                for condition, statement in branches
+            )
+        else:
+            failure_is_checked = any(
+                condition_rejects_predicate(condition, primitive)
+                and branch_returns_non_success(statement)
+                for condition, statement in branches
+            )
+        if not failure_is_checked:
+            raise AssertionError(f"{label} ignores {primitive} failure")
+        if not any(
+            interruption_token in condition and "Interrupted" in statement
+            for condition, statement in branches
+        ):
+            raise AssertionError(
+                f"{label} does not classify {interruption_token} for retry"
+            )
+        returns = re.findall(r"\breturn\b(?P<value>[^;]*);", body)
+        if not any(count in value and buffer_name in value for value in returns):
+            raise AssertionError(f"{label} does not bind bytes to the OS read count")
+        normalized_returns = [re.sub(r"\s+", "", value) for value in returns]
+        eof_expression = rf"{re.escape(count)}==0"
+        eof_bound = any(
+            re.search(eof_expression, value) for value in normalized_returns
+        )
+        if not eof_bound:
+            eof_declarations = re.finditer(
+                r"\b(?:const\s+)?bool\s+(?P<name>[A-Za-z_]\w*)\s*="
+                rf"\s*{re.escape(count)}\s*==\s*0\s*;",
+                body,
+            )
+            eof_bound = any(
+                any(match.group("name") in value for value in normalized_returns)
+                for match in eof_declarations
+            )
+        if not eof_bound:
+            raise AssertionError(f"{label} does not bind EOF to the OS read count")
+
+
+def assigned_call(
+    body: str,
+    call: str,
+    label: str,
+) -> tuple[str, str, int]:
+    pattern = re.compile(
+        r"\b(?:const\s+)?(?:auto|ParsedJournalRecordResult|"
+        r"JournalHistoryResult|AuthorityRootCandidateResult)\s+"
+        rf"(?P<result>[A-Za-z_]\w*)\s*=\s*"
+        rf"(?:lemon::residency::)?{re.escape(call)}\s*\("
+    )
+    matches = list(pattern.finditer(body))
+    if len(matches) != 1:
+        raise AssertionError(f"{label} does not call {call} exactly once")
+    match = matches[0]
+    opening = body.find("(", match.start())
+    closing = matching_delimiter(body, opening, "(", ")")
+    return match.group("result"), body[opening + 1 : closing], match.start()
+
+
+def require_task019_result_binding(
+    body: str,
+    call: str,
+    member: str,
+    label: str,
+    required_argument: str | None = None,
+) -> tuple[int, str, tuple[str, ...]]:
+    result, arguments, position = assigned_call(body, call, label)
+    if required_argument is not None and required_argument not in arguments:
+        raise AssertionError(f"{label} omits {required_argument} from {call}")
+    rejected = any(
+        result in condition
+        and (
+            f"!{result}.accepted(" in re.sub(r"\s+", "", condition)
+            or f"!{result}.{member}" in re.sub(r"\s+", "", condition)
+        )
+        and branch_returns_non_success(statement)
+        for condition, statement in fail_closed_if_branches(body[position:])
+    )
+    if not rejected:
+        raise AssertionError(f"{label} does not reject the {call} result")
+    if (
+        re.search(
+            rf"\*\s*{re.escape(result)}\s*\.\s*{re.escape(member)}\b",
+            body[position:],
+        )
+        is None
+    ):
+        raise AssertionError(f"{label} does not carry {call}'s {member} forward")
+    return position, result, split_cpp_arguments(arguments)
+
+
+def normalized_cpp_expression(expression: str) -> str:
+    return re.sub(r"\s+", "", expression)
+
+
+def require_mint_published_definition(source: str) -> None:
+    definitions = tuple(
+        re.finditer(
+            r"\bDurableJournalResult\s+DurableJournal::mint_published\s*"
+            r"\((?P<parameters>[^;{}]*)\)\s*(?:noexcept\s*)?\{",
+            source,
+        )
+    )
+    if len(definitions) != 1:
+        raise AssertionError("DurableJournal private mint sink is not unique")
+    parameters = split_cpp_arguments(definitions[0].group("parameters"))
+    if (
+        len(parameters) != 3
+        or re.search(r"\bJournalHistory\s*&&\s*[A-Za-z_]\w*\b", parameters[0]) is None
+        or re.search(
+            r"\bAuthorityRootCandidate\s*(?:&&\s*)?[A-Za-z_]\w*\b",
+            parameters[1],
+        )
+        is None
+        or re.search(r"\b(?:persistence|state)[A-Za-z_]*\b", parameters[2]) is None
+    ):
+        raise AssertionError("DurableJournal private mint sink signature drifted")
+
+
+def require_mint_published_return(
+    body: str,
+    history_expression: str,
+    root_expression: str,
+    label: str,
+) -> int:
+    calls = tuple(re.finditer(r"\bmint_published\s*\(", body))
+    arguments = call_argument_lists(body, "mint_published")
+    if len(calls) != 1 or len(arguments) != 1 or len(arguments[0]) != 3:
+        raise AssertionError(f"{label} does not use one private mint sink")
+    start = calls[0].start()
+    statement_start = (
+        max(
+            body.rfind(";", 0, start),
+            body.rfind("{", 0, start),
+            body.rfind("}", 0, start),
+        )
+        + 1
+    )
+    prefix = body[statement_start:start]
+    if re.fullmatch(r"\s*return\s+", prefix) is None:
+        raise AssertionError(f"{label} does not return the private mint result")
+    observed = tuple(normalized_cpp_expression(item) for item in arguments[0])
+    expected_history = normalized_cpp_expression(f"std::move({history_expression})")
+    expected_root = normalized_cpp_expression(f"std::move({root_expression})")
+    if (
+        observed[0] != expected_history
+        or observed[1] != expected_root
+        or re.fullmatch(r"(?:[A-Za-z_]\w*|std::move\([A-Za-z_]\w*\))", observed[2])
+        is None
+    ):
+        raise AssertionError(f"{label} mints from nonauthoritative replay state")
+    return start
+
+
+def require_root_replacement_binding(
+    body: str,
+    root_result: str,
+    label: str,
+) -> int:
+    calls = tuple(re.finditer(r"\breplace_root\s*\(", body))
+    arguments = call_argument_lists(body, "replace_root")
+    if len(calls) != 1 or len(arguments) != 1 or len(arguments[0]) != 1:
+        raise AssertionError(f"{label} root replacement call count drifted")
+    observed = normalized_cpp_expression(arguments[0][0])
+    canonical = normalized_cpp_expression(f"{root_result}.candidate->canonical_bytes()")
+    if observed not in {
+        canonical,
+        f"std::string({canonical})",
+        f"std::string{{{canonical}}}",
+    }:
+        raise AssertionError(f"{label} replaces a nonauthoritative root")
+    return calls[0].start()
+
+
+def require_task019_live_contract(source: str) -> None:
+    require_task019_live_contract_without_mutants(source)
+
+    task019_control = """
+DurableJournalResult DurableJournal::recover_existing() {
+    auto bytes = read_root();
+    auto journal = read_journal();
+    const auto parsed = parse_authority_root_candidate(bytes, history);
+    if (!parsed.candidate) { return corrupt(); }
+    return mint_published(std::move(history), std::move(*parsed.candidate),
+                          persistence_state);
+}
+DurableJournalResult DurableJournal::append_and_publish() {
+    const auto advanced = advance_history(std::move(history), candidate, verifier);
+    if (!advanced.history) { return corrupt(); }
+    append_journal(frame);
+    const auto root = seal_authority_root_candidate(*advanced.history, previous);
+    if (!root.candidate) { return corrupt(); }
+    replace_root(root.candidate->canonical_bytes());
+    return mint_published(std::move(*advanced.history),
+                          std::move(*root.candidate), persistence_state);
+}
+DurableJournalResult DurableJournal::create_new() {
+    const auto history = begin_history(genesis, verifier);
+    if (!history.history) { return corrupt(); }
+    const auto root = seal_authority_root_candidate(*history.history);
+    if (!root.candidate) { return corrupt(); }
+    create_journal(frame);
+    replace_root(root.candidate->canonical_bytes());
+    return mint_published(std::move(*history.history),
+                          std::move(*root.candidate), persistence_state);
+}
+DurableJournalResult DurableJournal::mint_published(
+    JournalHistory &&history, AuthorityRootCandidate &&root,
+    PersistenceState persistence_state) { return DurableJournalResult{}; }
+"""
+    require_task019_live_contract_without_mutants(task019_control)
+    typed_result_control = (
+        task019_control.replace(
+            "const auto parsed = parse_authority_root_candidate",
+            "AuthorityRootCandidateResult parsed = parse_authority_root_candidate",
+        )
+        .replace(
+            "const auto advanced = advance_history",
+            "JournalHistoryResult advanced = advance_history",
+        )
+        .replace(
+            "const auto history = begin_history",
+            "JournalHistoryResult history = begin_history",
+        )
+        .replace(
+            "const auto root = seal_authority_root_candidate",
+            "AuthorityRootCandidateResult root = seal_authority_root_candidate",
+        )
+    )
+    require_task019_live_contract_without_mutants(typed_result_control)
+    delegated_control = """
+DurableJournalResult deep_recover() {
+    auto bytes = read_root();
+    auto journal = read_journal();
+    const auto parsed = parse_authority_root_candidate(bytes, history);
+    if (!parsed.candidate) { return corrupt(); }
+    return mint_published(std::move(history), std::move(*parsed.candidate),
+                          persistence_state);
+}
+DurableJournalResult deep_append() {
+    const auto advanced = advance_history(std::move(history), candidate, verifier);
+    if (!advanced.history) { return corrupt(); }
+    append_journal(frame);
+    const auto root = seal_authority_root_candidate(*advanced.history, previous);
+    if (!root.candidate) { return corrupt(); }
+    replace_root(root.candidate->canonical_bytes());
+    return mint_published(std::move(*advanced.history),
+                          std::move(*root.candidate), persistence_state);
+}
+DurableJournalResult deep_create() {
+    const auto history = begin_history(genesis, verifier);
+    if (!history.history) { return corrupt(); }
+    const auto root = seal_authority_root_candidate(*history.history);
+    if (!root.candidate) { return corrupt(); }
+    create_journal(frame);
+    replace_root(root.candidate->canonical_bytes());
+    return mint_published(std::move(*history.history),
+                          std::move(*root.candidate), persistence_state);
+}
+DurableJournalResult DurableJournal::recover_existing() { return deep_recover(); }
+DurableJournalResult DurableJournal::append_and_publish() { return deep_append(); }
+DurableJournalResult DurableJournal::create_new() { return deep_create(); }
+DurableJournalResult DurableJournal::mint_published(
+    JournalHistory &&history, AuthorityRootCandidate &&root,
+    PersistenceState persistence_state) { return DurableJournalResult{}; }
+"""
+    require_task019_live_contract_without_mutants(delegated_control)
+    dead_parser_mutant = task019_control.replace(
+        "const auto parsed = parse_authority_root_candidate(bytes, history);",
+        "const auto unused = parse_authority_root_candidate(bytes, history);\n"
+        "    const auto parsed = custom_decode_root(bytes, history);",
+    )
+    duplicate_transition_mutant = task019_control.replace(
+        "const auto advanced = advance_history(std::move(history), candidate, verifier);\n"
+        "    if (!advanced.history) { return corrupt(); }",
+        "const auto unused_advance = advance_history(std::move(history), candidate, verifier);\n"
+        "    const auto advanced = custom_advance(history, candidate);\n"
+        "    if (!advanced.history) { return corrupt(); }",
+    )
+    duplicate_sealer_mutant = task019_control.replace(
+        "const auto root = seal_authority_root_candidate(*advanced.history, previous);",
+        "const auto unused_root = seal_authority_root_candidate(*advanced.history, previous);\n"
+        "    const auto root = custom_seal(*advanced.history);",
+        1,
+    )
+    delegated_dead_parser = delegated_control.replace(
+        "const auto parsed = parse_authority_root_candidate(bytes, history);",
+        "const auto unused = parse_authority_root_candidate(bytes, history);\n"
+        "    const auto parsed = custom_decode_root(bytes, history);",
+    )
+    duplicate_helper = delegated_control + "\nDurableJournalResult deep_recover(int);\n"
+    duplicate_helper = duplicate_helper.replace(
+        "DurableJournalResult deep_recover(int);",
+        "DurableJournalResult deep_recover(int) { return corrupt(); }",
+    )
+    typed_dead_call = typed_result_control.replace(
+        "AuthorityRootCandidateResult parsed = "
+        "parse_authority_root_candidate(bytes, history);",
+        "AuthorityRootCandidateResult unused = "
+        "parse_authority_root_candidate(bytes, history);\n"
+        "    const auto parsed = custom_decode_root(bytes, history);",
+        1,
+    )
+    typed_duplicate_call = typed_result_control.replace(
+        "AuthorityRootCandidateResult parsed = "
+        "parse_authority_root_candidate(bytes, history);",
+        "AuthorityRootCandidateResult ignored = "
+        "parse_authority_root_candidate(bytes, history);\n"
+        "    AuthorityRootCandidateResult parsed = "
+        "parse_authority_root_candidate(bytes, history);",
+        1,
+    )
+    typed_unused_result = typed_result_control.replace(
+        "if (!parsed.candidate) { return corrupt(); }",
+        "if (false) { return corrupt(); }",
+        1,
+    )
+    checked_but_nonauthoritative = task019_control.replace(
+        "return mint_published(std::move(history), "
+        "std::move(*parsed.candidate),\n"
+        "                          persistence_state);",
+        "observe(*parsed.candidate);\n"
+        "    const auto custom = custom_decode_root(bytes, history);\n"
+        "    return mint_published(std::move(history), std::move(custom),\n"
+        "                          persistence_state);",
+        1,
+    ).replace(
+        "replace_root(root.candidate->canonical_bytes());",
+        "observe(*root.candidate);\n"
+        "    const auto custom = custom_seal(history);\n"
+        "    replace_root(custom.canonical_bytes());",
+        1,
+    )
+    for mutant in (
+        dead_parser_mutant,
+        duplicate_transition_mutant,
+        duplicate_sealer_mutant,
+        delegated_dead_parser,
+        duplicate_helper,
+        typed_dead_call,
+        typed_duplicate_call,
+        typed_unused_result,
+        checked_but_nonauthoritative,
+    ):
+        try:
+            require_task019_live_contract_without_mutants(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("source scanner accepted a dead TASK-019 call")
+
+
+def require_task019_recovery_flow(recover: str) -> None:
+    parsed_root, parsed, parse_arguments = require_task019_result_binding(
+        recover,
+        "parse_authority_root_candidate",
+        "candidate",
+        "DurableJournal recovery",
+    )
+    if len(parse_arguments) < 2:
+        raise AssertionError("DurableJournal recovery omits replay history")
+    minted = require_mint_published_return(
+        recover,
+        parse_arguments[1],
+        f"*{parsed}.candidate",
+        "DurableJournal recovery",
+    )
+    root_read = recover.find("read_root(")
+    journal_read = recover.find("read_journal(")
+    if (
+        min(root_read, journal_read) < 0
+        or not root_read < journal_read < parsed_root < minted
+    ):
+        raise AssertionError("DurableJournal recovery does not bind root-first replay")
+
+
+def require_task019_append_flow(append: str) -> None:
+    advanced, history_result, _ = require_task019_result_binding(
+        append,
+        "advance_history",
+        "history",
+        "DurableJournal append",
+        "verifier",
+    )
+    sealed, root_result, _ = require_task019_result_binding(
+        append,
+        "seal_authority_root_candidate",
+        "candidate",
+        "DurableJournal append",
+    )
+    journal_append = append.find("append_journal(")
+    root_replace = require_root_replacement_binding(
+        append, root_result, "DurableJournal append"
+    )
+    minted = require_mint_published_return(
+        append,
+        f"*{history_result}.history",
+        f"*{root_result}.candidate",
+        "DurableJournal append",
+    )
+    if (
+        min(journal_append, root_replace) < 0
+        or not advanced < journal_append < sealed < root_replace < minted
+    ):
+        raise AssertionError("DurableJournal append bypasses TASK-019 ordering")
+
+
+def require_task019_create_flow(create: str) -> None:
+    history, history_result, _ = require_task019_result_binding(
+        create,
+        "begin_history",
+        "history",
+        "DurableJournal create",
+        "verifier",
+    )
+    root, root_result, _ = require_task019_result_binding(
+        create,
+        "seal_authority_root_candidate",
+        "candidate",
+        "DurableJournal create",
+    )
+    journal_create = create.find("create_journal(")
+    root_replace = require_root_replacement_binding(
+        create, root_result, "DurableJournal create"
+    )
+    minted = require_mint_published_return(
+        create,
+        f"*{history_result}.history",
+        f"*{root_result}.candidate",
+        "DurableJournal create",
+    )
+    if (
+        min(journal_create, root_replace) < 0
+        or not history < root < journal_create < root_replace < minted
+    ):
+        raise AssertionError("DurableJournal create bypasses TASK-019 ordering")
+
+
+def require_direct_or_unique_helper(
+    source: str,
+    entry: str,
+    flow_validator,
+) -> None:
+    public_bodies = qualified_function_bodies(source, "DurableJournal", entry)
+    if len(public_bodies) != 1:
+        raise AssertionError("DurableJournal live TASK-019 entry shape drifted")
+    public_body = public_bodies[0]
+    try:
+        flow_validator(public_body)
+        return
+    except AssertionError:
+        pass
+
+    delegation = re.fullmatch(
+        r"\s*return\s+"
+        r"(?:(?:[A-Za-z_]\w*)\s*(?:::|->|\.)\s*)*"
+        r"(?P<helper>[A-Za-z_]\w*)\s*\([^;{}]*\)\s*;\s*",
+        public_body,
+    )
+    if delegation is None:
+        raise AssertionError("DurableJournal entry is not a thin private delegation")
+    helper = delegation.group("helper")
+    if helper in {"create_new", "recover_existing", "append_and_publish"}:
+        raise AssertionError("DurableJournal helper is not uniquely named")
+    helper_bodies = function_bodies(source, helper)
+    if len(helper_bodies) != 1:
+        raise AssertionError("DurableJournal private helper is not unique")
+    flow_validator(helper_bodies[0])
+
+
+def require_task019_live_contract_without_mutants(source: str) -> None:
+    require_mint_published_definition(source)
+    require_direct_or_unique_helper(
+        source, "recover_existing", require_task019_recovery_flow
+    )
+    require_direct_or_unique_helper(
+        source, "append_and_publish", require_task019_append_flow
+    )
+    require_direct_or_unique_helper(source, "create_new", require_task019_create_flow)
+
+
+def require_compaction_prefix_binding(source: str) -> None:
+    public_bodies = qualified_function_bodies(
+        source, "DurableJournal", "compact_physical"
+    )
+    if len(public_bodies) != 1:
+        raise AssertionError("DurableJournal compaction entry shape drifted")
+    public = public_bodies[0]
+    try:
+        require_owned_compaction_prefix_flow(public)
+    except AssertionError:
+        delegation = re.fullmatch(
+            r"\s*return\s+(?P<helper>[A-Za-z_]\w*)\s*"
+            r"\(\s*std::move\s*\(\s*(?P<authority>[A-Za-z_]\w*)\s*\)\s*\)"
+            r"\s*;\s*",
+            public,
+        )
+        if delegation is None:
+            raise AssertionError("DurableJournal compaction is not a thin delegation")
+        helper = delegation.group("helper")
+        helper_bodies = function_bodies(source, helper)
+        if len(helper_bodies) != 1:
+            raise AssertionError("DurableJournal compaction helper is not unique")
+        require_owned_compaction_prefix_flow(helper_bodies[0])
+
+    control = """
+DurableJournalResult DurableJournal::compact_physical(
+    PublishedJournal &&authority) {
+    return compact_owned_prefix(std::move(authority));
+}
+DurableJournalResult compact_owned_prefix(PublishedJournal &&authority) {
+    return replace_journal(authority.impl_->committed_prefix_bytes);
+}
+"""
+    if source != control:
+        require_compaction_prefix_binding(control)
+    mutant = """
+DurableJournalResult DurableJournal::compact_physical(
+    PublishedJournal &&authority) {
+    std::string committed_prefix_bytes;
+    for (const auto &record : authority.impl_->history.records()) {
+        committed_prefix_bytes += record.canonical_bytes();
+        committed_prefix_bytes.push_back('\n');
+    }
+    return replace_journal(committed_prefix_bytes);
+}
+"""
+    if source != mutant:
+        try:
+            require_compaction_prefix_binding(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("compaction scanner accepted record reserialization")
+    transformed_prefix_mutant = """
+DurableJournalResult DurableJournal::compact_physical(
+    PublishedJournal &&authority) {
+    return replace_journal(
+        rebuild_from_records(authority.impl_->committed_prefix_bytes));
+}
+"""
+    if source != transformed_prefix_mutant:
+        try:
+            require_compaction_prefix_binding(transformed_prefix_mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("compaction scanner accepted a transformed prefix")
+
+
+def require_directory_lineage_fence_registry_without_mutants(source: str) -> None:
+    if (
+        re.search(
+            r"\bstd::unordered_map\s*<\s*std::string\s*,\s*"
+            r"IdentityFenceToken\s*>\s*"
+            r"fenced_identities\s*;",
+            source,
+        )
+        is None
+    ):
+        raise AssertionError("process fence registry does not retain lineage state")
+
+    for function in ("fence_identity", "identity_fence", "clear_identity_fence"):
+        bodies = function_bodies(source, function)
+        if len(bodies) != 1:
+            raise AssertionError(f"process fence {function} definition drifted")
+        if "directory_identity(identity)" not in compact_cpp(bodies[0]):
+            raise AssertionError(f"process fence {function} is not lineage keyed")
+
+    fence_body = compact_cpp(function_bodies(source, "fence_identity")[0])
+    if (
+        "insert_or_assign(std::string(directory_identity(identity)),token)"
+        not in fence_body
+    ):
+        raise AssertionError("process fence does not retain the lineage epoch")
+
+
+def require_directory_lineage_fence_registry(source: str) -> None:
+    require_directory_lineage_fence_registry_without_mutants(source)
+    for function in ("fence_identity", "identity_fence", "clear_identity_fence"):
+        mutant = replace_unique_function_body(
+            source,
+            function,
+            lambda body: body.replace("directory_identity(identity)", "identity", 1),
+        )
+        try:
+            require_directory_lineage_fence_registry_without_mutants(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(
+                f"process fence accepted full-identity {function} lookup"
+            )
+
+
+def require_final_authority_revalidation_without_mutants(source: str) -> None:
+    definitions = tuple(
+        re.finditer(
+            r"\bbool\s+revalidate_authority\s*" r"\((?P<parameters>[^;{}]*)\)\s*\{",
+            source,
+        )
+    )
+    bodies = bool_function_bodies(source, "revalidate_authority")
+    if len(definitions) != 1 or len(bodies) != 1:
+        raise AssertionError("final authority revalidation helper drifted")
+
+    parameters = split_cpp_arguments(definitions[0].group("parameters"))
+    if len(parameters) != 6:
+        raise AssertionError("final authority revalidation signature drifted")
+    parameter_patterns = (
+        r"std::string_view\s+(?P<name>[A-Za-z_]\w*)",
+        r"std::string_view\s+(?P<name>[A-Za-z_]\w*)",
+        r"std::string_view\s+(?P<name>[A-Za-z_]\w*)",
+        r"bool\s+(?P<name>[A-Za-z_]\w*)",
+        r"bool\s+(?P<name>[A-Za-z_]\w*)",
+        r"std::size_t\s+(?P<name>[A-Za-z_]\w*)",
+    )
+    parameter_names: list[str] = []
+    for parameter, pattern in zip(parameters, parameter_patterns, strict=True):
+        match = re.fullmatch(pattern, parameter.strip())
+        if match is None:
+            raise AssertionError("final authority revalidation signature drifted")
+        parameter_names.append(match.group("name"))
+    (
+        expected_identity,
+        expected_root,
+        expected_journal,
+        expected_journal_stage,
+        expected_root_stage,
+        journal_read_limit,
+    ) = parameter_names
+
+    body = bodies[0]
+    branches = fail_closed_if_branches(body)
+    if not any(
+        compact_cpp(condition) == "!lock_held"
+        and compact_cpp(statement) == "returnfalse;"
+        for condition, statement in branches
+    ):
+        raise AssertionError("final authority revalidation is not lock-bound")
+
+    def assigned_member_call(call: str) -> tuple[str, int]:
+        matches = tuple(
+            re.finditer(
+                r"\b(?:const\s+)?auto\s+(?P<result>[A-Za-z_]\w*)\s*=\s*"
+                rf"(?:[A-Za-z_]\w*\s*(?:->|\.)\s*)?{re.escape(call)}\s*\(",
+                body,
+            )
+        )
+        if len(matches) != 1:
+            raise AssertionError(
+                f"final authority revalidation does not call {call} exactly once"
+            )
+        return matches[0].group("result"), matches[0].start()
+
+    identity, identity_position = assigned_member_call("authority_identity")
+    fixed, fixed_position = assigned_member_call("inspect_fixed_namespace")
+    root, root_position = assigned_member_call("read_root")
+    journal, journal_position = assigned_member_call("read_journal")
+    if not identity_position < fixed_position < root_position < journal_position:
+        raise AssertionError("final authority revalidation order drifted")
+
+    root_arguments = call_argument_lists(body, "read_root")
+    journal_arguments = call_argument_lists(body, "read_journal")
+    if (
+        len(root_arguments) != 1
+        or len(root_arguments[0]) != 1
+        or normalized_cpp_expression(root_arguments[0][0]) != "max_journal_input_bytes"
+        or len(journal_arguments) != 1
+        or len(journal_arguments[0]) != 1
+        or normalized_cpp_expression(journal_arguments[0][0]) != journal_read_limit
+    ):
+        raise AssertionError("final authority revalidation read bounds drifted")
+
+    required_failure_predicates = (
+        (
+            identity_position,
+            (
+                f"!{identity}.result.succeeded()||"
+                f"{identity}.identity!={expected_identity}"
+            ),
+            "composite identity",
+        ),
+        (
+            fixed_position,
+            (
+                f"!{fixed}.result.succeeded()||"
+                f"!{fixed}.journal_present||"
+                f"!{fixed}.root_present||"
+                f"!{fixed}.lock_present||"
+                f"{fixed}.journal_stage_present!={expected_journal_stage}||"
+                f"{fixed}.root_stage_present!={expected_root_stage}"
+            ),
+            "fixed namespace",
+        ),
+        (
+            root_position,
+            (
+                f"!{root}.result.succeeded()||{root}.truncated||"
+                f"{root}.bytes!={expected_root}"
+            ),
+            "authority root",
+        ),
+    )
+    for position, expected_condition, label in required_failure_predicates:
+        if not any(
+            compact_cpp(condition) == expected_condition
+            and compact_cpp(statement) == "returnfalse;"
+            for condition, statement in fail_closed_if_branches(body[position:])
+        ):
+            raise AssertionError(f"final authority revalidation does not bind {label}")
+
+    final_returns = re.findall(
+        r"\breturn\b(?P<value>[^;]*);", body[journal_position:], re.DOTALL
+    )
+    expected_return = (
+        f"{journal}.result.succeeded()&&!{journal}.truncated&&"
+        f"{journal}.bytes=={expected_journal}"
+    )
+    if (
+        len(final_returns) != 1
+        or normalized_cpp_expression(final_returns[0]) != expected_return
+    ):
+        raise AssertionError("final authority revalidation does not bind journal bytes")
+
+    flow_contracts = {
+        "create_new": (
+            (
+                "identity",
+                "root_result.candidate->canonical_bytes()",
+                "framed",
+                "false",
+                "false",
+                "journal_read_limit",
+            ),
+            ("create_journal", "replace_root"),
+        ),
+        "recover_existing": (
+            (
+                "identity",
+                "parsed.candidate->canonical_bytes()",
+                "replay.persistence.committed_prefix_bytes",
+                "fixed.journal_stage_present",
+                "fixed.root_stage_present",
+                "journal_read_limit",
+            ),
+            ("read_root", "read_journal", "truncate_journal"),
+        ),
+        "append_and_publish": (
+            (
+                "identity",
+                "root_result.candidate->canonical_bytes()",
+                "expected_journal",
+                "authority_state->journal_stage_present",
+                "false",
+                "journal_read_limit",
+            ),
+            ("append_journal", "replace_root"),
+        ),
+        "compact_physical": (
+            (
+                "identity",
+                "authority_state->root.canonical_bytes()",
+                "authority_state->committed_prefix_bytes",
+                "false",
+                "authority_state->root_stage_present",
+                "journal_read_limit",
+            ),
+            ("replace_journal",),
+        ),
+    }
+    for entry, (expected_arguments, predecessors) in flow_contracts.items():
+        public_bodies = qualified_function_bodies(source, "DurableJournal", entry)
+        if len(public_bodies) != 1:
+            raise AssertionError(f"DurableJournal {entry} entry shape drifted")
+        flow = public_bodies[0]
+        revalidation_arguments = call_argument_lists(flow, "revalidate_authority")
+        if len(revalidation_arguments) != 1:
+            raise AssertionError(
+                f"DurableJournal {entry} omits final authority revalidation"
+            )
+        observed_arguments = tuple(
+            normalized_cpp_expression(argument)
+            for argument in revalidation_arguments[0]
+        )
+        if observed_arguments != expected_arguments:
+            raise AssertionError(
+                f"DurableJournal {entry} revalidates stale authority state"
+            )
+        revalidation_position = flow.find("revalidate_authority(")
+        mint_position = flow.find("mint_published(")
+        predecessor_positions = tuple(flow.find(f"{call}(") for call in predecessors)
+        if (
+            min(predecessor_positions) < 0
+            or mint_position < 0
+            or not max(predecessor_positions) < revalidation_position < mint_position
+        ):
+            raise AssertionError(
+                f"DurableJournal {entry} final revalidation order drifted"
+            )
+        if not any(
+            "!impl_->revalidate_authority(" in compact_cpp(condition)
+            and branch_returns_non_success(statement)
+            for condition, statement in fail_closed_if_branches(flow)
+        ):
+            raise AssertionError(
+                f"DurableJournal {entry} ignores final revalidation failure"
+            )
+
+
+def require_final_authority_revalidation(source: str) -> None:
+    require_final_authority_revalidation_without_mutants(source)
+    bypass_mutant = replace_unique_bool_function_body(
+        source, "revalidate_authority", lambda _body: " return true; "
+    )
+    try:
+        require_final_authority_revalidation_without_mutants(bypass_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError(
+            "final authority scanner accepted an unconditional success helper"
+        )
+    helper_mutations = (
+        (
+            "unlocked",
+            lambda body: body.replace("if (!lock_held)", "if (false)", 1),
+        ),
+        (
+            "identity-blind",
+            lambda body: body.replace(
+                "identity.identity != expected_identity", "false", 1
+            ),
+        ),
+        (
+            "stage-blind",
+            lambda body: body.replace(
+                "fixed.journal_stage_present != expected_journal_stage",
+                "false",
+                1,
+            ),
+        ),
+        (
+            "root-blind",
+            lambda body: body.replace("root.bytes != expected_root", "false", 1),
+        ),
+        (
+            "dead-root-check",
+            lambda body: body.replace(
+                "root.bytes != expected_root",
+                "(false && root.bytes != expected_root)",
+                1,
+            ),
+        ),
+        (
+            "journal-blind",
+            lambda body: body.replace("journal.bytes == expected_journal", "true", 1),
+        ),
+        (
+            "inflated-read",
+            lambda body: body.replace(
+                "read_journal(journal_read_limit)",
+                "read_journal(max_journal_input_bytes)",
+                1,
+            ),
+        ),
+    )
+    for label, transform in helper_mutations:
+        mutant = replace_unique_bool_function_body(
+            source, "revalidate_authority", transform
+        )
+        try:
+            require_final_authority_revalidation_without_mutants(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(f"final authority scanner accepted its {label} mutant")
+    for entry in (
+        "create_new",
+        "recover_existing",
+        "append_and_publish",
+        "compact_physical",
+    ):
+        bypassed_flow = replace_unique_function_body(
+            source,
+            entry,
+            lambda body: body.replace(
+                "!impl_->revalidate_authority(",
+                "false && impl_->revalidate_authority(",
+                1,
+            ),
+        )
+        try:
+            require_final_authority_revalidation_without_mutants(bypassed_flow)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(
+                f"final authority scanner accepted a bypassed {entry} check"
+            )
+
+
+def require_owned_compaction_prefix_flow(body: str) -> None:
+    calls = call_argument_lists(body, "replace_journal")
+    if len(calls) != 1 or len(calls[0]) != 1:
+        raise AssertionError("compaction does not replace the journal once")
+    argument = normalized_cpp_expression(calls[0][0])
+    string_copy = re.fullmatch(r"std::string\((?P<argument>.*)\)", argument)
+    if string_copy is not None:
+        argument = string_copy.group("argument")
+    owned_prefix = re.fullmatch(
+        r"(?:authority|published|token)[A-Za-z_0-9]*"
+        r"(?:(?:\.|->)[A-Za-z_]\w*)*"
+        r"(?:\.|->)(?:committed_prefix_bytes|authorized_prefix_bytes|"
+        r"committed_prefix|authorized_prefix)",
+        argument,
+    )
+    if owned_prefix is None:
+        raise AssertionError("compaction does not pass the exact owned prefix")
+
+
+def require_tokens(source: str, tokens: tuple[str, ...], label: str) -> None:
+    missing = [token for token in tokens if token not in source]
+    if missing:
+        raise AssertionError(f"{label} omitted {missing}")
+
+
+def require_absent_tokens(source: str, tokens: tuple[str, ...], label: str) -> None:
+    present = [token for token in tokens if token in source]
+    if present:
+        raise AssertionError(f"{label} uses forbidden {present}")
+
+
+def require_build_contract() -> None:
+    windows_root = PureWindowsPath("D:/a/lemonade/lemonade")
+    windows_runner = windows_root / (
+        "test/residency/recovery/test_durable_journal_public_seam.py"
+    )
+    expected_runner = "test/residency/recovery/test_durable_journal_public_seam.py"
+    if cmake_relative_path(windows_runner, windows_root) != expected_runner:
+        raise AssertionError("CMake runner path is host-dependent")
+    if str(windows_runner.relative_to(windows_root)) == expected_runner:
+        raise AssertionError("CMake Windows-path control is ineffective")
+
+    cmake = CMAKE.read_text(encoding="utf-8")
+    cmake_code = strip_cmake_comments(cmake)
+    require_tokens(
+        cmake_code,
+        (
+            "test_durable_residency_journal",
+            "ResidencyDurableJournal",
+            "add_cpp_ci_test",
+            "durable_file_adapter_posix.cpp",
+            "durable_file_adapter_windows.cpp",
+            "durable_file_adapter_macos.cpp",
+            TESTING_DEFINITION,
+        ),
+        "CMake durable-journal test contract",
+    )
+    block_start = cmake_code.find("test_durable_residency_journal")
+    block = cmake_code[max(0, block_start - 1500) : block_start + 5000]
+    if "BUILD_TESTING" not in block or "CI ON" not in block:
+        raise AssertionError("durable journal C++ seam is not an explicit CI test")
+    if not any(token in block for token in ("WIN32", "APPLE", "UNIX")):
+        raise AssertionError("durable journal adapters are not platform-selected")
+    testing_definition = re.compile(
+        rf"target_compile_definitions\s*\(\s*test_durable_residency_journal\s+PRIVATE\s+{TESTING_DEFINITION}\s*\)",
+        re.DOTALL,
+    )
+    if testing_definition.search(block) is None:
+        raise AssertionError("durable test injection is not target-confined")
+    if cmake_code.count(TESTING_DEFINITION) != 1:
+        raise AssertionError("durable test injection escaped its one test target")
+    quoted_hash_control = """
+if(TRUE)
+    set(version_pattern "^#define CLI11_VERSION ")
+endif()
+# if(FALSE)
+#     add_executable(test_durable_residency_journal narrated.cpp)
+# endif()
+"""
+    stripped_hash_control = strip_cmake_comments_preserve_arguments(quoted_hash_control)
+    if (
+        '"^#define CLI11_VERSION "' not in stripped_hash_control
+        or len(cmake_command_spans(stripped_hash_control, "if")) != 1
+        or len(cmake_command_spans(stripped_hash_control, "endif")) != 1
+        or cmake_command_spans(stripped_hash_control, "add_executable")
+    ):
+        raise AssertionError("CMake quoted hashes and comments are misclassified")
+    require_durable_target_sources(cmake)
+    require_private_authority_gate_contract(cmake)
+    require_durable_cmake_invocation(cmake)
+
+    private_gate_control = """
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/residency/recovery/durable_journal_public_seam.cpp")
+add_library(test_durable_residency_private_authority_gate OBJECT
+    test/residency/recovery/durable_journal_private_authority_gate.cpp
+)
+target_include_directories(test_durable_residency_private_authority_gate PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/residency
+)
+add_dependencies(test_durable_residency_journal
+        test_durable_residency_private_authority_gate
+)
+add_cpp_ci_test(
+        ResidencyDurableJournal
+)
+endif()
+"""
+    require_private_authority_gate_contract(private_gate_control)
+    private_gate_mutants = (
+        private_gate_control.replace(" OBJECT\n", " STATIC\n"),
+        private_gate_control.replace(
+            "test_durable_residency_private_authority_gate\n)\nadd_cpp_ci_test",
+            "unrelated_gate\n)\nadd_cpp_ci_test",
+        ),
+        private_gate_control.replace(
+            "add_dependencies(test_durable_residency_journal",
+            "target_compile_definitions("
+            "test_durable_residency_private_authority_gate PRIVATE "
+            f"{TESTING_DEFINITION})\n"
+            "add_dependencies(test_durable_residency_journal",
+        ),
+        private_gate_control.replace("BUILD_TESTING AND EXISTS", "FALSE AND EXISTS", 1),
+        private_gate_control.replace(
+            "BUILD_TESTING AND EXISTS",
+            "BUILD_TESTING AND TASK020_GATE_DISABLED AND EXISTS",
+        ),
+        "function(task020_disabled)\n" + private_gate_control + "\nendfunction()\n",
+        "return()\n" + private_gate_control,
+        "FUNCTION(task020_disabled)\n" + private_gate_control + "\nENDFUNCTION()\n",
+        "RETURN()\n" + private_gate_control,
+    )
+    for mutant in private_gate_mutants:
+        try:
+            require_private_authority_gate_contract(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("private-authority build-gate mutant was accepted")
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    windows_job_source = extract_yaml_job(
+        workflow,
+        "build-lemonade-server-installer",
+        "build-lemonade-desktop-installer",
+    )
+    build_command = re.compile(
+        r"(?m)^\s*cmake\s+--build\s+build\s+--config\s+Release\s+--target\s+test_durable_residency_journal\s*$"
+    )
+    test_command = re.compile(
+        r'(?m)^\s*ctest\s+--test-dir\s+build\s+-C\s+Release\s+--no-tests=error\s+--output-on-failure\s+-R\s+"\^ResidencyDurableJournal\$"\s*$'
+    )
+    require_live_windows_workflow_commands(
+        windows_job_source, build_command, test_command
+    )
+    failure_propagation_control = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Durable build
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          if (-not (Test-Path build)) { throw "build directory missing" }
+          cmake --build build --config Release --target test_durable_residency_journal
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+      - name: Durable test
+        shell: PowerShell
+        run: |
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+          $testExitCode = $LASTEXITCODE
+          if ($testExitCode -ne 0) {
+            exit $testExitCode
+          }
+"""
+    require_live_windows_workflow_commands(
+        failure_propagation_control, build_command, test_command
+    )
+
+    cmake_narration = """
+# test_durable_residency_journal ResidencyDurableJournal add_cpp_ci_test CI ON LEMONADE_RESIDENCY_DURABLE_TESTING
+message("durable_file_adapter_windows.cpp durable_file_adapter_macos.cpp")
+#[[
+test_durable_residency_journal ResidencyDurableJournal add_cpp_ci_test CI ON
+durable_file_adapter_posix.cpp durable_file_adapter_windows.cpp durable_file_adapter_macos.cpp
+]]
+set(narrated [[
+test_durable_residency_journal ResidencyDurableJournal add_cpp_ci_test CI ON
+durable_file_adapter_posix.cpp durable_file_adapter_windows.cpp durable_file_adapter_macos.cpp
+]])
+"""
+    stripped_cmake_narration = strip_cmake_comments(cmake_narration)
+    if any(
+        token in stripped_cmake_narration
+        for token in (
+            "ResidencyDurableJournal",
+            "test_durable_residency_journal",
+            "durable_file_adapter_windows.cpp",
+        )
+    ):
+        raise AssertionError("CMake scanner accepted narrated test wiring")
+    yaml_narration = """
+# test_durable_residency_journal ctest \"^ResidencyDurableJournal$\"
+name: "test_durable_residency_journal ctest ^ResidencyDurableJournal$"
+run: echo "cmake --build build --config Release --target test_durable_residency_journal ctest --test-dir build -C Release --no-tests=error --output-on-failure -R ^ResidencyDurableJournal$"
+run: |
+  Write-Host 'cmake --build build --config Release --target test_durable_residency_journal'
+  Write-Host 'ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"'
+env:
+  NARRATION: |
+    cmake --build build --config Release --target test_durable_residency_journal
+    ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+run: |
+  $narration = @'
+  cmake --build build --config Release --target test_durable_residency_journal
+  ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+  '@
+  cat <<'TASK020'
+  cmake --build build --config Release --target test_durable_residency_journal
+  ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+  TASK020
+"""
+    stripped_narration = strip_shell_heredocs(extract_yaml_run_bodies(yaml_narration))
+    if build_command.search(stripped_narration) or test_command.search(
+        stripped_narration
+    ):
+        raise AssertionError("workflow scanner accepted narrated test wiring")
+    skipped_step_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Narrated durable test
+        if: ${{ false }}
+        continue-on-error: true
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+"""
+    disabled_job_mutant = r"""
+  build-lemonade-server-installer:
+    if: ${{ false }}
+    continue-on-error: true
+    runs-on: windows-latest
+    steps:
+      - name: Durable test
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+"""
+    guarded_commands_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Guarded durable test
+        run: |
+          if ($false) {
+            cmake --build build --config Release --target test_durable_residency_journal
+            ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+          }
+"""
+    early_control_transfer_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Bypassed durable build
+        run: |
+          exit 0
+          cmake --build build --config Release --target test_durable_residency_journal
+      - name: Bypassed durable test
+        run: |
+          return
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+"""
+    conditional_control_transfer_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Bypassed durable build
+        run: |
+          if ($true) { return; }
+          cmake --build build --config Release --target test_durable_residency_journal
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Bypassed durable test
+        run: |
+          if ($true) { return; }
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+"""
+    linux_runner_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Durable build
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+      - name: Durable test
+        run: |
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+"""
+    missing_no_tests_error_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Durable build
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+      - name: Durable test
+        run: |
+          ctest --test-dir build -C Release --output-on-failure -R "^ResidencyDurableJournal$"
+"""
+    missing_exit_propagation_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Durable build
+        shell: PowerShell
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+      - name: Durable test
+        shell: PowerShell
+        run: |
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+"""
+    dead_exit_propagation_mutant = r"""
+  build-lemonade-server-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Durable build
+        shell: PowerShell
+        run: |
+          cmake --build build --config Release --target test_durable_residency_journal
+          if ($false) {
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+      - name: Durable test
+        shell: PowerShell
+        run: |
+          ctest --test-dir build -C Release --no-tests=error --output-on-failure -R "^ResidencyDurableJournal$"
+          if ($false) {
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+"""
+    for mutant in (
+        skipped_step_mutant,
+        disabled_job_mutant,
+        guarded_commands_mutant,
+        early_control_transfer_mutant,
+        conditional_control_transfer_mutant,
+        linux_runner_mutant,
+        missing_no_tests_error_mutant,
+        missing_exit_propagation_mutant,
+        dead_exit_propagation_mutant,
+    ):
+        try:
+            require_live_windows_workflow_commands(mutant, build_command, test_command)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("workflow scanner accepted a disabled durable test")
+    commented_job_mutant = """
+#   build-lemonade-server-installer:
+#     run: cmake --build build --config Release --target test_durable_residency_journal
+  build-lemonade-desktop-installer:
+    runs-on: windows-latest
+"""
+    try:
+        extract_yaml_job(
+            commented_job_mutant,
+            "build-lemonade-server-installer",
+            "build-lemonade-desktop-installer",
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("workflow scanner accepted a commented job")
+
+    direct_binary_mutant = """
+if(BUILD_TESTING)
+    add_executable(test_durable_residency_journal fixture.cpp)
+    add_cpp_ci_test(
+        ResidencyDurableJournal
+        CI ON
+        COMMAND test_durable_residency_journal
+        DEPENDS test_durable_residency_journal)
+endif()
+"""
+    incomplete_wrapper_mutant = f"""
+if(BUILD_TESTING)
+    add_executable(test_durable_residency_journal fixture.cpp)
+    add_cpp_ci_test(
+        ResidencyDurableJournal
+        CI ON
+        COMMAND ${{Python3_EXECUTABLE}} {RUNNER}
+            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
+        DEPENDS test_durable_residency_journal)
+endif()
+"""
+    inert_command_prefix_mutant = f"""
+if(BUILD_TESTING)
+    add_executable(test_durable_residency_journal fixture.cpp)
+    add_cpp_ci_test(
+        ResidencyDurableJournal
+        CI ON
+        COMMAND ${{CMAKE_COMMAND}} -E echo
+            ${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)}
+            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
+            --compiler ${{CMAKE_CXX_COMPILER}}
+        DEPENDS test_durable_residency_journal)
+endif()
+"""
+    inactive_enclosure_mutant = f"""
+if(BUILD_TESTING AND FALSE)
+    add_executable(test_durable_residency_journal fixture.cpp)
+    add_cpp_ci_test(
+        ResidencyDurableJournal
+        CI ON
+        COMMAND ${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)}
+            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
+            --compiler ${{CMAKE_CXX_COMPILER}}
+        DEPENDS test_durable_residency_journal)
+endif()
+"""
+    masked_test_mutant = f"""
+if(BUILD_TESTING)
+    add_executable(test_durable_residency_journal fixture.cpp)
+    add_cpp_ci_test(
+        ResidencyDurableJournal
+        CI ON
+        COMMAND ${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)}
+            --existing-executable $<TARGET_FILE:test_durable_residency_journal>
+            --compiler ${{CMAKE_CXX_COMPILER}}
+        DEPENDS test_durable_residency_journal)
+    set_tests_properties(ResidencyDurableJournal PROPERTIES DISABLED TRUE)
+endif()
+"""
+    for mutant in (
+        direct_binary_mutant,
+        incomplete_wrapper_mutant,
+        inert_command_prefix_mutant,
+        inactive_enclosure_mutant,
+        masked_test_mutant,
+    ):
+        try:
+            require_durable_cmake_invocation(mutant)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("CTest can bypass the frozen Python race wrapper")
+    target_source_control = """
+if(WIN32)
+    set(_TASK020_PLATFORM_SOURCE
+        src/cpp/server/residency/durable_file_adapter_windows.cpp)
+elseif(APPLE)
+    set(_TASK020_PLATFORM_SOURCE
+        src/cpp/server/residency/durable_file_adapter_macos.cpp)
+else()
+    set(_TASK020_PLATFORM_SOURCE
+        src/cpp/server/residency/durable_file_adapter_posix.cpp)
+endif()
+add_executable(test_durable_residency_journal
+    test/residency/recovery/durable_journal_public_seam.cpp
+    test/residency/recovery/journal_persistence_test_support.cpp
+    src/cpp/server/residency/durable_journal.cpp
+    src/cpp/server/residency/durable_file_adapter_common.cpp
+    src/cpp/server/residency/journal.cpp
+    ${_TASK020_PLATFORM_SOURCE})
+target_include_directories(test_durable_residency_journal PRIVATE src/cpp/include)
+target_link_libraries(test_durable_residency_journal PRIVATE lemonade-digest-crypto)
+target_compile_definitions(test_durable_residency_journal PRIVATE
+    LEMONADE_RESIDENCY_DURABLE_TESTING)
+"""
+    require_durable_target_sources(target_source_control)
+    unconditional_platform_mutant = re.sub(
+        r"if\(WIN32\).*?endif\(\)",
+        """set(_TASK020_PLATFORM_SOURCE
+    src/cpp/server/residency/durable_file_adapter_windows.cpp)
+set(_TASK020_PLATFORM_SOURCE
+    src/cpp/server/residency/durable_file_adapter_macos.cpp)
+set(_TASK020_PLATFORM_SOURCE
+    src/cpp/server/residency/durable_file_adapter_posix.cpp)""",
+        target_source_control,
+        count=1,
+        flags=re.DOTALL,
+    )
+    try:
+        require_durable_target_sources(unconditional_platform_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("CMake platform sources are selected sequentially")
+    dummy_target_mutant = target_source_control.replace(
+        "test/residency/recovery/durable_journal_public_seam.cpp",
+        "test/residency/recovery/fixture.cpp",
+    )
+    try:
+        require_durable_target_sources(dummy_target_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("CMake target bypassed the frozen semantic fixture")
+    narrated_wrapper_mutant = f"""
+message("add_cpp_ci_test(ResidencyDurableJournal CI ON COMMAND "
+        "${{Python3_EXECUTABLE}} {RUNNER.relative_to(REPO_ROOT)} "
+        "--existing-executable $<TARGET_FILE:test_durable_residency_journal> "
+        "--compiler ${{CMAKE_CXX_COMPILER}} DEPENDS "
+        "test_durable_residency_journal)")
+add_cpp_ci_test(
+    ResidencyDurableJournal
+    CI ON
+    COMMAND test_durable_residency_journal
+    DEPENDS test_durable_residency_journal)
+"""
+    try:
+        require_durable_cmake_invocation(narrated_wrapper_mutant)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("CTest scanner accepted a narrated wrapper call")
+
+
+def cmake_tokens(body: str) -> tuple[str, ...]:
+    return tuple(
+        token[1:-1] if token[:1] == token[-1:] and token[:1] in {'"', "'"} else token
+        for token in re.findall(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\S+', body)
+    )
+
+
+def require_durable_target_sources(source: str) -> None:
+    code = strip_cmake_comments_preserve_arguments(source)
+    target_calls = [
+        body
+        for body in cmake_command_arguments(code, "add_executable")
+        if cmake_tokens(body)[:1] == ("test_durable_residency_journal",)
+    ]
+    if len(target_calls) != 1:
+        raise AssertionError("durable semantic executable target is unavailable")
+    arguments = cmake_tokens(target_calls[0])
+    required = {
+        "test/residency/recovery/durable_journal_public_seam.cpp",
+        "test/residency/recovery/journal_persistence_test_support.cpp",
+        "src/cpp/server/residency/durable_journal.cpp",
+        "src/cpp/server/residency/durable_file_adapter_common.cpp",
+        "src/cpp/server/residency/journal.cpp",
+    }
+    set_calls = [cmake_tokens(body) for body in cmake_command_arguments(code, "set")]
+    variables = {
+        match.group("name")
+        for argument in arguments
+        if (match := re.fullmatch(r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\}", argument))
+    }
+    conditional_events = sorted(
+        (
+            start,
+            command,
+            cmake_tokens(body),
+        )
+        for command in ("if", "elseif", "else", "endif", "set")
+        for body, start, _end in cmake_command_spans(code, command)
+    )
+    conditional_stack: list[tuple[int, str]] = []
+    branch_sequences: dict[int, list[str]] = {}
+    positioned_sets: list[tuple[tuple[str, ...], tuple[int, str] | None]] = []
+    next_chain = 0
+    for _position, command, tokens in conditional_events:
+        if command == "if":
+            branch = "".join(tokens).upper()
+            branch_sequences[next_chain] = [branch]
+            conditional_stack.append((next_chain, branch))
+            next_chain += 1
+        elif command == "elseif":
+            if not conditional_stack:
+                raise AssertionError("CMake platform selection is unbalanced")
+            chain, _previous = conditional_stack[-1]
+            branch = "".join(tokens).upper()
+            branch_sequences[chain].append(branch)
+            conditional_stack[-1] = (chain, branch)
+        elif command == "else":
+            if not conditional_stack:
+                raise AssertionError("CMake platform selection is unbalanced")
+            chain, _previous = conditional_stack[-1]
+            branch_sequences[chain].append("ELSE")
+            conditional_stack[-1] = (chain, "ELSE")
+        elif command == "endif":
+            if not conditional_stack:
+                raise AssertionError("CMake platform selection is unbalanced")
+            conditional_stack.pop()
+        else:
+            positioned_sets.append(
+                (tokens, conditional_stack[-1] if conditional_stack else None)
+            )
+    if conditional_stack:
+        raise AssertionError("CMake platform selection is unbalanced")
+
+    def repo_relative(token: str) -> str:
+        return re.sub(r"^\$\{CMAKE_CURRENT_SOURCE_DIR\}/", "", token)
+
+    resolved_arguments = {repo_relative(token) for token in arguments}
+    for variable in variables:
+        resolved_arguments.update(
+            repo_relative(token)
+            for tokens in set_calls
+            if tokens[:1] == (variable,)
+            for token in tokens[1:]
+        )
+    if not required.issubset(resolved_arguments) or any(
+        token.endswith(("fixture.cpp", "dummy.cpp")) for token in resolved_arguments
+    ):
+        raise AssertionError("durable semantic executable omits frozen sources")
+    selected: list[str] = []
+    platform_files = {
+        "durable_file_adapter_posix.cpp",
+        "durable_file_adapter_windows.cpp",
+        "durable_file_adapter_macos.cpp",
+    }
+    for variable in variables:
+        assignments = [tokens for tokens in set_calls if tokens[:1] == (variable,)]
+        values = {Path(token).name for tokens in assignments for token in tokens[1:]}
+        guarded_assignments = [
+            (tokens, context)
+            for tokens, context in positioned_sets
+            if tokens[:1] == (variable,)
+        ]
+        if len(guarded_assignments) != 3 or any(
+            context is None or len(tokens) != 2
+            for tokens, context in guarded_assignments
+        ):
+            continue
+        chains = {context[0] for _tokens, context in guarded_assignments}
+        if len(chains) != 1:
+            continue
+        branch_files = {
+            context[1]: Path(tokens[1]).name for tokens, context in guarded_assignments
+        }
+        posix_branch = "ELSE" if "ELSE" in branch_files else "UNIX"
+        chain = next(iter(chains))
+        if (
+            platform_files.issubset(values)
+            and branch_sequences[chain] == ["WIN32", "APPLE", posix_branch]
+            and branch_files
+            == {
+                "WIN32": "durable_file_adapter_windows.cpp",
+                "APPLE": "durable_file_adapter_macos.cpp",
+                posix_branch: "durable_file_adapter_posix.cpp",
+            }
+        ):
+            selected.append(variable)
+    if len(selected) != 1 or any(
+        Path(argument).name in platform_files for argument in arguments
+    ):
+        raise AssertionError("durable semantic target does not select one platform")
+    for command in (
+        "target_include_directories",
+        "target_link_libraries",
+        "target_compile_definitions",
+    ):
+        calls = [
+            body
+            for body in cmake_command_arguments(code, command)
+            if cmake_tokens(body)[:1] == ("test_durable_residency_journal",)
+        ]
+        if len(calls) != 1:
+            raise AssertionError(f"durable semantic target {command} drifted")
+
+
+def require_private_authority_gate_contract(source: str) -> None:
+    code = strip_cmake_comments_preserve_arguments(source)
+    target = "test_durable_residency_private_authority_gate"
+    expected_calls = {
+        "add_library": (
+            target,
+            "OBJECT",
+            "test/residency/recovery/durable_journal_private_authority_gate.cpp",
+        ),
+        "add_dependencies": (
+            "test_durable_residency_journal",
+            target,
+        ),
+    }
+    positions: dict[str, int] = {}
+    for command, expected in expected_calls.items():
+        matching = [
+            (cmake_tokens(body), start)
+            for body, start, _end in cmake_command_spans(code, command)
+            if target in cmake_tokens(body)
+        ]
+        if len(matching) != 1 or matching[0][0] != expected:
+            raise AssertionError("private-authority build gate is incomplete")
+        positions[command] = matching[0][1]
+        require_live_cmake_test_enclosure(code, matching[0][1])
+
+    if any(
+        cmake_tokens(body)[:1] == (target,) and TESTING_DEFINITION in cmake_tokens(body)
+        for body in cmake_command_arguments(code, "target_compile_definitions")
+    ):
+        raise AssertionError("private-authority gate gained test-only access")
+
+    invocations = [
+        start
+        for body, start, _end in cmake_command_spans(code, "add_cpp_ci_test")
+        if cmake_tokens(body)[:1] == ("ResidencyDurableJournal",)
+    ]
+    if len(invocations) != 1 or positions["add_dependencies"] >= invocations[0]:
+        raise AssertionError("private-authority gate is not a build prerequisite")
+
+
+def require_durable_cmake_invocation(source: str) -> None:
+    code = strip_cmake_comments_preserve_arguments(source)
+    matching_calls = [
+        (body, start)
+        for body, start, _end in cmake_command_spans(code, "add_cpp_ci_test")
+        if re.match(r"\s*ResidencyDurableJournal\b", body)
+    ]
+    if len(matching_calls) != 1:
+        raise AssertionError("durable CTest wrapper call is unavailable")
+    body, call_start = matching_calls[0]
+    arguments = cmake_tokens(body)
+    expected = (
+        "ResidencyDurableJournal",
+        "CI",
+        "ON",
+        "COMMAND",
+        "${Python3_EXECUTABLE}",
+        cmake_relative_path(RUNNER, REPO_ROOT),
+        "--existing-executable",
+        "$<TARGET_FILE:test_durable_residency_journal>",
+        "--compiler",
+        "${CMAKE_CXX_COMPILER}",
+        "--private-authority-gate",
+        "$<TARGET_OBJECTS:test_durable_residency_private_authority_gate>",
+        "DEPENDS",
+        "test_durable_residency_journal",
+    )
+    if arguments != expected:
+        raise AssertionError("durable CTest wrapper/race argv is incomplete")
+    require_live_cmake_test_enclosure(code, call_start)
+    require_unmasked_cmake_test(code, "ResidencyDurableJournal")
+
+
+def require_live_cmake_test_enclosure(source: str, call_start: int) -> None:
+    commands: list[tuple[int, str, str]] = []
+    for command in ("if", "elseif", "else", "endif"):
+        commands.extend(
+            (start, command, body)
+            for body, start, _end in cmake_command_spans(source, command)
+            if start < call_start
+        )
+    stack: list[str] = []
+    for _start, command, body in sorted(commands):
+        if command == "if":
+            stack.append(body)
+        elif command in ("elseif", "else"):
+            if not stack:
+                raise AssertionError("CMake conditional structure is unbalanced")
+            stack[-1] = "CONDITIONAL_BRANCH"
+        else:
+            if not stack:
+                raise AssertionError("CMake conditional structure is unbalanced")
+            stack.pop()
+    expected = (
+        "BUILD_TESTING",
+        "AND",
+        "EXISTS",
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/residency/recovery/durable_journal_public_seam.cpp",
+    )
+    if len(stack) != 1 or cmake_tokens(stack[0]) != expected:
+        raise AssertionError("durable CTest does not have its exact live enclosure")
+    scope_pairs = {
+        "endfunction": "function",
+        "endmacro": "macro",
+        "endforeach": "foreach",
+        "endwhile": "while",
+    }
+    scope_commands: list[tuple[int, str]] = []
+    for command in (*scope_pairs.values(), *scope_pairs):
+        scope_commands.extend(
+            (start, command)
+            for _body, start, _end in cmake_command_spans(source, command)
+            if start < call_start
+        )
+    scope_stack: list[str] = []
+    for _start, command in sorted(scope_commands):
+        if command in scope_pairs.values():
+            scope_stack.append(command)
+        else:
+            if not scope_stack or scope_stack[-1] != scope_pairs[command]:
+                raise AssertionError("CMake executable scope is unbalanced")
+            scope_stack.pop()
+    if scope_stack:
+        raise AssertionError("durable CTest is not at global executable scope")
+    if any(
+        start < call_start
+        for _body, start, _end in cmake_command_spans(source, "return")
+    ):
+        raise AssertionError("durable CTest is unreachable after CMake return")
+
+
+def require_unmasked_cmake_test(source: str, test: str) -> None:
+    forbidden = {
+        "DISABLED",
+        "WILL_FAIL",
+        "SKIP_RETURN_CODE",
+        "PASS_REGULAR_EXPRESSION",
+        "SKIP_REGULAR_EXPRESSION",
+    }
+    for command in ("set_tests_properties", "set_property"):
+        for body in cmake_command_arguments(source, command):
+            tokens = {
+                token.strip("\"'").upper()
+                for token in re.findall(
+                    r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'|\S+', body
+                )
+            }
+            if test.upper() in tokens and tokens & forbidden:
+                raise AssertionError("durable CTest outcome is masked")
+
+
+def strip_cmake_comments(source: str) -> str:
+    without_bracket_comments = re.sub(
+        r"#\[(?P<comment_equals>=*)\[.*?\](?P=comment_equals)\]",
+        "",
+        source,
+        flags=re.DOTALL,
+    )
+    without_bracket_arguments = re.sub(
+        r"(?<!#)\[(?P<argument_equals>=*)\[.*?\](?P=argument_equals)\]",
+        "",
+        without_bracket_comments,
+        flags=re.DOTALL,
+    )
+    without_comments = re.sub(r"(?m)#.*$", "", without_bracket_arguments)
+    return re.sub(r'"(?:\\.|[^"\\])*"', "", without_comments)
+
+
+def strip_cmake_comments_preserve_arguments(source: str) -> str:
+    without_bracket_comments = re.sub(
+        r"#\[(?P<comment_equals>=*)\[.*?\](?P=comment_equals)\]",
+        "",
+        source,
+        flags=re.DOTALL,
+    )
+    without_bracket_arguments = re.sub(
+        r"(?<!#)\[(?P<argument_equals>=*)\[.*?\](?P=argument_equals)\]",
+        "",
+        without_bracket_comments,
+        flags=re.DOTALL,
+    )
+    stripped: list[str] = []
+    index = 0
+    quoted = False
+    escaped = False
+    while index < len(without_bracket_arguments):
+        character = without_bracket_arguments[index]
+        if quoted:
+            stripped.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                quoted = False
+            index += 1
+            continue
+        if character == '"':
+            quoted = True
+            stripped.append(character)
+            index += 1
+            continue
+        if character == "#":
+            while (
+                index < len(without_bracket_arguments)
+                and without_bracket_arguments[index] not in "\r\n"
+            ):
+                index += 1
+            continue
+        stripped.append(character)
+        index += 1
+    return "".join(stripped)
+
+
+def cmake_command_spans(source: str, command: str) -> list[tuple[str, int, int]]:
+    calls: list[tuple[str, int, int]] = []
+    folded_source = source.casefold()
+    folded_command = command.casefold()
+    index = 0
+    quoted = False
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        if quoted:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                quoted = False
+            index += 1
+            continue
+        if character == '"':
+            quoted = True
+            index += 1
+            continue
+        if folded_source.startswith(folded_command, index):
+            before = source[index - 1] if index else ""
+            after_index = index + len(command)
+            after = source[after_index] if after_index < len(source) else ""
+            if (before and (before.isalnum() or before == "_")) or (
+                after and (after.isalnum() or after == "_")
+            ):
+                index += 1
+                continue
+            opening = after_index
+            while opening < len(source) and source[opening].isspace():
+                opening += 1
+            if opening >= len(source) or source[opening] != "(":
+                index += 1
+                continue
+            depth = 1
+            cursor = opening + 1
+            inner_quoted = False
+            inner_escaped = False
+            while cursor < len(source) and depth:
+                current = source[cursor]
+                if inner_quoted:
+                    if inner_escaped:
+                        inner_escaped = False
+                    elif current == "\\":
+                        inner_escaped = True
+                    elif current == '"':
+                        inner_quoted = False
+                elif current == '"':
+                    inner_quoted = True
+                elif current == "(":
+                    depth += 1
+                elif current == ")":
+                    depth -= 1
+                cursor += 1
+            if depth != 0:
+                raise AssertionError("CMake command has unbalanced arguments")
+            calls.append((source[opening + 1 : cursor - 1], index, cursor))
+            index = cursor
+            continue
+        index += 1
+    return calls
+
+
+def cmake_command_arguments(source: str, command: str) -> list[str]:
+    return [body for body, _start, _end in cmake_command_spans(source, command)]
+
+
+def extract_yaml_job(source: str, job: str, following_job: str) -> str:
+    job_matches = list(re.finditer(rf"(?m)^  {re.escape(job)}\s*:\s*(?:#.*)?$", source))
+    following_matches = list(
+        re.finditer(rf"(?m)^  {re.escape(following_job)}\s*:\s*(?:#.*)?$", source)
+    )
+    if len(job_matches) != 1 or len(following_matches) != 1:
+        raise AssertionError("Windows installer job is unavailable")
+    start = job_matches[0].start()
+    end = following_matches[0].start()
+    if end <= start:
+        raise AssertionError("Windows installer job order drifted")
+    return source[start:end]
+
+
+def extract_yaml_run_bodies(source: str) -> str:
+    lines = source.splitlines(keepends=True)
+    bodies: list[str] = []
+    index = 0
+    run_line = re.compile(
+        r"^(?P<indent>\s*)(?:-\s+)?run\s*:\s*(?P<value>.*?)(?:\r?\n)?$"
+    )
+    while index < len(lines):
+        match = run_line.match(lines[index])
+        if match is None:
+            index += 1
+            continue
+        value = match.group("value").strip()
+        if re.fullmatch(r"[|>][+-]?\d?", value):
+            base_indent = len(match.group("indent"))
+            index += 1
+            block: list[str] = []
+            while index < len(lines):
+                line = lines[index]
+                if not line.strip():
+                    block.append(line)
+                    index += 1
+                    continue
+                indentation = len(line) - len(line.lstrip())
+                if indentation <= base_indent:
+                    break
+                block.append(line)
+                index += 1
+            bodies.extend(block)
+            continue
+        bodies.append(value + "\n")
+        index += 1
+    return "".join(bodies)
+
+
+def direct_yaml_metadata(
+    source: str,
+    indentation: int,
+    strip_sequence_marker: bool = False,
+) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for line in source.splitlines():
+        leading = len(line) - len(line.lstrip())
+        if leading != indentation:
+            continue
+        content = line.lstrip()
+        if strip_sequence_marker and content.startswith("- "):
+            content = content[2:].lstrip()
+        match = re.match(r"(?P<key>[A-Za-z0-9_-]+)\s*:\s*(?P<value>.*)$", content)
+        if match is not None:
+            metadata[match.group("key")] = match.group("value").strip()
+    return metadata
+
+
+def extract_yaml_step_blocks(job_source: str) -> tuple[tuple[str, int], ...]:
+    lines = job_source.splitlines(keepends=True)
+    steps = [
+        (index, len(match.group("indent")))
+        for index, line in enumerate(lines)
+        if (match := re.match(r"^(?P<indent>\s*)steps\s*:\s*(?:#.*)?$", line))
+    ]
+    if len(steps) != 1:
+        raise AssertionError("Windows installer steps are unavailable")
+    steps_index, steps_indent = steps[0]
+    item_indent = steps_indent + 2
+    starts = [
+        index
+        for index in range(steps_index + 1, len(lines))
+        if re.match(rf"^\s{{{item_indent}}}-\s+", lines[index])
+    ]
+    if not starts:
+        raise AssertionError("Windows installer has no executable steps")
+    blocks: list[tuple[str, int]] = []
+    for offset, start in enumerate(starts):
+        end = starts[offset + 1] if offset + 1 < len(starts) else len(lines)
+        while end > start + 1 and not lines[end - 1].strip():
+            end -= 1
+        blocks.append(("".join(lines[start:end]), item_indent))
+    return tuple(blocks)
+
+
+def yaml_execution_metadata_is_live(metadata: dict[str, str]) -> bool:
+    if "if" in metadata:
+        return False
+    continue_on_error = metadata.get("continue-on-error")
+    return (
+        continue_on_error is None or continue_on_error.strip("'\"").lower() == "false"
+    )
+
+
+def direct_top_level_shell_statements(source: str) -> tuple[str, ...]:
+    lines = [line for line in source.splitlines() if line.strip()]
+    if not lines:
+        return ()
+    direct_indent = min(len(line) - len(line.lstrip()) for line in lines)
+    statements: list[str] = []
+    statement: list[str] = []
+    brace_depth = 0
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        code = re.sub(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'', "", stripped)
+        indentation = len(line) - len(line.lstrip())
+        if not statement and indentation != direct_indent:
+            continue
+        statement.append(stripped)
+        brace_depth += code.count("{") - code.count("}")
+        if brace_depth <= 0:
+            statements.append("\n".join(statement))
+            statement = []
+            brace_depth = 0
+    if statement:
+        statements.append("\n".join(statement))
+    return tuple(statements)
+
+
+def is_powershell_exit_check(statement: str, variable: str) -> bool:
+    reference = re.escape(variable)
+    return (
+        re.fullmatch(
+            rf"(?is)^\s*if\s*\(\s*{reference}\s+-ne\s+0\s*\)"
+            rf"\s*\{{\s*exit\s+{reference}\s*\}}\s*$",
+            statement,
+        )
+        is not None
+    )
+
+
+def powershell_can_bypass_successfully(source: str) -> bool:
+    transfer_prefix = r"(?i)(?:^|[;{}\n])\s*"
+    if re.search(transfer_prefix + r"return(?=\s|[;}]|$)", source):
+        return True
+    for exit_statement in re.finditer(
+        transfer_prefix + r"exit(?:\s+(?P<status>[^;}\n]+))?", source
+    ):
+        status = (exit_statement.group("status") or "").strip()
+        if re.fullmatch(r"[+-]?\d+", status) is None or int(status) == 0:
+            return True
+    return False
+
+
+def has_immediate_powershell_exit_propagation(
+    source: str,
+    command: re.Pattern,
+) -> bool:
+    statements = direct_top_level_shell_statements(source)
+    for index, statement in enumerate(statements):
+        if command.fullmatch(statement) is None:
+            continue
+        prior_code = "\n".join(statements[:index])
+        prior_code = re.sub(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'', "", prior_code)
+        prior_code = "\n".join(
+            line.split("#", 1)[0] for line in prior_code.splitlines()
+        )
+        if powershell_can_bypass_successfully(prior_code):
+            continue
+        next_index = index + 1
+        if next_index >= len(statements):
+            continue
+        if is_powershell_exit_check(statements[next_index], "$LASTEXITCODE"):
+            return True
+        capture = re.fullmatch(
+            r"(?i)^\s*(?P<variable>\$[A-Za-z_]\w*)\s*=\s*\$LASTEXITCODE\s*$",
+            statements[next_index],
+        )
+        if capture is None or next_index + 1 >= len(statements):
+            continue
+        if is_powershell_exit_check(
+            statements[next_index + 1], capture.group("variable")
+        ):
+            return True
+    return False
+
+
+def require_live_windows_workflow_commands(
+    job_source: str,
+    build_command: re.Pattern,
+    test_command: re.Pattern,
+) -> None:
+    job_metadata = direct_yaml_metadata(job_source, 4)
+    if not yaml_execution_metadata_is_live(job_metadata):
+        raise AssertionError("Windows durable-journal job is disabled or ignored")
+    runner = job_metadata.get("runs-on", "").strip("'\"").lower()
+    if runner != "windows-latest":
+        raise AssertionError("durable-journal job is not bound to Windows")
+    live_build = False
+    live_test = False
+    for block, item_indent in extract_yaml_step_blocks(job_source):
+        first = direct_yaml_metadata(block, item_indent, True)
+        remaining = direct_yaml_metadata(block, item_indent + 2)
+        metadata = {**first, **remaining}
+        shell = metadata.get("shell", "").strip("'\"").lower()
+        if shell and not re.match(r"^(?:powershell|pwsh)(?:\s|$)", shell):
+            continue
+        run_body = strip_shell_heredocs(extract_yaml_run_bodies(block))
+        has_build = has_immediate_powershell_exit_propagation(run_body, build_command)
+        has_test = has_immediate_powershell_exit_propagation(run_body, test_command)
+        if not (has_build or has_test):
+            continue
+        if not yaml_execution_metadata_is_live(metadata):
+            continue
+        live_build |= has_build
+        live_test |= has_test
+    if not (live_build and live_test):
+        raise AssertionError(
+            "Windows durable-journal commands are unavailable in live steps"
+        )
+
+
+def strip_shell_heredocs(source: str) -> str:
+    lines = source.splitlines(keepends=True)
+    kept: list[str] = []
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        here_string = re.search(r"@(?P<quote>['\"])\s*$", stripped)
+        if here_string:
+            terminator = here_string.group("quote") + "@"
+            index += 1
+            while index < len(lines) and lines[index].strip() != terminator:
+                index += 1
+            index += index < len(lines)
+            continue
+        heredoc = re.search(
+            r"<<-?\s*['\"]?(?P<end>[A-Za-z_][A-Za-z0-9_]*)['\"]?", lines[index]
+        )
+        if heredoc:
+            terminator = heredoc.group("end")
+            index += 1
+            while index < len(lines) and lines[index].strip() != terminator:
+                index += 1
+            index += index < len(lines)
+            continue
+        kept.append(lines[index])
+        index += 1
+    return "".join(kept)
+
+
+def require_compiler_selection_contract() -> None:
+    absolute_wrapper = "/fixture/toolchains/task020/c++ wrapper"
+    fallback = "c++"
+    lookups: list[str] = []
+
+    def fake_which(command: str) -> str | None:
+        lookups.append(command)
+        if command == absolute_wrapper:
+            return command
+        if command == fallback:
+            raise AssertionError("configured compiler fell back to PATH")
+        return None
+
+    configured = configured_compiler(
+        environment={"CXX": f'"{absolute_wrapper}" --task020-wrapper'},
+        which=fake_which,
+    )
+    if configured != [absolute_wrapper, "--task020-wrapper"]:
+        raise AssertionError("absolute configured compiler was not preserved")
+    if fallback in lookups:
+        raise AssertionError("configured compiler consulted the PATH fallback")
+
+    observed: list[tuple[list[str], Path]] = []
+
+    def recording_runner(command, **kwargs):
+        observed.append((command, kwargs["cwd"]))
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    output = Path("/fixture/output/durable-journal-public-seam")
+    failure = execute_public_seam(
+        output,
+        configured=configured,
+        environment={"MBEDCRYPTO_LIBRARY": "/fixture/libmbedcrypto.a"},
+        runner=recording_runner,
+    )
+    if failure is not None:
+        raise AssertionError(
+            "absolute configured compiler could not drive the public seam"
+        )
+    compile_commands = [
+        command for command, _cwd in observed if str(JOURNAL_SOURCE) in command
+    ]
+    if not compile_commands or any(
+        command[0] != absolute_wrapper for command in compile_commands
+    ):
+        raise AssertionError("public seam ignored the absolute configured compiler")
+    if any(command and command[0] == fallback for command, _cwd in observed):
+        raise AssertionError("public seam invoked the PATH fallback compiler")
+    if any(cwd != output.parent for _command, cwd in observed):
+        raise AssertionError("public seam escaped its temporary output directory")
+
+
+def require_command_contract() -> None:
+    output = Path("durable-journal-public-seam")
+    if os.name != "nt":
+        fallback = compiler_command(output, configured=["c++"], environment={})
+        if (
+            "-lmbedcrypto" not in fallback
+            or "-pthread" not in fallback
+            or f"-D{TESTING_DEFINITION}" not in fallback
+        ):
+            raise AssertionError("POSIX public seam omitted required link flags")
+        environment: Mapping[str, str] = {
+            "NLOHMANN_JSON_INCLUDE_DIR": "/fixture/nlohmann",
+            "MBEDTLS_INCLUDE_DIR": "/fixture/mbedtls",
+            "MBEDCRYPTO_LIBRARY": "/fixture/libmbedcrypto.a",
+        }
+        configured = compiler_command(
+            output, configured=["c++"], environment=environment
+        )
+        for include in (
+            str(INCLUDE_ROOT),
+            str(INTERNAL_INCLUDE_ROOT),
+            str(TEST_INCLUDE_ROOT),
+            "/fixture/nlohmann",
+            "/fixture/mbedtls",
+        ):
+            if include not in configured:
+                raise AssertionError(f"public seam omitted include {include}")
+        if "/fixture/libmbedcrypto.a" not in configured or "-lmbedcrypto" in configured:
+            raise AssertionError("public seam ignored configured mbedcrypto library")
+
+    environment = {
+        "NLOHMANN_JSON_INCLUDE_DIR": "C:/fixture/nlohmann",
+        "MBEDTLS_INCLUDE_DIR": "C:/fixture/mbedtls",
+        "MBEDCRYPTO_LIBRARY": "C:/fixture/mbedcrypto.lib",
+    }
+    command = compiler_command(output, configured=["cl.exe"], environment=environment)
+    for include in (
+        str(INCLUDE_ROOT),
+        str(INTERNAL_INCLUDE_ROOT),
+        str(TEST_INCLUDE_ROOT),
+        "C:/fixture/nlohmann",
+        "C:/fixture/mbedtls",
+    ):
+        if f"/I{include}" not in command:
+            raise AssertionError(f"MSVC public seam omitted include {include}")
+    if "C:/fixture/mbedcrypto.lib" not in command:
+        raise AssertionError("MSVC public seam ignored configured mbedcrypto library")
+    if f"/D{TESTING_DEFINITION}" not in command:
+        raise AssertionError("MSVC public seam omitted its test-only definition")
+
+    negative_posix = compile_only_command(
+        Path("forgery.cpp"), output, configured=["c++"]
+    )
+    ordered_system_includes = compile_only_command(
+        Path("forgery.cpp"),
+        output,
+        configured=["c++"],
+        system_includes=("/fixture/first", "/fixture/second"),
+    )
+    negative_msvc = compile_only_command(
+        Path("forgery.cpp"), output, configured=["cl.exe"]
+    )
+    if f"-U{TESTING_DEFINITION}" not in negative_posix or any(
+        token == f"-D{TESTING_DEFINITION}" for token in negative_posix
+    ):
+        raise AssertionError("POSIX forgery compile enabled test injection")
+    if f"/U{TESTING_DEFINITION}" not in negative_msvc or any(
+        token == f"/D{TESTING_DEFINITION}" for token in negative_msvc
+    ):
+        raise AssertionError("MSVC forgery compile enabled test injection")
+    if ordered_system_includes.index("/fixture/first") > (
+        ordered_system_includes.index("/fixture/second")
+    ):
+        raise AssertionError("POSIX system include precedence was reversed")
+    try:
+        compiler_command(output, configured=["cl.exe"], environment={})
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("MSVC public seam accepted a missing mbedcrypto library")
+
+    tokenized = split_compiler_command(
+        '"C:\\Program Files\\Microsoft Visual Studio\\VC\\cl.exe" /O2',
+        windows=True,
+    )
+    if tokenized != [
+        "C:\\Program Files\\Microsoft Visual Studio\\VC\\cl.exe",
+        "/O2",
+    ]:
+        raise AssertionError("Windows CXX tokenization is not path-safe")
+    if split_compiler_command("c++ -O2", windows=False) != ["c++", "-O2"]:
+        raise AssertionError("POSIX CXX tokenization drifted")
+
+
+def run_stage(
+    command: list[str],
+    *,
+    workdir: Path,
+    failed: str,
+    timed_out: str,
+    unavailable: str,
+    runner=subprocess.run,
+) -> str | None:
+    try:
+        completed = runner(
+            command,
+            cwd=workdir,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=PROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return timed_out
+    except (OSError, UnicodeError):
+        return unavailable
+    if completed.returncode != 0:
+        return failed
+    return None
+
+
+def execute_public_seam(
+    output: Path,
+    *,
+    configured: list[str],
+    environment: Mapping[str, str],
+    runner=subprocess.run,
+) -> str | None:
+    try:
+        command = compiler_command(
+            output,
+            configured=configured,
+            environment=environment,
+        )
+    except (RuntimeError, OSError, UnicodeError, ValueError):
+        return COMPILER_UNAVAILABLE
+    failure = run_stage(
+        command,
+        workdir=output.parent,
+        failed=COMPILATION_FAILED,
+        timed_out=COMPILATION_TIMED_OUT,
+        unavailable=COMPILER_UNAVAILABLE,
+        runner=runner,
+    )
+    if failure is not None:
+        return failure
+    return run_stage(
+        [str(output)],
+        workdir=output.parent,
+        failed=CONTRACT_ASSERTION_FAILED,
+        timed_out=EXECUTION_TIMED_OUT,
+        unavailable=EXECUTABLE_UNAVAILABLE,
+        runner=runner,
+    )
+
+
+def race_worker_status(stdout: bytes) -> bytes | None:
+    match = re.fullmatch(rb"(conflict_before_write|published)\r?\n", stdout)
+    return None if match is None else match.group(1)
+
+
+def require_race_worker_status_contract() -> None:
+    for status in (b"conflict_before_write", b"published"):
+        if race_worker_status(status + b"\n") != status:
+            raise AssertionError("POSIX race-worker status is unavailable")
+        if race_worker_status(status + b"\r\n") != status:
+            raise AssertionError("Windows race-worker status is unavailable")
+    for invalid in (
+        b"published",
+        b"published\n\n",
+        b"published\r\r\n",
+        b"published\nconflict_before_write\n",
+        b"unknown\n",
+    ):
+        if race_worker_status(invalid) is not None:
+            raise AssertionError("malformed race-worker status was accepted")
+
+
+def require_cross_process_cas(output: Path) -> str | None:
+    with tempfile.TemporaryDirectory(
+        prefix="durable-residency-journal-process-race-",
+        dir=output.parent,
+    ) as directory:
+        root = Path(directory)
+        authority = root / "authority"
+        controls = root / "controls"
+        authority.mkdir()
+        controls.mkdir()
+        floor = controls / "trusted-floor.json"
+        init_failure = run_stage(
+            [str(output), "--race-init", str(authority), str(floor)],
+            workdir=output.parent,
+            failed=CONTRACT_ASSERTION_FAILED,
+            timed_out=EXECUTION_TIMED_OUT,
+            unavailable=EXECUTABLE_UNAVAILABLE,
+        )
+        if init_failure is not None:
+            return init_failure
+
+        ready_files = [controls / "left.ready", controls / "right.ready"]
+        go_file = controls / "go"
+        workers: list[subprocess.Popen] = []
+        try:
+            for ready_file in ready_files:
+                workers.append(
+                    subprocess.Popen(
+                        [
+                            str(output),
+                            "--race-worker",
+                            str(authority),
+                            str(floor),
+                            str(ready_file),
+                            str(go_file),
+                        ],
+                        cwd=output.parent,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                )
+
+            ready_deadline = time.monotonic() + 30
+            while not all(path.is_file() for path in ready_files):
+                if any(worker.poll() is not None for worker in workers):
+                    return CONTRACT_ASSERTION_FAILED
+                if time.monotonic() >= ready_deadline:
+                    return EXECUTION_TIMED_OUT
+                time.sleep(0.01)
+
+            go_file.write_bytes(b"go\n")
+            outputs: list[bytes] = []
+            for worker in workers:
+                stdout, stderr = worker.communicate(timeout=PROCESS_TIMEOUT_SECONDS)
+                if worker.returncode != 0 or stderr:
+                    return CONTRACT_ASSERTION_FAILED
+                status = race_worker_status(stdout)
+                if status is None:
+                    return CONTRACT_ASSERTION_FAILED
+                outputs.append(status)
+            if sorted(outputs) != [b"conflict_before_write", b"published"]:
+                return CONTRACT_ASSERTION_FAILED
+        except subprocess.TimeoutExpired:
+            return EXECUTION_TIMED_OUT
+        except (OSError, UnicodeError):
+            return EXECUTABLE_UNAVAILABLE
+        finally:
+            for worker in workers:
+                if worker.poll() is None:
+                    worker.kill()
+                    try:
+                        worker.communicate(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        pass
+
+        return run_stage(
+            [str(output), "--race-verify", str(authority), str(floor)],
+            workdir=output.parent,
+            failed=CONTRACT_ASSERTION_FAILED,
+            timed_out=EXECUTION_TIMED_OUT,
+            unavailable=EXECUTABLE_UNAVAILABLE,
+        )
+
+
+def execute_existing_public_seam(
+    output: Path,
+    *,
+    stage_runner=run_stage,
+    race_runner=require_cross_process_cas,
+) -> str | None:
+    failure = stage_runner(
+        [str(output)],
+        workdir=output.parent,
+        failed=CONTRACT_ASSERTION_FAILED,
+        timed_out=EXECUTION_TIMED_OUT,
+        unavailable=EXECUTABLE_UNAVAILABLE,
+    )
+    if failure is not None:
+        return failure
+    return race_runner(output)
+
+
+def execute_hosted_public_seam(
+    output: Path,
+    compiler: list[str],
+    directory: Path,
+    *,
+    private_authority_gate: Path | None = None,
+    compile_runner=subprocess.run,
+    stage_runner=run_stage,
+    race_runner=require_cross_process_cas,
+) -> str | None:
+    if not (private_authority_gate is not None and is_msvc_frontend(compiler)):
+        failure = require_private_authority_construction(
+            directory,
+            configured=compiler,
+            runner=compile_runner,
+        )
+        if failure is not None:
+            return failure
+    return execute_existing_public_seam(
+        output,
+        stage_runner=stage_runner,
+        race_runner=race_runner,
+    )
+
+
+def require_existing_executable_contract() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="durable-residency-journal-hosted-contract-"
+    ) as temporary:
+        directory = Path(temporary)
+        output = directory / (
+            "durable-journal-public-seam.exe"
+            if os.name == "nt"
+            else "durable-journal-public-seam"
+        )
+        compiler = directory / "c++"
+        output.write_bytes(b"fixture executable")
+        compiler.write_bytes(b"fixture compiler")
+        gate_artifact = directory / "durable_journal_private_authority_gate.cpp.o"
+        gate_artifact.write_bytes(b"fixture object")
+        msvc_gate_artifact = directory / "durable_journal_private_authority_gate.obj"
+        msvc_gate_artifact.write_bytes(b"fixture object")
+        if os.name != "nt":
+            output.chmod(0o700)
+            compiler.chmod(0o700)
+
+        parsed_output, parsed_compiler, private_authority_gate = existing_executable(
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+                str(gate_artifact),
+            ]
+        )
+        if (
+            parsed_output != output
+            or parsed_compiler != [str(compiler)]
+            or private_authority_gate != gate_artifact
+        ):
+            raise AssertionError("hosted arguments changed executable identity")
+        _, _, parsed_msvc_gate = existing_executable(
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+                str(msvc_gate_artifact),
+            ]
+        )
+        if parsed_msvc_gate != msvc_gate_artifact:
+            raise AssertionError("MSVC build-gate artifact spelling was rejected")
+        if os.name != "nt":
+            executable_link = directory / "selected-executable-link"
+            compiler_link = directory / "selected-compiler-link"
+            executable_link.symlink_to(output)
+            compiler_link.symlink_to(compiler)
+            linked_output, linked_compiler, linked_private_authority_gate = (
+                existing_executable(
+                    [
+                        "--existing-executable",
+                        str(executable_link),
+                        "--compiler",
+                        str(compiler_link),
+                    ]
+                )
+            )
+            if (
+                linked_output != executable_link
+                or linked_compiler != [str(compiler_link)]
+                or linked_private_authority_gate
+            ):
+                raise AssertionError("hosted mode bypassed a selected wrapper")
+
+        invalid_arguments = (
+            [],
+            ["--existing-executable", str(output)],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "extra",
+            ],
+            [
+                "--compiler",
+                str(compiler),
+                "--existing-executable",
+                str(output),
+            ],
+            [
+                "--existing-executable",
+                output.name,
+                "--compiler",
+                str(compiler),
+            ],
+            [
+                "--existing-executable",
+                str(directory),
+                "--compiler",
+                str(compiler),
+            ],
+            [
+                "--existing-executable",
+                str(directory / "missing-executable"),
+                "--compiler",
+                str(compiler),
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                compiler.name,
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(directory),
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(directory / "missing-compiler"),
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--unknown-gate",
+                str(gate_artifact),
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+                "relative/gate.obj",
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+                str(directory / "missing-gate.obj"),
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+                str(directory),
+            ],
+            [
+                "--existing-executable",
+                str(output),
+                "--compiler",
+                str(compiler),
+                "--private-authority-gate",
+                str(output),
+            ],
+        )
+        for arguments in invalid_arguments:
+            try:
+                existing_executable(list(arguments))
+            except (AssertionError, RuntimeError):
+                pass
+            else:
+                raise AssertionError("hosted mode accepted invalid arguments")
+
+        observed: list[tuple[str, Path]] = []
+        compile_commands: list[list[str]] = []
+
+        def fake_compile(command, **kwargs):
+            compile_commands.append(command)
+            source = next(
+                (Path(token) for token in command if str(token).endswith(".cpp")),
+                None,
+            )
+            succeeded = (
+                source is not None
+                and source.name == "published_journal_positive_control.cpp"
+            )
+            return subprocess.CompletedProcess(
+                command,
+                0 if succeeded else 1,
+                b"",
+                b"",
+            )
+
+        def fake_stage(command, **kwargs):
+            observed.append(("semantic", Path(command[0])))
+            if kwargs["workdir"] != output.parent:
+                raise AssertionError("existing executable escaped its build directory")
+
+        def fake_race(executable):
+            observed.append(("race", executable))
+
+        failure = execute_hosted_public_seam(
+            output,
+            parsed_compiler,
+            directory,
+            private_authority_gate=private_authority_gate,
+            compile_runner=fake_compile,
+            stage_runner=fake_stage,
+            race_runner=fake_race,
+        )
+        if failure is not None or observed != [
+            ("semantic", output),
+            ("race", output),
+        ]:
+            raise AssertionError(
+                "existing-executable mode bypassed the semantic process race"
+            )
+        if not compile_commands or any(
+            command[0] != str(compiler) for command in compile_commands
+        ):
+            raise AssertionError("hosted mode ignored its explicit compiler")
+        forbidden_full_seam_inputs = {
+            str(JOURNAL_SOURCE),
+            str(DURABLE_SOURCE),
+            str(ADAPTER_COMMON),
+            str(native_adapter_source()),
+            str(TEST_SUPPORT),
+            str(PUBLIC_SEAM),
+        }
+        if any(
+            forbidden_full_seam_inputs.intersection(command)
+            for command in compile_commands
+        ):
+            raise AssertionError("hosted mode rebuilt the public seam")
+
+        msvc_compiler = directory / "cl.exe"
+        msvc_compiler.write_bytes(b"fixture compiler")
+        if os.name != "nt":
+            msvc_compiler.chmod(0o700)
+        compile_count = len(compile_commands)
+        observed.clear()
+        failure = execute_hosted_public_seam(
+            output,
+            [str(msvc_compiler)],
+            directory,
+            private_authority_gate=msvc_gate_artifact,
+            compile_runner=fake_compile,
+            stage_runner=fake_stage,
+            race_runner=fake_race,
+        )
+        if (
+            failure is not None
+            or len(compile_commands) != compile_count
+            or observed != [("semantic", output), ("race", output)]
+        ):
+            raise AssertionError("MSVC hosted mode ignored its CMake compile gate")
+        observed.clear()
+        failure = execute_hosted_public_seam(
+            output,
+            [str(msvc_compiler)],
+            directory,
+            private_authority_gate=None,
+            compile_runner=fake_compile,
+            stage_runner=fake_stage,
+            race_runner=fake_race,
+        )
+        if failure is not None or len(compile_commands) == compile_count:
+            raise AssertionError("MSVC hosted mode skipped an unproven compile gate")
+
+        race_called = False
+
+        def rejected_semantic(_command, **_kwargs):
+            return CONTRACT_ASSERTION_FAILED
+
+        def forbidden_race(_executable):
+            nonlocal race_called
+            race_called = True
+
+        failure = execute_existing_public_seam(
+            output,
+            stage_runner=rejected_semantic,
+            race_runner=forbidden_race,
+        )
+        if failure != CONTRACT_ASSERTION_FAILED or race_called:
+            raise AssertionError("hosted mode raced after semantic failure")
+
+
+def existing_executable(
+    arguments: list[str],
+) -> tuple[Path, list[str], Path | None]:
+    if (
+        len(arguments) not in (4, 6)
+        or arguments[0] != "--existing-executable"
+        or arguments[2] != "--compiler"
+        or (len(arguments) == 6 and arguments[4] != "--private-authority-gate")
+    ):
+        raise AssertionError("existing-executable arguments are invalid")
+    candidate = Path(arguments[1])
+    if not candidate.is_absolute() or not candidate.is_file():
+        raise AssertionError("existing executable is not an absolute regular file")
+    if not candidate.is_file() or (
+        os.name != "nt" and not os.access(candidate, os.X_OK)
+    ):
+        raise AssertionError("existing executable is not runnable")
+    private_authority_gate = None
+    if len(arguments) == 6:
+        private_authority_gate = Path(arguments[5])
+        if (
+            not private_authority_gate.is_absolute()
+            or not private_authority_gate.is_file()
+            or re.fullmatch(
+                r"durable_journal_private_authority_gate(?:\.cpp)?\.(?:o|obj)",
+                private_authority_gate.name,
+            )
+            is None
+        ):
+            raise AssertionError("private-authority build artifact is invalid")
+    return candidate, explicit_compiler(arguments[3]), private_authority_gate
+
+
+def failure_line(message: str) -> str:
+    rendered = f"{message}\n"
+    if rendered.count("\n") != 1 or len(rendered.encode("utf-8")) > 256:
+        raise AssertionError("public-seam failure line is not bounded")
+    return rendered
+
+
+def require_runner_failure_contract() -> None:
+    secret = "private-compiler-path/boom"
+    raw_output = f"raw tool output {secret}".encode()
+
+    class FakeRunner:
+        def __init__(self, outcomes):
+            self.outcomes = iter(outcomes)
+
+        def __call__(self, _command, **_kwargs):
+            outcome = next(self.outcomes)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+    successful = subprocess.CompletedProcess([], 0, b"", b"")
+    failed = subprocess.CompletedProcess([], 17, raw_output, raw_output)
+    timeout = subprocess.TimeoutExpired([secret], 1, output=raw_output)
+    invalid_utf8 = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
+    cases = [
+        ([OSError(secret)], COMPILER_UNAVAILABLE),
+        ([invalid_utf8], COMPILER_UNAVAILABLE),
+        ([failed], COMPILATION_FAILED),
+        ([timeout], COMPILATION_TIMED_OUT),
+        ([successful, failed], CONTRACT_ASSERTION_FAILED),
+        ([successful, timeout], EXECUTION_TIMED_OUT),
+        ([successful, OSError(secret)], EXECUTABLE_UNAVAILABLE),
+    ]
+    environment = {"MBEDCRYPTO_LIBRARY": "/fixture/libmbedcrypto.a"}
+    for outcomes, expected in cases:
+        observed = execute_public_seam(
+            Path("durable-journal-public-seam"),
+            configured=[f"/{secret}/c++"],
+            environment=environment,
+            runner=FakeRunner(outcomes),
+        )
+        if observed != expected:
+            raise AssertionError("public-seam failure classification drifted")
+        rendered = failure_line(observed)
+        if secret in rendered or "Traceback" in rendered:
+            raise AssertionError("public-seam failure leaked process details")
+
+
+def required_test_files() -> tuple[Path, ...]:
+    return (
+        RUNNER,
+        PUBLIC_SEAM,
+        PRIVATE_AUTHORITY_GATE,
+        TEST_SUPPORT,
+        TEST_SUPPORT_HEADER,
+    )
+
+
+def required_production_files() -> tuple[Path, ...]:
+    return (
+        DURABLE_HEADER,
+        DURABLE_SOURCE,
+        ADAPTER_HEADER,
+        ADAPTER_COMMON,
+        ADAPTER_POSIX,
+        ADAPTER_WINDOWS,
+        ADAPTER_MACOS,
+    )
+
+
+def main() -> int:
+    if any(not path.is_file() for path in required_test_files()):
+        sys.stderr.write(failure_line(CONTRACT_ASSERTION_FAILED))
+        return 1
+    if any(not path.is_file() for path in required_production_files()):
+        sys.stderr.write(failure_line(UNAVAILABLE))
+        return 1
+
+    try:
+        arguments = sys.argv[1:]
+        hosted: tuple[Path, list[str], Path | None] | None = None
+        if arguments:
+            hosted = existing_executable(arguments)
+        require_command_contract()
+        require_compiler_selection_contract()
+        require_runner_failure_contract()
+        require_race_worker_status_contract()
+        require_existing_executable_contract()
+        require_platform_source_contract()
+        require_build_contract()
+        with tempfile.TemporaryDirectory(
+            prefix="durable-residency-journal-"
+        ) as directory:
+            temporary = Path(directory)
+            if hosted is not None:
+                output, configured, private_authority_gate = hosted
+                failure = execute_hosted_public_seam(
+                    output,
+                    configured,
+                    temporary,
+                    private_authority_gate=private_authority_gate,
+                )
+            else:
+                configured = configured_compiler()
+                suffix = ".exe" if os.name == "nt" else ""
+                output = temporary / f"durable_journal_public_seam{suffix}"
+                failure = execute_public_seam(
+                    output,
+                    configured=configured,
+                    environment=os.environ,
+                )
+                if failure is None:
+                    failure = require_private_authority_construction(
+                        temporary,
+                        configured=configured,
+                    )
+                if failure is None:
+                    failure = require_cross_process_cas(output)
+    except AssertionError:
+        failure = CONTRACT_ASSERTION_FAILED
+    except (
+        RuntimeError,
+        OSError,
+        subprocess.TimeoutExpired,
+        UnicodeError,
+        ValueError,
+    ):
+        failure = COMPILER_UNAVAILABLE
+
+    if failure is not None:
+        sys.stderr.write(failure_line(failure))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_residency_implementation_handoff.py
+++ b/test/test_residency_implementation_handoff.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from collections.abc import Callable
 from pathlib import Path
+from unittest import mock
+
+from tools.residency_handoff.contract import HandoffError
+from tools.residency_handoff.validation import (
+    GitRepository,
+    RedFixtureObservation,
+    _apply_patch,
+    _patch_paths,
+    _patched_fixture_digests,
+    _red_fixture_metadata,
+    _red_fixture_metadata_v2,
+    _run_at_commit,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = REPO_ROOT / "tools" / "validate_residency_implementation_handoff.py"
@@ -44,6 +59,44 @@ LATER_UNIT_IDS = (
         for operation in ("ADM", "LFR", "STA", "REC", "UNL", "PIN")
     ),
 )
+TASK_020_COMMAND = [
+    "python3",
+    "-B",
+    "test/residency/recovery/test_durable_journal_public_seam.py",
+]
+TASK_020_FAILURE = "TASK-020 durable residency persistence contract is unavailable"
+TASK_020_BASE = "0c93411bc9b0463eee0f56d38cd97fffb0bae633"
+TASK_020_EVIDENCE = "27d2291335e3b334ba7436e2a3cd686bf34c61f7"
+TASK_020_BUNDLE = "4e9ff6284e599bfb3869d929416b2f915524eab14506620abd1d7fe95f93a650"
+TASK_020_PATCH_PATH = "plan/evidence/red-fixtures/TASK-020/test.patch"
+TASK_020_PATCH_SHA256 = (
+    "0e1dc4d01f848c19c41aade640b14f9ea656d00f358b8d82a58f8099fda12213"
+)
+TASK_020_RESULT_PATH = "plan/evidence/red-fixtures/TASK-020/result.json"
+TASK_020_FIXTURE_PATHS = (
+    "test/residency/recovery/durable_journal_private_authority_gate.cpp",
+    "test/residency/recovery/durable_journal_public_seam.cpp",
+    "test/residency/recovery/journal_persistence_test_support.cpp",
+    "test/residency/recovery/journal_persistence_test_support.h",
+    "test/residency/recovery/test_durable_journal_public_seam.py",
+)
+TASK_020_FIXTURE_SHA256 = {
+    TASK_020_FIXTURE_PATHS[0]: (
+        "9869521ed951ae3df9e9947d118665f65e3eda04edb854fd7711aa2160d31f63"
+    ),
+    TASK_020_FIXTURE_PATHS[1]: (
+        "5ecadcea7ac2c0ed17a4ae95474f0b46f6848acf780c1b418ddaa02ebf1af30e"
+    ),
+    TASK_020_FIXTURE_PATHS[2]: (
+        "27598da43517dbf829345a9d8cc2d1d61812a8669c21d25f3f4fd9217e827561"
+    ),
+    TASK_020_FIXTURE_PATHS[3]: (
+        "24f2a89d3b670708157d69c1fca5565fd72dc3ebaa69c11cd59f072f58334e01"
+    ),
+    TASK_020_FIXTURE_PATHS[4]: (
+        "8be11f9d6fa5fb7a22a2b50197a884855bad6d23739d3f44f2b23486730388a6"
+    ),
+}
 
 
 def _sha256(value: bytes) -> str:
@@ -714,6 +767,615 @@ class ResidencyImplementationHandoffCliTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("must change exactly the manifest path", result.stderr)
+
+
+class ResidencyImplementationHandoffV2Test(unittest.TestCase):
+    @staticmethod
+    def _inputs() -> tuple[GitRepository, dict[str, object], bytes]:
+        repo = GitRepository(REPO_ROOT)
+        metadata = json.loads(
+            repo.blob(TASK_020_EVIDENCE, TASK_020_RESULT_PATH).decode()
+        )
+        patch = repo.blob(TASK_020_EVIDENCE, TASK_020_PATCH_PATH)
+        return repo, metadata, patch
+
+    def _validate_metadata(
+        self,
+        metadata: dict[str, object],
+        *,
+        evidence_commit: str = TASK_020_EVIDENCE,
+        bundle_sha256: str = TASK_020_BUNDLE,
+        task_base: str = TASK_020_BASE,
+        command: list[str] | None = None,
+        patch_path: str = TASK_020_PATCH_PATH,
+        patch: bytes | None = None,
+    ) -> RedFixtureObservation:
+        repo, _, accepted_patch = self._inputs()
+        return _red_fixture_metadata_v2(
+            repo,
+            metadata,
+            evidence_commit,
+            bundle_sha256,
+            "TASK-020",
+            task_base,
+            TASK_020_COMMAND if command is None else command,
+            TASK_020_FAILURE,
+            patch_path,
+            accepted_patch if patch is None else patch,
+            list(TASK_020_FIXTURE_PATHS),
+            "task_evidence[TASK-020]",
+        )
+
+    def _assert_invalid(
+        self,
+        metadata_mutator: Callable[[dict[str, object]], None],
+        expected: str,
+    ) -> None:
+        _, metadata, _ = self._inputs()
+        metadata_mutator(metadata)
+        with self.assertRaises(HandoffError) as raised:
+            self._validate_metadata(metadata)
+        self.assertIn(expected, str(raised.exception))
+
+    def test_task020_v2_binds_exact_fixture_and_binary_red_result(self) -> None:
+        repo, _, patch = self._inputs()
+
+        self.assertEqual(_sha256(patch), TASK_020_PATCH_SHA256)
+        self.assertEqual(
+            _patched_fixture_digests(
+                repo,
+                TASK_020_BASE,
+                patch,
+                list(TASK_020_FIXTURE_PATHS),
+                "task_evidence[TASK-020]",
+            ),
+            TASK_020_FIXTURE_SHA256,
+        )
+
+        observed = _red_fixture_metadata(
+            repo,
+            TASK_020_EVIDENCE,
+            TASK_020_BUNDLE,
+            TASK_020_RESULT_PATH,
+            "TASK-020",
+            TASK_020_BASE,
+            TASK_020_COMMAND,
+            TASK_020_FAILURE,
+            TASK_020_PATCH_PATH,
+            patch,
+            list(TASK_020_FIXTURE_PATHS),
+            "task_evidence[TASK-020]",
+        )
+        replay = _run_at_commit(
+            repo,
+            TASK_020_BASE,
+            TASK_020_COMMAND,
+            patch,
+            text=False,
+        )
+
+        self.assertEqual(observed.exit_code, 1)
+        self.assertEqual(observed.stdout, b"")
+        self.assertEqual(observed.stderr, f"{TASK_020_FAILURE}\n".encode())
+        self.assertEqual(replay.returncode, observed.exit_code)
+        self.assertEqual(replay.stdout, observed.stdout)
+        self.assertEqual(replay.stderr, observed.stderr)
+
+    def test_task020_v2_missing_patched_fixture_fails_closed(self) -> None:
+        repo, _, patch = self._inputs()
+
+        with self.assertRaises(HandoffError) as raised:
+            _patched_fixture_digests(
+                repo,
+                TASK_020_BASE,
+                patch,
+                [*TASK_020_FIXTURE_PATHS, "test/residency/recovery/missing.cpp"],
+                "task_evidence[TASK-020]",
+            )
+
+        self.assertIn("missing.cpp cannot be read", str(raised.exception))
+
+    def test_git_materialization_ignores_ambient_attributes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            ambient = root / "ambient"
+            destination = root / "destination"
+            source.mkdir()
+            ambient.mkdir()
+            destination.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=source, check=True)
+            subprocess.run(["git", "init", "-q"], cwd=ambient, check=True)
+            (source / "fixture.cpp").write_bytes(b"frozen\n")
+            subprocess.run(["git", "add", "fixture.cpp"], cwd=source, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Residency Handoff Test",
+                    "-c",
+                    "user.email=residency-handoff@example.invalid",
+                    "commit",
+                    "-qm",
+                    "fixture",
+                ],
+                cwd=source,
+                check=True,
+            )
+            commit = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=source,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            (source / ".git" / "info").mkdir(parents=True, exist_ok=True)
+            (ambient / ".git" / "info").mkdir(parents=True, exist_ok=True)
+            (source / ".git" / "info" / "attributes").write_text(
+                "*.cpp export-ignore\n",
+                encoding="utf-8",
+            )
+            (ambient / ".git" / "info" / "attributes").write_text(
+                "*.cpp text eol=crlf\n",
+                encoding="utf-8",
+            )
+            template = root / "template"
+            (template / "info").mkdir(parents=True)
+            (template / "info" / "attributes").write_text(
+                "*.cpp text eol=crlf\n",
+                encoding="utf-8",
+            )
+            global_attributes = root / "global-attributes"
+            global_attributes.write_text(
+                "*.cpp text eol=crlf\n",
+                encoding="utf-8",
+            )
+            xdg = root / "xdg"
+            home = root / "home"
+            (xdg / "git").mkdir(parents=True)
+            home.mkdir()
+            (home / ".gitconfig").write_text("[broken\n", encoding="utf-8")
+            config = xdg / "git" / "config"
+            hooks = root / "hooks"
+            hooks.mkdir()
+            reference_transaction = hooks / "reference-transaction"
+            reference_transaction.write_text(
+                "#!/bin/sh\nexit 1\n",
+                encoding="utf-8",
+            )
+            reference_transaction.chmod(0o755)
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "--file",
+                    str(config),
+                    "init.templateDir",
+                    str(template),
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "--file",
+                    str(config),
+                    "core.hooksPath",
+                    str(hooks),
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "--file",
+                    str(config),
+                    "core.attributesFile",
+                    str(global_attributes),
+                ],
+                check=True,
+            )
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GIT_DIR": str(ambient / ".git"),
+                    "HOME": str(home),
+                    "XDG_CONFIG_HOME": str(xdg),
+                },
+            ):
+                GitRepository(source).materialize("HEAD", destination)
+
+            self.assertEqual(
+                (destination / "fixture.cpp").read_bytes(),
+                b"frozen\n",
+            )
+            self.assertFalse((destination / ".git" / "info" / "attributes").exists())
+            self.assertEqual(
+                subprocess.run(
+                    ["git", "rev-parse", "HEAD"],
+                    cwd=destination,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.strip(),
+                commit,
+            )
+
+    def test_git_materialization_rejects_committed_export_subst(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=source, check=True)
+            (source / ".gitattributes").write_text(
+                "fixture.txt export-subst\n",
+                encoding="utf-8",
+            )
+            (source / "fixture.txt").write_text(
+                "$Format:%H$\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "."], cwd=source, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Residency Handoff Test",
+                    "-c",
+                    "user.email=residency-handoff@example.invalid",
+                    "commit",
+                    "-qm",
+                    "fixture",
+                ],
+                cwd=source,
+                check=True,
+            )
+
+            with self.assertRaises(HandoffError) as raised:
+                GitRepository(source).materialize("HEAD", destination)
+
+            self.assertIn("export-subst", str(raised.exception))
+            self.assertIn("fixture.txt", str(raised.exception))
+            self.assertEqual(list(destination.iterdir()), [])
+
+    def test_git_materialization_rejects_committed_export_ignore(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=source, check=True)
+            (source / ".gitattributes").write_text(
+                "omitted.txt export-ignore\n",
+                encoding="utf-8",
+            )
+            (source / "omitted.txt").write_text("frozen\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=source, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Residency Handoff Test",
+                    "-c",
+                    "user.email=residency-handoff@example.invalid",
+                    "commit",
+                    "-qm",
+                    "fixture",
+                ],
+                cwd=source,
+                check=True,
+            )
+
+            with self.assertRaises(HandoffError) as raised:
+                GitRepository(source).materialize("HEAD", destination)
+
+            self.assertIn("export-ignore", str(raised.exception))
+            self.assertIn("omitted.txt", str(raised.exception))
+            self.assertEqual(list(destination.iterdir()), [])
+
+    def test_git_repository_queries_ignore_ambient_global_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            home = root / "home"
+            xdg = root / "xdg"
+            source.mkdir()
+            home.mkdir()
+            xdg.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=source, check=True)
+            (source / "fixture.txt").write_text("fixture\n", encoding="utf-8")
+            subprocess.run(["git", "add", "fixture.txt"], cwd=source, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Residency Handoff Test",
+                    "-c",
+                    "user.email=residency-handoff@example.invalid",
+                    "commit",
+                    "-qm",
+                    "fixture",
+                ],
+                cwd=source,
+                check=True,
+            )
+            commit = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=source,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            (home / ".gitconfig").write_text("[broken\n", encoding="utf-8")
+
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": str(home), "XDG_CONFIG_HOME": str(xdg)},
+            ):
+                repo = GitRepository.discover(source)
+                self.assertEqual(repo.resolve("HEAD"), commit)
+                self.assertTrue(repo.is_ancestor(commit, commit))
+
+    def test_git_repository_ignores_replace_refs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            fixture_path = source / "fixture.txt"
+
+            def git(*arguments: str, cwd: Path = source) -> str:
+                return subprocess.run(
+                    ["git", *arguments],
+                    cwd=cwd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.strip()
+
+            def commit(contents: str, message: str) -> str:
+                fixture_path.write_text(contents, encoding="utf-8")
+                git("add", "fixture.txt")
+                git("commit", "-qm", message)
+                return git("rev-parse", "HEAD")
+
+            git("init", "-q")
+            git("config", "user.name", "Residency Handoff Test")
+            git("config", "user.email", "residency-handoff@example.invalid")
+            original_parent = commit("original parent\n", "original parent")
+            original = commit("original\n", "original")
+
+            git("checkout", "-q", "--orphan", "replacement")
+            git("rm", "-q", "-rf", ".")
+            replacement_parent = commit("replacement parent\n", "replacement parent")
+            replacement = commit("replacement\n", "replacement")
+            git("replace", original, replacement)
+
+            self.assertEqual(git("show", f"{original}:fixture.txt"), "replacement")
+            replaced_history = git("rev-list", "--parents", "-n", "1", original).split()
+            self.assertEqual(replaced_history, [original, replacement_parent])
+
+            repo = GitRepository(source)
+            self.assertEqual(repo.blob(original, "fixture.txt"), b"original\n")
+            self.assertEqual(repo.parents(original), [original_parent])
+            repo.materialize(original, destination)
+            self.assertEqual((destination / "fixture.txt").read_bytes(), b"original\n")
+            self.assertEqual(git("rev-parse", "HEAD", cwd=destination), original)
+            self.assertEqual(
+                git(
+                    "rev-list", "--parents", "-n", "1", original, cwd=destination
+                ).split(),
+                [original, original_parent],
+            )
+
+    def test_patch_inspection_ignores_ambient_global_config(self) -> None:
+        patch = b"""diff --git a/fixture.txt b/fixture.txt
+new file mode 100644
+--- /dev/null
++++ b/fixture.txt
+@@ -0,0 +1 @@
++fixture
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            xdg = root / "xdg"
+            home.mkdir()
+            xdg.mkdir()
+            (home / ".gitconfig").write_text("[broken\n", encoding="utf-8")
+
+            with mock.patch.dict(
+                os.environ,
+                {"HOME": str(home), "XDG_CONFIG_HOME": str(xdg)},
+            ):
+                self.assertEqual(_patch_paths(patch, "fixture patch"), ["fixture.txt"])
+
+    def test_task020_patch_application_preserves_checkout_control_path(
+        self,
+    ) -> None:
+        patch = b"""diff --git a/fixture.txt b/fixture.txt
+--- a/fixture.txt
++++ b/fixture.txt
+@@ -1 +1 @@
+-old
++new
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            checkout = Path(directory)
+            control = checkout / ".handoff-red.patch"
+            fixture = checkout / "fixture.txt"
+            control.write_bytes(b"checkout-owned\n")
+            fixture.write_bytes(b"old\n")
+
+            _apply_patch(checkout, patch, "fixture patch does not apply")
+
+            self.assertEqual(control.read_bytes(), b"checkout-owned\n")
+            self.assertEqual(fixture.read_bytes(), b"new\n")
+
+    def test_task020_patch_application_ignores_ambient_line_endings(self) -> None:
+        patch = b"""diff --git a/fixture.cpp b/fixture.cpp
+new file mode 100644
+--- /dev/null
++++ b/fixture.cpp
+@@ -0,0 +1 @@
++frozen
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            checkout = Path(directory) / "checkout"
+            ambient = Path(directory) / "ambient"
+            checkout.mkdir()
+            ambient.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+            subprocess.run(["git", "init", "-q"], cwd=ambient, check=True)
+            (checkout / ".gitattributes").write_text(
+                "*.cpp text eol=crlf\n",
+                encoding="utf-8",
+            )
+            subprocess.run(
+                ["git", "config", "core.autocrlf", "true"],
+                cwd=checkout,
+                check=True,
+            )
+            attributes = checkout / "local-attributes"
+            attributes.write_text("*.cpp text eol=crlf\n", encoding="utf-8")
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "core.attributesFile",
+                    str(attributes),
+                ],
+                cwd=checkout,
+                check=True,
+            )
+            (ambient / ".git" / "info").mkdir(parents=True, exist_ok=True)
+            (ambient / ".git" / "info" / "attributes").write_text(
+                "*.cpp text eol=crlf\n",
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(
+                os.environ,
+                {"GIT_DIR": str(ambient / ".git")},
+            ):
+                _apply_patch(checkout, patch, "fixture patch does not apply")
+
+            self.assertEqual((checkout / "fixture.cpp").read_bytes(), b"frozen\n")
+
+    def test_task020_v2_is_closed_and_content_addressed(self) -> None:
+        cases: tuple[tuple[Callable[[dict[str, object]], None], str], ...] = (
+            (
+                lambda metadata: metadata.__setitem__("unknown", True),
+                "keys differ",
+            ),
+            (
+                lambda metadata: metadata.__setitem__(
+                    "schema", "portable_residency_red_fixture_result/v1"
+                ),
+                "schema is unsupported",
+            ),
+            (
+                lambda metadata: metadata.__setitem__(
+                    "fallback_state", "legacy_cutover_active"
+                ),
+                "fallback_state must be 'production_cutover_inactive'",
+            ),
+            (
+                lambda metadata: metadata.__setitem__("task_base_commit", "0" * 40),
+                "identity does not match the task",
+            ),
+            (
+                lambda metadata: metadata["patch"].__setitem__(
+                    "path", "plan/evidence/red-fixtures/TASK-020/other.patch"
+                ),
+                "patch identity does not match the record",
+            ),
+            (
+                lambda metadata: metadata["fixture_sha256"].__setitem__(
+                    TASK_020_FIXTURE_PATHS[0], "0" * 64
+                ),
+                "fixture_sha256 does not match patched bytes",
+            ),
+            (
+                lambda metadata: metadata["observed_result"]["stderr"].update(
+                    {
+                        "hex": "00" * len((TASK_020_FAILURE + "\n").encode()),
+                        "sha256": _sha256(
+                            b"\0" * len((TASK_020_FAILURE + "\n").encode())
+                        ),
+                    }
+                ),
+                "streams differ from the accepted TASK-020 RED",
+            ),
+            (
+                lambda metadata: metadata["observed_result"].__setitem__(
+                    "exit_code", True
+                ),
+                "exit_code must be 1",
+            ),
+            (
+                lambda metadata: metadata["observed_result"].__setitem__(
+                    "exit_code", 1.0
+                ),
+                "exit_code must be 1",
+            ),
+        )
+        for mutator, expected in cases:
+            with self.subTest(expected=expected):
+                self._assert_invalid(mutator, expected)
+
+    def test_task020_v2_command_requires_python_no_bytecode_mode(self) -> None:
+        command = [
+            "python3",
+            "test/residency/recovery/test_durable_journal_public_seam.py",
+        ]
+
+        _, metadata, _ = self._inputs()
+        metadata["command"] = command
+        with self.assertRaises(HandoffError) as raised:
+            self._validate_metadata(metadata, command=command)
+
+        self.assertIn(
+            "must use the exact accepted TASK-020 command",
+            str(raised.exception),
+        )
+
+    def test_task020_v2_rejects_rebound_record_identities(self) -> None:
+        _, metadata, patch = self._inputs()
+        cases = (
+            (
+                {"evidence_commit": "0" * 40},
+                "evidence_commit is not the frozen TASK-020 RED",
+            ),
+            (
+                {"bundle_sha256": "0" * 64},
+                "bundle_sha256 is not the frozen TASK-020 bundle",
+            ),
+            (
+                {"task_base": "0" * 40},
+                "task_base_commit is not the frozen TASK-020 base",
+            ),
+            (
+                {"patch_path": "plan/evidence/red-fixtures/TASK-020/other.patch"},
+                "patch is not the frozen TASK-020 patch",
+            ),
+            (
+                {"patch": patch + b"\n"},
+                "patch is not the frozen TASK-020 patch",
+            ),
+        )
+        for overrides, expected in cases:
+            with self.subTest(expected=expected):
+                with self.assertRaises(HandoffError) as raised:
+                    self._validate_metadata(metadata, **overrides)
+                self.assertIn(expected, str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/tools/residency_handoff/validation.py
+++ b/tools/residency_handoff/validation.py
@@ -8,7 +8,9 @@ import re
 import subprocess
 import tarfile
 import tempfile
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -16,10 +18,54 @@ from typing import Any
 from .contract import canonical_digest, fail, load_manifest, sha256_bytes
 
 SCHEMA = "portable_residency_implementation_handoff/v1"
+RED_FIXTURE_SCHEMA_V1 = "portable_residency_red_fixture_result/v1"
+RED_FIXTURE_SCHEMA_V2 = "portable_residency_red_fixture_result/v2"
 HEX_DIGEST = re.compile(r"^[0-9a-f]{64}$")
 GIT_OBJECT = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 TASK_ID = re.compile(r"^TASK-[0-9]{3}$")
 ALLOWED_COMMANDS = {"cmake", "ctest", "python3"}
+TASK_020_COMMAND = (
+    "python3",
+    "-B",
+    "test/residency/recovery/test_durable_journal_public_seam.py",
+)
+TASK_020_FAILURE_SIGNATURE = (
+    "TASK-020 durable residency persistence contract is unavailable"
+)
+TASK_020_FALLBACK_STATE = "production_cutover_inactive"
+TASK_020_TASK_BASE_COMMIT = "0c93411bc9b0463eee0f56d38cd97fffb0bae633"
+TASK_020_EVIDENCE_COMMIT = "27d2291335e3b334ba7436e2a3cd686bf34c61f7"
+TASK_020_BUNDLE_SHA256 = (
+    "4e9ff6284e599bfb3869d929416b2f915524eab14506620abd1d7fe95f93a650"
+)
+TASK_020_PATCH_PATH = "plan/evidence/red-fixtures/TASK-020/test.patch"
+TASK_020_PATCH_SHA256 = (
+    "0e1dc4d01f848c19c41aade640b14f9ea656d00f358b8d82a58f8099fda12213"
+)
+TASK_020_FIXTURE_PATHS = (
+    "test/residency/recovery/durable_journal_private_authority_gate.cpp",
+    "test/residency/recovery/durable_journal_public_seam.cpp",
+    "test/residency/recovery/journal_persistence_test_support.cpp",
+    "test/residency/recovery/journal_persistence_test_support.h",
+    "test/residency/recovery/test_durable_journal_public_seam.py",
+)
+TASK_020_FIXTURE_SHA256 = {
+    TASK_020_FIXTURE_PATHS[0]: (
+        "9869521ed951ae3df9e9947d118665f65e3eda04edb854fd7711aa2160d31f63"
+    ),
+    TASK_020_FIXTURE_PATHS[1]: (
+        "5ecadcea7ac2c0ed17a4ae95474f0b46f6848acf780c1b418ddaa02ebf1af30e"
+    ),
+    TASK_020_FIXTURE_PATHS[2]: (
+        "27598da43517dbf829345a9d8cc2d1d61812a8669c21d25f3f4fd9217e827561"
+    ),
+    TASK_020_FIXTURE_PATHS[3]: (
+        "24f2a89d3b670708157d69c1fca5565fd72dc3ebaa69c11cd59f072f58334e01"
+    ),
+    TASK_020_FIXTURE_PATHS[4]: (
+        "8be11f9d6fa5fb7a22a2b50197a884855bad6d23739d3f44f2b23486730388a6"
+    ),
+}
 LATER_ROSTER_PATH = "docs/research/portable-residency-capability-inventory.json"
 EXPECTED_PHASE_TASKS = {
     0: ("TASK-093", "TASK-006", "TASK-007", "TASK-108", "TASK-109"),
@@ -123,10 +169,35 @@ REQUIRED_SEAMS = {
 }
 
 
+@dataclass(frozen=True)
+class RedFixtureObservation:
+    exit_code: int
+    stdout: bytes | None = None
+    stderr: bytes | None = None
+
+
 def _without_git_environment() -> dict[str, str]:
     return {
         key: value for key, value in os.environ.items() if not key.startswith("GIT_")
     }
+
+
+def _git_environment(global_config: Path) -> dict[str, str]:
+    return {
+        **_without_git_environment(),
+        "GIT_ATTR_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": str(global_config),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+    }
+
+
+@contextmanager
+def _isolated_git_environment() -> Iterator[dict[str, str]]:
+    with tempfile.TemporaryDirectory(
+        prefix="residency-handoff-git-config-"
+    ) as directory:
+        yield _git_environment(Path(directory) / "global-config")
 
 
 class GitRepository:
@@ -135,23 +206,27 @@ class GitRepository:
 
     @classmethod
     def discover(cls, start: Path) -> GitRepository:
-        result = subprocess.run(
-            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        with _isolated_git_environment() as environment:
+            result = subprocess.run(
+                ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
         if result.returncode:
             fail(f"cannot locate Git repository: {result.stderr.strip()}")
         return cls(Path(result.stdout.strip()))
 
     def run(self, *args: str, text: bool = True) -> str | bytes:
-        result = subprocess.run(
-            ["git", "-C", str(self.root), *args],
-            capture_output=True,
-            text=text,
-            check=False,
-        )
+        with _isolated_git_environment() as environment:
+            result = subprocess.run(
+                ["git", "-C", str(self.root), *args],
+                capture_output=True,
+                text=text,
+                check=False,
+                env=environment,
+            )
         if result.returncode:
             stderr = result.stderr if text else result.stderr.decode("utf-8", "replace")
             fail(f"git {' '.join(args)} failed: {stderr.strip()}")
@@ -171,19 +246,21 @@ class GitRepository:
         return line.split()[1:]
 
     def is_ancestor(self, ancestor: str, descendant: str) -> bool:
-        result = subprocess.run(
-            [
-                "git",
-                "-C",
-                str(self.root),
-                "merge-base",
-                "--is-ancestor",
-                ancestor,
-                descendant,
-            ],
-            capture_output=True,
-            check=False,
-        )
+        with _isolated_git_environment() as environment:
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(self.root),
+                    "merge-base",
+                    "--is-ancestor",
+                    ancestor,
+                    descendant,
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
         return result.returncode == 0
 
     def changed_paths(self, parent: str, commit: str) -> list[str]:
@@ -193,7 +270,161 @@ class GitRepository:
         return [line for line in output.splitlines() if line]
 
     def materialize(self, commit: str, destination: Path) -> None:
-        archive = bytes(self.run("archive", "--format=tar", commit, text=False))
+        resolved_commit = self.resolve(commit)
+        object_format = str(self.run("rev-parse", "--show-object-format")).strip()
+        if object_format not in {"sha1", "sha256"}:
+            fail(f"unsupported source repository object format {object_format!r}")
+        object_path = Path(str(self.run("rev-parse", "--git-path", "objects")).strip())
+        if not object_path.is_absolute():
+            object_path = self.root / object_path
+
+        with (
+            tempfile.TemporaryDirectory(
+                prefix="residency-handoff-archive-repository-"
+            ) as archive_directory,
+            tempfile.TemporaryDirectory(
+                prefix="residency-handoff-empty-git-template-"
+            ) as template_directory,
+            tempfile.TemporaryDirectory(
+                prefix="residency-handoff-git-config-"
+            ) as config_directory,
+        ):
+            archive_repository = Path(archive_directory)
+            environment = _git_environment(Path(config_directory) / "global-config")
+            initialized_archive = subprocess.run(
+                [
+                    "git",
+                    "init",
+                    "-q",
+                    "--bare",
+                    f"--object-format={object_format}",
+                    f"--template={template_directory}",
+                ],
+                cwd=archive_repository,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+            if initialized_archive.returncode:
+                fail(
+                    "cannot initialize archive repository: "
+                    f"{initialized_archive.stderr.strip()}"
+                )
+            archive_alternates = archive_repository / "objects" / "info" / "alternates"
+            archive_alternates.write_text(
+                f"{object_path.resolve()}\n",
+                encoding="utf-8",
+            )
+            bound_index = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={archive_repository}",
+                    "read-tree",
+                    resolved_commit,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+            if bound_index.returncode:
+                fail(
+                    "cannot bind archive attributes to source tree: "
+                    f"{bound_index.stderr.strip()}"
+                )
+            listed_paths = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={archive_repository}",
+                    "ls-tree",
+                    "-r",
+                    "-t",
+                    "-z",
+                    "--name-only",
+                    resolved_commit,
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            if listed_paths.returncode:
+                fail(
+                    "cannot enumerate source tree for archive attributes: "
+                    f"{listed_paths.stderr.decode('utf-8', 'replace').strip()}"
+                )
+            checked_attributes = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={archive_repository}",
+                    "check-attr",
+                    "--cached",
+                    "-z",
+                    "export-subst",
+                    "export-ignore",
+                    "--stdin",
+                ],
+                input=listed_paths.stdout,
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            if checked_attributes.returncode:
+                fail(
+                    "cannot inspect source tree archive attributes: "
+                    f"{checked_attributes.stderr.decode('utf-8', 'replace').strip()}"
+                )
+            attribute_fields = checked_attributes.stdout.split(b"\0")
+            if attribute_fields[-1:] != [b""]:
+                fail("malformed Git archive attribute output")
+            attribute_fields.pop()
+            if len(attribute_fields) % 3:
+                fail("malformed Git archive attribute output")
+            for index in range(0, len(attribute_fields), 3):
+                path, attribute, value = attribute_fields[index : index + 3]
+                if value not in {b"unspecified", b"unset"}:
+                    fail(
+                        f"committed Git attribute {attribute.decode('ascii')} "
+                        f"is set for archive path {path!r}"
+                    )
+            archived = subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "core.attributesFile=",
+                    f"--git-dir={archive_repository}",
+                    "archive",
+                    "--format=tar",
+                    resolved_commit,
+                ],
+                capture_output=True,
+                check=False,
+                env=environment,
+            )
+            if archived.returncode:
+                fail(
+                    "cannot archive replay repository: "
+                    f"{archived.stderr.decode('utf-8', 'replace').strip()}"
+                )
+            archive = archived.stdout
+
+            initialized = subprocess.run(
+                [
+                    "git",
+                    "init",
+                    "-q",
+                    f"--object-format={object_format}",
+                    f"--template={template_directory}",
+                ],
+                cwd=destination,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+        if initialized.returncode:
+            fail(f"cannot initialize replay repository: {initialized.stderr.strip()}")
+
         with tarfile.open(fileobj=BytesIO(archive), mode="r:") as source:
             for member in source.getmembers():
                 path = PurePosixPath(member.name)
@@ -205,29 +436,11 @@ class GitRepository:
                 ):
                     fail(f"unsafe path in Git archive: {member.name!r}")
             source.extractall(destination, filter="data")
-
-        environment = _without_git_environment()
-        object_format = str(self.run("rev-parse", "--show-object-format")).strip()
-        if object_format not in {"sha1", "sha256"}:
-            fail(f"unsupported source repository object format {object_format!r}")
-        object_path = Path(str(self.run("rev-parse", "--git-path", "objects")).strip())
-        if not object_path.is_absolute():
-            object_path = self.root / object_path
-        initialized = subprocess.run(
-            ["git", "init", "-q", f"--object-format={object_format}"],
-            cwd=destination,
-            capture_output=True,
-            text=True,
-            check=False,
-            env=environment,
-        )
-        if initialized.returncode:
-            fail(f"cannot initialize replay repository: {initialized.stderr.strip()}")
         alternates = destination / ".git" / "objects" / "info" / "alternates"
         alternates.write_text(f"{object_path.resolve()}\n", encoding="utf-8")
         for arguments in (
-            ("update-ref", "--no-deref", "HEAD", commit),
-            ("read-tree", commit),
+            ("update-ref", "--no-deref", "HEAD", resolved_commit),
+            ("read-tree", resolved_commit),
         ):
             prepared = subprocess.run(
                 ["git", *arguments],
@@ -752,41 +965,31 @@ def _run_at_commit(
     commit: str,
     command: list[str],
     patch: bytes | None = None,
-) -> subprocess.CompletedProcess[str]:
+    *,
+    text: bool = True,
+) -> subprocess.CompletedProcess[Any]:
     with tempfile.TemporaryDirectory(prefix="residency-handoff-") as directory:
         checkout = Path(directory)
         repo.materialize(commit, checkout)
         if patch is not None:
-            patch_path = checkout / ".handoff-red.patch"
-            patch_path.write_bytes(patch)
-            applied = subprocess.run(
-                [
-                    "git",
-                    "apply",
-                    "--whitespace=nowarn",
-                    "--unidiff-zero",
-                    str(patch_path),
-                ],
-                cwd=checkout,
-                capture_output=True,
-                text=True,
-                check=False,
+            _apply_patch(
+                checkout,
+                patch,
+                "red fixture patch does not apply",
             )
-            patch_path.unlink()
-            if applied.returncode:
-                fail(f"red fixture patch does not apply: {applied.stderr.strip()}")
-        try:
-            return subprocess.run(
-                command,
-                cwd=checkout,
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=120,
-                env={**_without_git_environment(), "PYTHONDONTWRITEBYTECODE": "1"},
-            )
-        except subprocess.TimeoutExpired:
-            fail(f"fixture command timed out: {command!r}")
+        with _isolated_git_environment() as environment:
+            try:
+                return subprocess.run(
+                    command,
+                    cwd=checkout,
+                    capture_output=True,
+                    text=text,
+                    check=False,
+                    timeout=120,
+                    env={**environment, "PYTHONDONTWRITEBYTECODE": "1"},
+                )
+            except subprocess.TimeoutExpired:
+                fail(f"fixture command timed out: {command!r}")
 
 
 def _json_object_bytes(source: bytes, label: str) -> dict[str, Any]:
@@ -804,20 +1007,22 @@ def _patch_paths(patch: bytes, label: str) -> list[str]:
     with tempfile.TemporaryDirectory(prefix="residency-handoff-numstat-") as directory:
         patch_path = Path(directory) / "fixture.patch"
         patch_path.write_bytes(patch)
-        result = subprocess.run(
-            [
-                "git",
-                "apply",
-                "--whitespace=nowarn",
-                "--unidiff-zero",
-                "--numstat",
-                str(patch_path),
-            ],
-            cwd=directory,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        with _isolated_git_environment() as environment:
+            result = subprocess.run(
+                [
+                    "git",
+                    "apply",
+                    "--whitespace=nowarn",
+                    "--unidiff-zero",
+                    "--numstat",
+                    str(patch_path),
+                ],
+                cwd=directory,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
     if result.returncode:
         fail(f"{label} cannot be inspected: {result.stderr.strip()}")
     paths: list[str] = []
@@ -831,19 +1036,278 @@ def _patch_paths(patch: bytes, label: str) -> list[str]:
     return paths
 
 
+def _apply_patch(checkout: Path, patch: bytes, failure: str) -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="residency-handoff-patch-file-"
+    ) as directory:
+        patch_path = Path(directory) / "fixture.patch"
+        patch_path.write_bytes(patch)
+        applied = subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.autocrlf=false",
+                "-c",
+                "core.attributesFile=",
+                "apply",
+                "--no-index",
+                "--whitespace=nowarn",
+                "--unidiff-zero",
+                str(patch_path),
+            ],
+            cwd=checkout,
+            capture_output=True,
+            text=True,
+            check=False,
+            env={
+                **_git_environment(Path(directory) / "global-config"),
+                "GIT_DIR": str(Path(directory) / "no-repository"),
+            },
+        )
+    if applied.returncode:
+        fail(f"{failure}: {applied.stderr.strip()}")
+
+
+def _fixture_bytes(checkout: Path, path: str, label: str) -> bytes:
+    try:
+        return (checkout / path).read_bytes()
+    except OSError as error:
+        fail(f"{label} cannot be read: {error}")
+
+
+def _stream_bytes(value: Any, label: str) -> bytes:
+    stream = _mapping(value, label)
+    _exact_keys(stream, {"byte_count", "hex", "sha256"}, label)
+    byte_count = stream["byte_count"]
+    if (
+        isinstance(byte_count, bool)
+        or not isinstance(byte_count, int)
+        or byte_count < 0
+    ):
+        fail(f"{label}.byte_count must be a nonnegative integer")
+    encoded = stream["hex"]
+    if (
+        not isinstance(encoded, str)
+        or re.fullmatch(r"(?:[0-9a-f]{2})*", encoded) is None
+    ):
+        fail(f"{label}.hex must be lowercase hexadecimal bytes")
+    decoded = bytes.fromhex(encoded)
+    if len(decoded) != byte_count:
+        fail(f"{label}.byte_count does not match its bytes")
+    if sha256_bytes(decoded) != _digest(stream["sha256"], f"{label}.sha256"):
+        fail(f"{label}.sha256 does not match its bytes")
+    return decoded
+
+
+def _patched_fixture_digests(
+    repo: GitRepository,
+    base: str,
+    patch: bytes,
+    test_paths: list[str],
+    label: str,
+) -> dict[str, str]:
+    with tempfile.TemporaryDirectory(
+        prefix="residency-handoff-v2-fixtures-"
+    ) as directory:
+        checkout = Path(directory)
+        repo.materialize(base, checkout)
+        _apply_patch(checkout, patch, f"{label} does not apply")
+        return {
+            path: sha256_bytes(
+                _fixture_bytes(checkout, path, f"{label} fixture {path}")
+            )
+            for path in test_paths
+        }
+
+
+def _red_fixture_metadata_v2(
+    repo: GitRepository,
+    metadata: dict[str, Any],
+    evidence_commit: str,
+    bundle_sha256: str,
+    task_id: str,
+    task_base: str,
+    command: list[str],
+    failure_signature: str,
+    patch_path: str,
+    patch: bytes,
+    test_paths: list[str],
+    label: str,
+) -> RedFixtureObservation:
+    metadata_label = f"{label} red fixture metadata"
+    _exact_keys(
+        metadata,
+        {
+            "command",
+            "environment",
+            "fallback_state",
+            "fixture_sha256",
+            "observed_result",
+            "patch",
+            "schema",
+            "task_base_commit",
+            "task_id",
+        },
+        metadata_label,
+    )
+    if metadata["schema"] != RED_FIXTURE_SCHEMA_V2:
+        fail(f"{metadata_label} schema is unsupported")
+    if task_id != "TASK-020":
+        fail(f"{metadata_label} v2 is reserved for TASK-020")
+    if evidence_commit != TASK_020_EVIDENCE_COMMIT:
+        fail(f"{label}.red_fixture.evidence_commit is not the frozen TASK-020 RED")
+    if bundle_sha256 != TASK_020_BUNDLE_SHA256:
+        fail(f"{label}.red_fixture.bundle_sha256 is not the frozen TASK-020 bundle")
+    if task_base != TASK_020_TASK_BASE_COMMIT:
+        fail(f"{label}.task_base_commit is not the frozen TASK-020 base")
+    if metadata["task_id"] != task_id or metadata["task_base_commit"] != task_base:
+        fail(f"{label} red fixture metadata identity does not match the task")
+    metadata_command = _command(metadata["command"], f"{label} metadata.command")
+    if metadata_command != command:
+        fail(f"{label} red fixture metadata command does not match the record")
+    if tuple(metadata_command) != TASK_020_COMMAND:
+        fail(
+            f"{label} red fixture metadata must use the exact accepted TASK-020 command"
+        )
+
+    environment = _mapping(metadata["environment"], f"{label} metadata.environment")
+    _exact_keys(
+        environment,
+        {"platform", "python_version", "toolchain"},
+        f"{label} metadata.environment",
+    )
+    _string(environment["platform"], f"{label} metadata.environment.platform")
+    _string(
+        environment["python_version"],
+        f"{label} metadata.environment.python_version",
+    )
+    toolchain = [
+        _string(item, f"{label} metadata.environment.toolchain[{index}]")
+        for index, item in enumerate(
+            _list(environment["toolchain"], f"{label} metadata.environment.toolchain")
+        )
+    ]
+    if not toolchain or len(toolchain) != len(set(toolchain)):
+        fail(f"{label} metadata.environment.toolchain must be non-empty and unique")
+
+    if metadata["fallback_state"] != TASK_020_FALLBACK_STATE:
+        fail(
+            f"{label} red fixture metadata fallback_state must be "
+            f"{TASK_020_FALLBACK_STATE!r}"
+        )
+    recorded_patch = _mapping(metadata["patch"], f"{label} metadata.patch")
+    _exact_keys(recorded_patch, {"path", "sha256"}, f"{label} metadata.patch")
+    if (
+        patch_path != TASK_020_PATCH_PATH
+        or sha256_bytes(patch) != TASK_020_PATCH_SHA256
+    ):
+        fail(f"{label}.red_fixture patch is not the frozen TASK-020 patch")
+    if _path(
+        recorded_patch["path"], f"{label} metadata.patch.path"
+    ) != patch_path or _digest(
+        recorded_patch["sha256"], f"{label} metadata.patch.sha256"
+    ) != sha256_bytes(
+        patch
+    ):
+        fail(f"{label} red fixture metadata patch identity does not match the record")
+
+    if tuple(test_paths) != TASK_020_FIXTURE_PATHS:
+        fail(f"{label}.red_fixture.test_paths must equal the TASK-020 fixture set")
+    fixture_sha256 = _mapping(
+        metadata["fixture_sha256"], f"{label} metadata.fixture_sha256"
+    )
+    _exact_keys(
+        fixture_sha256,
+        TASK_020_FIXTURE_PATHS,
+        f"{label} metadata.fixture_sha256",
+    )
+    actual_fixture_sha256 = _patched_fixture_digests(
+        repo,
+        task_base,
+        patch,
+        test_paths,
+        f"{label}.red_fixture.patch",
+    )
+    recorded_fixture_sha256 = {
+        path: _digest(
+            fixture_sha256[path],
+            f"{label} metadata.fixture_sha256[{path!r}]",
+        )
+        for path in test_paths
+    }
+    if (
+        recorded_fixture_sha256 != TASK_020_FIXTURE_SHA256
+        or actual_fixture_sha256 != TASK_020_FIXTURE_SHA256
+    ):
+        fail(
+            f"{label} red fixture metadata fixture_sha256 does not match patched bytes"
+        )
+
+    observed = _mapping(
+        metadata["observed_result"], f"{label} metadata.observed_result"
+    )
+    _exact_keys(
+        observed,
+        {"exit_code", "failure_signature", "stderr", "stdout"},
+        f"{label} metadata.observed_result",
+    )
+    exit_code = observed["exit_code"]
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int) or exit_code != 1:
+        fail(f"{label} metadata.observed_result.exit_code must be 1")
+    if (
+        observed["failure_signature"] != failure_signature
+        or failure_signature != TASK_020_FAILURE_SIGNATURE
+    ):
+        fail(
+            f"{label} red fixture metadata failure signature does not match the record"
+        )
+    stdout = _stream_bytes(
+        observed["stdout"], f"{label} metadata.observed_result.stdout"
+    )
+    stderr = _stream_bytes(
+        observed["stderr"], f"{label} metadata.observed_result.stderr"
+    )
+    if stdout or stderr != f"{TASK_020_FAILURE_SIGNATURE}\n".encode():
+        fail(
+            f"{label} red fixture metadata streams differ from the accepted TASK-020 RED"
+        )
+    return RedFixtureObservation(exit_code=1, stdout=stdout, stderr=stderr)
+
+
 def _red_fixture_metadata(
     repo: GitRepository,
     evidence_commit: str,
+    bundle_sha256: str,
     metadata_path: str,
     task_id: str,
     task_base: str,
     command: list[str],
     failure_signature: str,
+    patch_path: str,
+    patch: bytes,
+    test_paths: list[str],
     label: str,
-) -> int:
+) -> RedFixtureObservation:
     metadata = _json_object_bytes(
         repo.blob(evidence_commit, metadata_path), f"{label} red fixture metadata"
     )
+    if task_id == "TASK-020" and metadata.get("schema") != RED_FIXTURE_SCHEMA_V2:
+        fail(f"{label} red fixture metadata must use the TASK-020 v2 schema")
+    if metadata.get("schema") == RED_FIXTURE_SCHEMA_V2:
+        return _red_fixture_metadata_v2(
+            repo,
+            metadata,
+            evidence_commit,
+            bundle_sha256,
+            task_id,
+            task_base,
+            command,
+            failure_signature,
+            patch_path,
+            patch,
+            test_paths,
+            label,
+        )
     _exact_keys(
         metadata,
         {
@@ -856,7 +1320,7 @@ def _red_fixture_metadata(
         },
         f"{label} red fixture metadata",
     )
-    if metadata["schema"] != "portable_residency_red_fixture_result/v1":
+    if metadata["schema"] != RED_FIXTURE_SCHEMA_V1:
         fail(f"{label} red fixture metadata schema is unsupported")
     if metadata["task_id"] != task_id or metadata["task_base_commit"] != task_base:
         fail(f"{label} red fixture metadata identity does not match the task")
@@ -896,7 +1360,7 @@ def _red_fixture_metadata(
         fail(
             f"{label} red fixture metadata failure signature does not match the record"
         )
-    return exit_code
+    return RedFixtureObservation(exit_code=exit_code)
 
 
 def _validate_task_evidence(
@@ -952,9 +1416,8 @@ def _validate_task_evidence(
     changed = repo.changed_paths(base, evidence)
     if not changed or any(not path.startswith(prefix) for path in changed):
         fail(f"{label}.red_fixture.evidence_commit changed paths outside {prefix}")
-    if _bundle_digest(repo, evidence, prefix) != _digest(
-        red["bundle_sha256"], f"{label}.red_fixture.bundle_sha256"
-    ):
+    bundle_sha256 = _digest(red["bundle_sha256"], f"{label}.red_fixture.bundle_sha256")
+    if _bundle_digest(repo, evidence, prefix) != bundle_sha256:
         fail(f"{label}.red_fixture.bundle_sha256 does not match the evidence bundle")
     patch_path = _path(red["patch_path"], f"{label}.red_fixture.patch_path")
     if not patch_path.startswith(prefix):
@@ -991,24 +1454,37 @@ def _validate_task_evidence(
         fail(f"{label}.red_fixture.metadata_path must be under {prefix}")
     if metadata_path not in changed:
         fail(f"{label}.red_fixture.metadata_path was not changed by evidence_commit")
-    observed_exit_code = _red_fixture_metadata(
+    observation = _red_fixture_metadata(
         repo,
         evidence,
+        bundle_sha256,
         metadata_path,
         task_id,
         base,
         red_command,
         failure_signature,
+        patch_path,
+        patch,
+        test_paths,
         label,
     )
-    red_result = _run_at_commit(repo, base, red_command, patch)
-    red_output = red_result.stdout + red_result.stderr
-    if (
-        red_result.returncode != observed_exit_code
-        or red_result.returncode == 0
-        or failure_signature not in red_output
-    ):
-        fail(f"{label}.red_fixture did not reproduce its frozen failure signature")
+    if observation.stdout is None or observation.stderr is None:
+        red_result = _run_at_commit(repo, base, red_command, patch)
+        red_output = red_result.stdout + red_result.stderr
+        if (
+            red_result.returncode != observation.exit_code
+            or red_result.returncode == 0
+            or failure_signature not in red_output
+        ):
+            fail(f"{label}.red_fixture did not reproduce its frozen failure signature")
+    else:
+        red_result = _run_at_commit(repo, base, red_command, patch, text=False)
+        if (
+            red_result.returncode != observation.exit_code
+            or red_result.stdout != observation.stdout
+            or red_result.stderr != observation.stderr
+        ):
+            fail(f"{label}.red_fixture did not reproduce its frozen binary streams")
 
     green = _mapping(task["green_checkpoint"], f"{label}.green_checkpoint")
     _exact_keys(
@@ -1026,28 +1502,17 @@ def _validate_task_evidence(
     with tempfile.TemporaryDirectory(prefix="residency-handoff-patch-") as directory:
         reconstructed = Path(directory)
         repo.materialize(base, reconstructed)
-        patch_file = reconstructed / ".handoff.patch"
-        patch_file.write_bytes(patch)
-        applied = subprocess.run(
-            [
-                "git",
-                "apply",
-                "--whitespace=nowarn",
-                "--unidiff-zero",
-                str(patch_file),
-            ],
-            cwd=reconstructed,
-            capture_output=True,
-            text=True,
-            check=False,
+        _apply_patch(
+            reconstructed,
+            patch,
+            f"{label}.red_fixture patch does not reconstruct",
         )
-        patch_file.unlink()
-        if applied.returncode:
-            fail(
-                f"{label}.red_fixture patch does not reconstruct: {applied.stderr.strip()}"
-            )
         for test_path in test_paths:
-            reconstructed_bytes = (reconstructed / test_path).read_bytes()
+            reconstructed_bytes = _fixture_bytes(
+                reconstructed,
+                test_path,
+                f"{label} reconstructed fixture {test_path}",
+            )
             if reconstructed_bytes != repo.blob(green_commit, test_path):
                 fail(
                     f"{label} test patch is not byte-identical at green checkpoint: {test_path}"


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 6046 additions, 126 deletions" src="https://img.shields.io/badge/IMPL-%2B6046%20%E2%88%92126-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 36923 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B36923%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 20 touched" src="https://img.shields.io/badge/FILES-20-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 6046 additions, 126 deletions" src="https://img.shields.io/badge/IMPL-%2B6046%20%E2%88%92126-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 12 implementation files" src="https://img.shields.io/badge/FILES-12-5F6B78?style=flat" height="16"></picture>
  - [`.gitattributes`](https://github.com/nisavid/lemonade/pull/95/files#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393e) <picture><img alt="2 additions, 0 deletions" title="2 additions, 0 deletions" src="https://img.shields.io/badge/%2B2-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`.github/workflows/cpp_server_build_test_release.yml`](https://github.com/nisavid/lemonade/pull/95/files#diff-dcb39f088456eb2a678ab900f935496e0fadfdb894bccccb3c5239710173b209) <picture><img alt="19 additions, 0 deletions" title="19 additions, 0 deletions" src="https://img.shields.io/badge/%2B19-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`CMakeLists.txt`](https://github.com/nisavid/lemonade/pull/95/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) <picture><img alt="60 additions, 0 deletions" title="60 additions, 0 deletions" src="https://img.shields.io/badge/%2B60-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/durable_journal.h`](https://github.com/nisavid/lemonade/pull/95/files#diff-b13ca5d832f2fe7a3200ae84e2516c2780918821b7c2050bf760e1c171e2e51f) <picture><img alt="152 additions, 0 deletions" title="152 additions, 0 deletions" src="https://img.shields.io/badge/%2B152-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/durable_file_adapter_common.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-0999f9be003f03a710345753b42cf25587d0f9794505eb64f6349565a49f62fe) <picture><img alt="1 addition, 0 deletions" title="1 addition, 0 deletions" src="https://img.shields.io/badge/%2B1-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/durable_journal.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-b5849536569b1697ea73ac517eafe64d23d3921f18248705521247a705e8abe2) <picture><img alt="1030 additions, 0 deletions" title="1030 additions, 0 deletions" src="https://img.shields.io/badge/%2B1030-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/platform/durable_file_adapter.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-9ebd298b7cd3f094640fd0362e2d0a48f5390ce718b23a5a6263de0e3fed7aa8) <picture><img alt="190 additions, 0 deletions" title="190 additions, 0 deletions" src="https://img.shields.io/badge/%2B190-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/platform/durable_file_adapter.h`](https://github.com/nisavid/lemonade/pull/95/files#diff-348f1d9af764ce60fbc867bfe61c727cfa540c95f8519f360176a65bf699ff1d) <picture><img alt="146 additions, 0 deletions" title="146 additions, 0 deletions" src="https://img.shields.io/badge/%2B146-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/platform/durable_file_adapter_macos.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-8b38130a5c9262e1b1cfb20d734d3ca9de8cef9481d634dc932e6e604479aaeb) <picture><img alt="1194 additions, 0 deletions" title="1194 additions, 0 deletions" src="https://img.shields.io/badge/%2B1194-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/platform/durable_file_adapter_posix.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-5106c92ab75f8e5449f5867dc3d552ffbfa7d117855cd2a35a8cc720cba04e5f) <picture><img alt="1194 additions, 0 deletions" title="1194 additions, 0 deletions" src="https://img.shields.io/badge/%2B1194-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/platform/durable_file_adapter_windows.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-0e3c832316ee5c0efee0508a6217cc69c62045f479d5249cb1d290654f45174d) <picture><img alt="1467 additions, 0 deletions" title="1467 additions, 0 deletions" src="https://img.shields.io/badge/%2B1467-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`tools/residency_handoff/validation.py`](https://github.com/nisavid/lemonade/pull/95/files#diff-49ac3afb9c522737483ad47571cc488fdddceda243470a7a613a98fe07102db7) <picture><img alt="591 additions, 126 deletions" title="591 additions, 126 deletions" src="https://img.shields.io/badge/%2B591-%E2%88%92126-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 36923 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B36923%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 8 test files" src="https://img.shields.io/badge/FILES-8-5F6B78?style=flat" height="16"></picture>
  - [`plan/evidence/red-fixtures/TASK-020/result.json`](https://github.com/nisavid/lemonade/pull/95/files#diff-d84d4ea7d67d1e8fea374098a3faafb087f32eeaaed4ff0fdd1aed5e1eea4010) <picture><img alt="45 additions, 0 deletions" title="45 additions, 0 deletions" src="https://img.shields.io/badge/%2B45-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`plan/evidence/red-fixtures/TASK-020/test.patch`](https://github.com/nisavid/lemonade/pull/95/files#diff-077260e257e9c7725cee9deef0b57ec15bd164a8c141d8b9b686da726a4b464a) <picture><img alt="18123 additions, 0 deletions" title="18123 additions, 0 deletions" src="https://img.shields.io/badge/%2B18123-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/recovery/durable_journal_private_authority_gate.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-256715f0fe457ce4d7921fb27f798a3a0ecd466f132ced203421ff3f58612ab0) <picture><img alt="122 additions, 0 deletions" title="122 additions, 0 deletions" src="https://img.shields.io/badge/%2B122-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/recovery/durable_journal_public_seam.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-da0302e40627c3800eb0b07e8679baaf38475745650e26747c7f8c18c74b9e4e) <picture><img alt="6252 additions, 0 deletions" title="6252 additions, 0 deletions" src="https://img.shields.io/badge/%2B6252-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/recovery/journal_persistence_test_support.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-c14338709c1019399c3597bc86d198b0cb4121e7244dd708efc980815e5f17b0) <picture><img alt="2294 additions, 0 deletions" title="2294 additions, 0 deletions" src="https://img.shields.io/badge/%2B2294-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/recovery/journal_persistence_test_support.h`](https://github.com/nisavid/lemonade/pull/95/files#diff-72561845d185b0b33302fd75d8b1495e2f3efff5bfe3c6c3b90b2342c6fef2b4) <picture><img alt="261 additions, 0 deletions" title="261 additions, 0 deletions" src="https://img.shields.io/badge/%2B261-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/recovery/test_durable_journal_public_seam.py`](https://github.com/nisavid/lemonade/pull/95/files#diff-5cb480942a6520af8617191f13d3f8aa5d3020490ee3a6463c494b151a032b6a) <picture><img alt="9164 additions, 0 deletions" title="9164 additions, 0 deletions" src="https://img.shields.io/badge/%2B9164-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/test_residency_implementation_handoff.py`](https://github.com/nisavid/lemonade/pull/95/files#diff-1daa7ee8f6f7dccbd8eacb51a19444bc994d917df8e9b8678e1c6eeb0bcfcefc) <picture><img alt="662 additions, 0 deletions" title="662 additions, 0 deletions" src="https://img.shields.io/badge/%2B662-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

I added a crash-safe `DurableJournal` around the TASK-019 codec, with bounded replay, move-only publication authority, exact-root compare-and-swap, process fencing, and native durable-file adapters for Linux, Windows, and macOS. Production cutover remains inactive; this PR establishes the persistence contract and evidence seam.

## Review path

1. Start with the [public authority API](https://github.com/nisavid/lemonade/pull/95/files#diff-b13ca5d832f2fe7a3200ae84e2516c2780918821b7c2050bf760e1c171e2e51f) and [`durable_journal.cpp`](https://github.com/nisavid/lemonade/pull/95/files#diff-b5849536569b1697ea73ac517eafe64d23d3921f18248705521247a705e8abe2) for publication, recovery, compaction, export, and fencing invariants.
2. Review the [adapter contract and bounded I/O helpers](https://github.com/nisavid/lemonade/pull/95/files#diff-9ebd298b7cd3f094640fd0362e2d0a48f5390ce718b23a5a6263de0e3fed7aa8), then the native adapters for lock binding, flush/replace order, and fixed-child confinement.
3. Use the [semantic seam](https://github.com/nisavid/lemonade/pull/95/files#diff-da0302e40627c3800eb0b07e8679baaf38475745650e26747c7f8c18c74b9e4e) and [support adapter](https://github.com/nisavid/lemonade/pull/95/files#diff-c14338709c1019399c3597bc86d198b0cb4121e7244dd708efc980815e5f17b0) to inspect the fault, crash, concurrency, and namespace matrix. [`test.patch`](https://github.com/nisavid/lemonade/pull/95/files#diff-077260e257e9c7725cee9deef0b57ec15bd164a8c141d8b9b686da726a4b464a) is the immutable RED payload and can be de-emphasized after its recorded hashes reproduce.

## Verification

- `env CXX=/usr/bin/g++ python3 -B test/residency/recovery/test_durable_journal_public_seam.py` — passed.
- `env CXX=/usr/bin/clang++ python3 -B test/residency/recovery/test_durable_journal_public_seam.py` — passed.
- Clang ASan/UBSan, GCC TSan, and the production macro-off compile gate passed.
- `python3 -B -m unittest -v test.test_residency_implementation_handoff` — 28/28 passed.
- Black, Ruff, `py_compile`, and `git diff --check` passed.
- [Hosted Linux, macOS, and Windows qualification](https://github.com/nisavid/lemonade/actions/runs/32432719237) passed for commit `07afd86633e74154e565319133f266a1a9966913`.

## Boundaries

- `PublishedJournal` binds the exact bytes and namespace state validated under the stable lock; newest-generation rollback resistance still requires an independent `TrustedReplayFloor`.
- Deliberate direct writers that ignore the stable advisory lock are outside the publication contract after the final under-lock validation point.
- Production cutover remains inactive.

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable residency journal support for creating, recovering, appending, publishing, compacting, and exporting journal data.
  - Added reliable storage handling across Windows, macOS, and POSIX systems, including interrupted-operation recovery and crash-tail repair.
  - Added safeguards for storage capabilities, file integrity, locking, concurrent access, and corruption detection.

- **Tests**
  - Added comprehensive persistence, recovery, fault-injection, locking, and cross-platform validation.
  - Added automated Windows and macOS build-and-test coverage.
  - Added strict validation for reproducible implementation handoff evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
