### PR TITLE
ci/fork: gate upstream-only automation

### DIFF
--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   repo-manager:
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
     runs-on: [self-hosted, linux, repo-manager]
     timeout-minutes: 30
     env:

--- a/.github/workflows/triage-dashboard.yml
+++ b/.github/workflows/triage-dashboard.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository == 'lemonade-sdk/lemonade' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 2 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B2%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 2 touched" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 2 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B2%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 2 implementation files" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture>
  - [`.github/workflows/repo-manager.yml`](https://github.com/nisavid/lemonade/pull/128/files#diff-11f4007d4e91d6c3139c1fd9ca82c42ed04bd5edc7344452b016dfca4b029eba) <picture><img alt="1 addition, 0 deletions" title="1 addition, 0 deletions" src="https://img.shields.io/badge/%2B1-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`.github/workflows/triage-dashboard.yml`](https://github.com/nisavid/lemonade/pull/128/files#diff-910c29f7122d44d54815ca30f50890745639376981a02787b5e5d7741e3e367e) <picture><img alt="1 addition, 0 deletions" title="1 addition, 0 deletions" src="https://img.shields.io/badge/%2B1-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Gate the inherited upstream-only publication and release-management jobs so they skip in `nisavid/lemonade` instead of attempting upstream publication or waiting for infrastructure this fork does not own.

Fixes #127

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Build is not applicable; this PR changes only workflow YAML.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- PyYAML parsed both workflows and confirmed the repository-owner guard is attached to each job.
- `python3 .github/scripts/test_triage_dashboard.py` — 3 tests passed.
- `git diff --check` passed.
- `actionlint .github/workflows/triage-dashboard.yml .github/workflows/repo-manager.yml` reported only the pre-existing custom `repo-manager` self-hosted-label warning; no syntax errors.

The earlier fork triage run failed at its upstream publish step because no deploy token was configured, and the Repo Manager run remained queued without a matching self-hosted runner. Those workflows are inherited upstream automation; this PR does not provision credentials, runners, or fork-owned publication targets.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted repository management automation to run only in the intended repository.
  * Restricted triage dashboard builds to run only in the intended repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->