### PR TITLE
feat(residency): add isolated profiling transaction seam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,6 +977,7 @@ set(SOURCES_CORE
     src/cpp/server/residency/explanations.cpp
     src/cpp/server/residency/generated_contract.cpp
     src/cpp/server/residency/local_overlay.cpp
+    src/cpp/server/residency/profiling_transaction.cpp
     src/cpp/server/wrapped_server.cpp
     src/cpp/server/streaming_proxy.cpp
     src/cpp/server/system_info.cpp
@@ -3466,6 +3467,25 @@ if(BUILD_TESTING AND EXISTS "${_ROUTER_MODEL_LIFECYCLE_TEST_SRC}")
     target_link_libraries(test_router_model_lifecycle PRIVATE lemonade-server-core)
     add_cpp_ci_test(RouterModelLifecycleTest CI ON COMMAND test_router_model_lifecycle)
     set_tests_properties(RouterModelLifecycleTest PROPERTIES TIMEOUT 30)
+endif()
+
+set(_RESIDENCY_PROFILING_TRANSACTION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_residency_profiling_transaction.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_TRANSACTION_TEST_SRC}")
+    add_executable(
+        test_residency_profiling_transaction
+        test/cpp/test_residency_profiling_transaction.cpp
+    )
+    target_link_libraries(test_residency_profiling_transaction PRIVATE
+        lemonade-server-core
+    )
+    add_cpp_ci_test(
+        ResidencyProfilingTransaction
+        CI ON
+        COMMAND test_residency_profiling_transaction
+    )
+    set_tests_properties(ResidencyProfilingTransaction PROPERTIES TIMEOUT 30)
 endif()
 
 # Routing-helper reconciliation: durable needed-set + non-blocking prune that

--- a/src/cpp/include/lemon/residency/profiling_transaction.h
+++ b/src/cpp/include/lemon/residency/profiling_transaction.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "lemon/residency/local_overlay.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace lemon {
+
+class Router;
+
+namespace residency {
+
+enum class ProfilingTransactionStatus {
+    Accepted,
+    AlreadyRunning,
+    Cancelled,
+    Restarted,
+    GateTimeout,
+    EvidenceUnavailable,
+    InvalidEvidence,
+    Failed,
+};
+
+enum class ProfilingAbortReason {
+    Cancelled,
+    Restarted,
+    Failed,
+};
+
+using ProfilingCancellationCheck = std::function<bool()>;
+
+struct ProfilingTransactionCapture {
+    std::optional<ProfilingInputEnvelopeDraft> draft;
+    // These attestations come from the server-owned observation provider. The
+    // transaction never infers identity, freshness, health, uncertainty, or
+    // safety from aggregate benchmark output.
+    bool baseline_captured = false;
+    bool workload_captured = false;
+    bool release_captured = false;
+    bool identity_complete = false;
+    bool observations_fresh = false;
+    bool observations_healthy = false;
+    bool uncertainty_bound_verified = false;
+    bool safety_margin_verified = false;
+    std::string diagnostic;
+};
+
+struct ProfilingTransactionResult {
+    ProfilingTransactionStatus status = ProfilingTransactionStatus::Failed;
+    std::string diagnostic;
+    std::optional<ParsedProfilingInputEnvelope> candidate;
+
+    bool accepted() const noexcept {
+        return status == ProfilingTransactionStatus::Accepted &&
+               candidate.has_value();
+    }
+};
+
+struct ProfilingTransactionOptions {
+    std::chrono::milliseconds gate_timeout{std::chrono::seconds(30)};
+    std::chrono::milliseconds retry_interval{25};
+};
+
+class ProfilingTransaction {
+public:
+    // Server owns one instance per Router. That instance is the admission point
+    // for profiling; callers must not create parallel coordinators. Capture is
+    // synchronous: it must not retain Router, the cancellation check, or the
+    // cancel pointer, and it must join any work it starts before returning.
+    // Capture code must poll the cancellation check at bounded points, must
+    // not call Router::end_exclusive(), and must not invoke Server lifecycle
+    // or configuration mutations (directly or from spawned work) while the
+    // exclusive lease is held. It must also avoid nested HTTP/jobs calls and
+    // Router work from non-owner threads, which would queue behind this lease.
+    using Capture = std::function<ProfilingTransactionCapture(
+        Router &, const ProfilingCancellationCheck &)>;
+
+    explicit ProfilingTransaction(Router &router,
+                                  ProfilingTransactionOptions options = {});
+    // Destruction must occur outside the synchronous capture callback. An
+    // owner-thread destruction cannot safely wait for the active Router lease.
+    ~ProfilingTransaction();
+
+    ProfilingTransaction(const ProfilingTransaction &) = delete;
+    ProfilingTransaction &operator=(const ProfilingTransaction &) = delete;
+
+    // restart_detected is a cheap, non-blocking lifecycle predicate owned by
+    // the Server. Capture providers must not use it as a substitute for their
+    // own bounded cancellation checks.
+    ProfilingTransactionResult run(std::string transaction_id, Capture capture,
+                                   std::atomic<bool> *cancel = nullptr,
+                                   std::function<bool()> restart_detected = {});
+
+    // Latch a lifecycle abort for the active run. The latch is scoped to that
+    // run and remains set even when an external flag is later cleared.
+    void request_abort(
+        ProfilingAbortReason reason = ProfilingAbortReason::Restarted) noexcept;
+
+    bool running() const noexcept;
+    bool running_on_current_thread() const noexcept;
+    // Returns false when called by the active capture thread; waiting there
+    // would deadlock and the caller must defer Router teardown.
+    bool wait_for_idle();
+
+private:
+    struct RunState;
+    class RunningGuard;
+
+    Router &router_;
+    ProfilingTransactionOptions options_;
+    mutable std::mutex mutex_;
+    std::condition_variable idle_cv_;
+    bool running_ = false;
+    std::shared_ptr<RunState> active_run_;
+    std::thread::id owner_thread_;
+};
+
+} // namespace residency
+} // namespace lemon

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -21,19 +21,19 @@
 #include <thread>
 #include <vector>
 #include <httplib.h>
-#include "runtime_config.h"
-#include "router.h"
-#include "routing_policy.h"
 #include "alias_manager.h"
-#include "model_manager.h"
-#include "lemon/model_load_tracker.h"
-#include "lemon/residency/profiling_transaction.h"
 #include "backend_manager.h"
 #include "cloud_provider_registry.h"
+#include "lemon/model_load_tracker.h"
+#include "lemon/residency/profiling_transaction.h"
+#include "lemon/system_metrics_platform.h"
+#include "lemon/utils/network_beacon.h"
+#include "model_manager.h"
+#include "router.h"
+#include "routing_policy.h"
+#include "runtime_config.h"
 #include "upgradable_http_server.h"
 #include "websocket_server.h"
-#include "lemon/utils/network_beacon.h"
-#include "lemon/system_metrics_platform.h"
 
 namespace lemon {
 

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -7,16 +7,18 @@
 #define CPPHTTPLIB_THREAD_POOL_COUNT 64
 #endif
 
-#include <string>
-#include <thread>
-#include <memory>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
+#include <string>
+#include <thread>
 #include <vector>
 #include <httplib.h>
 #include "runtime_config.h"
@@ -25,6 +27,7 @@
 #include "alias_manager.h"
 #include "model_manager.h"
 #include "lemon/model_load_tracker.h"
+#include "lemon/residency/profiling_transaction.h"
 #include "backend_manager.h"
 #include "cloud_provider_registry.h"
 #include "upgradable_http_server.h"
@@ -73,6 +76,16 @@ public:
     bool startup_failed() const;
 
 private:
+    void begin_residency_lifecycle_change();
+
+    // This trusted internal seam does not publish. Its caller must be a
+    // Server-owned provider that binds every observation attestation before
+    // the result reaches durable overlay activation or a transport.
+    residency::ProfilingTransactionResult run_residency_profiling_transaction(
+        std::string transaction_id,
+        residency::ProfilingTransaction::Capture capture,
+        std::atomic<bool> *cancel = nullptr);
+
     std::string resolve_host_to_ip(int ai_family, const std::string& host);
     void setup_routes(httplib::Server &web_server);
     void setup_static_files(httplib::Server &web_server);
@@ -382,6 +395,7 @@ private:
     std::unique_ptr<UpgradableFrontServer> http_front_v6_;
 
     std::unique_ptr<Router> router_;
+    std::unique_ptr<residency::ProfilingTransaction> profiling_transaction_;
     std::unique_ptr<AliasManager> alias_manager_;
     std::unique_ptr<ModelManager> model_manager_;
     std::unique_ptr<BackendManager> backend_manager_;
@@ -392,11 +406,17 @@ private:
     std::mutex downloads_mutex_;
     std::map<std::string, std::shared_ptr<DownloadJob>> download_jobs_;
 
-    bool running_;
+    std::atomic<bool> running_{false};
     bool startup_failed_ = false;
     std::atomic<bool> shutdown_requested_{false};
     std::atomic<bool> rebind_requested_{false};
+    std::atomic<bool> profiling_accepting_{false};
+    std::atomic<uint64_t> profiling_lifecycle_epoch_{0};
     std::atomic<bool> metrics_access_logged_{false};
+    std::mutex lifecycle_mutex_;
+    std::mutex stop_mutex_;
+    std::condition_variable profiling_admission_cv_;
+    std::size_t profiling_admissions_ = 0;
 
     std::string api_key_;
     std::string admin_api_key_;

--- a/src/cpp/server/residency/profiling_transaction.cpp
+++ b/src/cpp/server/residency/profiling_transaction.cpp
@@ -1,0 +1,387 @@
+#include "lemon/residency/profiling_transaction.h"
+
+#include "lemon/router.h"
+
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <thread>
+#include <utility>
+
+namespace lemon::residency {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+std::string bounded_diagnostic(std::string value) {
+    if (value.size() > max_local_overlay_diagnostic_bytes) {
+        std::size_t boundary = max_local_overlay_diagnostic_bytes;
+        while (boundary > 0 &&
+               (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u)
+            --boundary;
+        value.resize(boundary);
+    }
+    return value;
+}
+
+ProfilingTransactionResult result_for(ProfilingTransactionStatus status,
+                                      std::string diagnostic = {}) {
+    return ProfilingTransactionResult{
+        status, bounded_diagnostic(std::move(diagnostic)), std::nullopt};
+}
+
+class RouterExclusiveLease {
+public:
+    explicit RouterExclusiveLease(Router &router) : router_(&router) {}
+
+    RouterExclusiveLease(const RouterExclusiveLease &) = delete;
+    RouterExclusiveLease &operator=(const RouterExclusiveLease &) = delete;
+
+    ~RouterExclusiveLease() {
+        if (router_ != nullptr)
+            router_->end_exclusive();
+    }
+
+private:
+    Router *router_;
+};
+
+} // namespace
+
+struct ProfilingTransaction::RunState {
+    // Zero means no abort. A single atomic keeps restart precedence ordered
+    // with caller cancellation when lifecycle teardown races a capture poll.
+    std::atomic<int> abort_reason{0};
+
+    void latch(ProfilingAbortReason reason) noexcept {
+        const auto status = reason == ProfilingAbortReason::Restarted
+                                ? ProfilingTransactionStatus::Restarted
+                            : reason == ProfilingAbortReason::Cancelled
+                                ? ProfilingTransactionStatus::Cancelled
+                                : ProfilingTransactionStatus::Failed;
+        // A lifecycle restart always wins over an ordinary caller cancel.
+        if (status == ProfilingTransactionStatus::Restarted) {
+            abort_reason.store(static_cast<int>(status),
+                               std::memory_order_seq_cst);
+        } else {
+            int expected = 0;
+            abort_reason.compare_exchange_strong(
+                expected, static_cast<int>(status), std::memory_order_seq_cst);
+        }
+    }
+
+    std::optional<ProfilingTransactionStatus> reason() const noexcept {
+        const int raw = abort_reason.load(std::memory_order_seq_cst);
+        if (raw == 0)
+            return std::nullopt;
+        const auto value = static_cast<ProfilingTransactionStatus>(raw);
+        if (value == ProfilingTransactionStatus::Restarted ||
+            value == ProfilingTransactionStatus::Cancelled ||
+            value == ProfilingTransactionStatus::Failed) {
+            return value;
+        }
+        return ProfilingTransactionStatus::Failed;
+    }
+};
+
+class ProfilingTransaction::RunningGuard {
+public:
+    RunningGuard(ProfilingTransaction &transaction,
+                 std::shared_ptr<RunState> state)
+        : transaction_(transaction), state_(std::move(state)) {}
+
+    RunningGuard(const RunningGuard &) = delete;
+    RunningGuard &operator=(const RunningGuard &) = delete;
+
+    ~RunningGuard() {
+        std::lock_guard<std::mutex> lock(transaction_.mutex_);
+        if (transaction_.active_run_ == state_)
+            transaction_.active_run_.reset();
+        transaction_.owner_thread_ = std::thread::id{};
+        transaction_.running_ = false;
+        transaction_.idle_cv_.notify_all();
+    }
+
+private:
+    ProfilingTransaction &transaction_;
+    std::shared_ptr<RunState> state_;
+};
+
+ProfilingTransaction::ProfilingTransaction(Router &router,
+                                           ProfilingTransactionOptions options)
+    : router_(router), options_(std::move(options)) {
+    if (options_.gate_timeout <= std::chrono::milliseconds::zero())
+        options_.gate_timeout = std::chrono::milliseconds(1);
+    if (options_.retry_interval <= std::chrono::milliseconds::zero())
+        options_.retry_interval = std::chrono::milliseconds(1);
+}
+
+ProfilingTransaction::~ProfilingTransaction() {
+    if (running_on_current_thread()) {
+        // Destroying the coordinator from its capture stack would invalidate
+        // the Router lease and the RunningGuard before run() can unwind.
+        std::terminate();
+    }
+    request_abort(ProfilingAbortReason::Restarted);
+    wait_for_idle();
+}
+
+bool ProfilingTransaction::running() const noexcept {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return running_;
+}
+
+bool ProfilingTransaction::running_on_current_thread() const noexcept {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return running_ && owner_thread_ == std::this_thread::get_id();
+}
+
+void ProfilingTransaction::request_abort(ProfilingAbortReason reason) noexcept {
+    std::shared_ptr<RunState> state;
+    try {
+        std::lock_guard<std::mutex> lock(mutex_);
+        state = active_run_;
+    } catch (...) {
+        return;
+    }
+    if (state)
+        state->latch(reason);
+    idle_cv_.notify_all();
+}
+
+bool ProfilingTransaction::wait_for_idle() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!running_)
+        return true;
+    if (owner_thread_ == std::this_thread::get_id())
+        return false;
+    idle_cv_.wait(lock, [this] { return !running_; });
+    return true;
+}
+
+ProfilingTransactionResult
+ProfilingTransaction::run(std::string transaction_id, Capture capture,
+                          std::atomic<bool> *cancel,
+                          std::function<bool()> restart_detected) {
+    auto state = std::make_shared<RunState>();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (running_)
+            return result_for(ProfilingTransactionStatus::AlreadyRunning,
+                              "profiling transaction already running");
+        running_ = true;
+        active_run_ = state;
+        owner_thread_ = std::this_thread::get_id();
+    }
+    RunningGuard running_guard(*this, state);
+
+    if (!capture)
+        return result_for(ProfilingTransactionStatus::Failed,
+                          "profiling capture provider is unavailable");
+
+    auto check_abort = [&]() -> std::optional<ProfilingTransactionResult> {
+        const auto latched = state->reason();
+        if (latched && *latched == ProfilingTransactionStatus::Restarted)
+            return result_for(*latched,
+                              "profiling transaction interrupted by restart");
+        if (latched) {
+            try {
+                if (restart_detected && restart_detected())
+                    state->latch(ProfilingAbortReason::Restarted);
+            } catch (...) {
+            }
+            const auto reason = state->reason().value_or(*latched);
+            const char *message =
+                reason == ProfilingTransactionStatus::Restarted
+                    ? "profiling transaction interrupted by restart"
+                : reason == ProfilingTransactionStatus::Cancelled
+                    ? "profiling transaction cancelled"
+                    : "profiling lifecycle check failed";
+            return result_for(reason, message);
+        }
+        try {
+            if (restart_detected && restart_detected())
+                state->latch(ProfilingAbortReason::Restarted);
+            else if (cancel != nullptr && cancel->load())
+                state->latch(ProfilingAbortReason::Cancelled);
+        } catch (...) {
+            state->latch(ProfilingAbortReason::Failed);
+        }
+        if (const auto reason = state->reason()) {
+            const char *message =
+                *reason == ProfilingTransactionStatus::Restarted
+                    ? "profiling transaction interrupted by restart"
+                : *reason == ProfilingTransactionStatus::Cancelled
+                    ? "profiling transaction cancelled"
+                    : "profiling lifecycle check failed";
+            return result_for(*reason, message);
+        }
+        return std::nullopt;
+    };
+
+    if (auto aborted = check_abort())
+        return std::move(*aborted);
+    if (transaction_id.empty())
+        return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                          "profiling transaction ID is missing");
+
+    const auto deadline = Clock::now() + options_.gate_timeout;
+    auto wait_for_retry = [&]() {
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline -
+                                                                  Clock::now());
+        if (remaining <= std::chrono::milliseconds::zero())
+            return;
+        const auto delay = options_.retry_interval < remaining
+                               ? options_.retry_interval
+                               : remaining;
+        std::this_thread::sleep_for(delay);
+    };
+    auto timeout_or_abort = [&]() {
+        if (auto aborted = check_abort())
+            return std::move(*aborted);
+        return result_for(ProfilingTransactionStatus::GateTimeout,
+                          "profiling Router gate timed out");
+    };
+    bool acquired = false;
+    try {
+        while (!acquired) {
+            if (auto aborted = check_abort())
+                return std::move(*aborted);
+            if (Clock::now() >= deadline)
+                return timeout_or_abort();
+
+            auto request = router_.request_exclusive(cancel);
+            while (request.pending()) {
+                if (auto aborted = check_abort())
+                    return std::move(*aborted);
+                const auto acquire_result =
+                    router_.try_begin_exclusive(request, cancel);
+                if (acquire_result ==
+                    Router::ExclusiveAcquireResult::Acquired) {
+                    acquired = true;
+                    break;
+                }
+                if (acquire_result ==
+                    Router::ExclusiveAcquireResult::Cancelled) {
+                    state->latch(ProfilingAbortReason::Cancelled);
+                    if (auto aborted = check_abort())
+                        return std::move(*aborted);
+                    return result_for(ProfilingTransactionStatus::Cancelled,
+                                      "profiling transaction cancelled");
+                }
+                if (acquire_result != Router::ExclusiveAcquireResult::Retry)
+                    return result_for(
+                        ProfilingTransactionStatus::Failed,
+                        "profiling Router gate acquisition failed");
+                if (Clock::now() >= deadline)
+                    return timeout_or_abort();
+                wait_for_retry();
+            }
+            if (acquired)
+                break;
+
+            if (request.result() == Router::ExclusiveAcquireResult::Cancelled) {
+                state->latch(ProfilingAbortReason::Cancelled);
+                if (auto aborted = check_abort())
+                    return std::move(*aborted);
+                return result_for(ProfilingTransactionStatus::Cancelled,
+                                  "profiling transaction cancelled");
+            }
+            if (request.result() != Router::ExclusiveAcquireResult::Retry)
+                return result_for(ProfilingTransactionStatus::Failed,
+                                  "profiling Router gate request failed");
+            wait_for_retry();
+        }
+    } catch (...) {
+        if (auto aborted = check_abort())
+            return std::move(*aborted);
+        return result_for(ProfilingTransactionStatus::Failed,
+                          "profiling Router gate acquisition failed");
+    }
+
+    RouterExclusiveLease lease(router_);
+    if (auto aborted = check_abort())
+        return std::move(*aborted);
+
+    ProfilingTransactionCapture capture_result;
+    try {
+        const ProfilingCancellationCheck should_abort = [&]() noexcept {
+            const auto latched = state->reason();
+            if (latched && *latched == ProfilingTransactionStatus::Restarted)
+                return true;
+            if (latched) {
+                try {
+                    if (restart_detected && restart_detected())
+                        state->latch(ProfilingAbortReason::Restarted);
+                } catch (...) {
+                }
+                return true;
+            }
+            try {
+                if (restart_detected && restart_detected())
+                    state->latch(ProfilingAbortReason::Restarted);
+                else if (cancel != nullptr && cancel->load())
+                    state->latch(ProfilingAbortReason::Cancelled);
+            } catch (...) {
+                state->latch(ProfilingAbortReason::Failed);
+            }
+            return state->reason().has_value();
+        };
+        capture_result = capture(router_, should_abort);
+    } catch (...) {
+        if (auto aborted = check_abort())
+            return std::move(*aborted);
+        return result_for(ProfilingTransactionStatus::Failed,
+                          "profiling capture failed");
+    }
+
+    if (auto aborted = check_abort())
+        return std::move(*aborted);
+    if (!capture_result.draft.has_value() ||
+        !capture_result.baseline_captured ||
+        !capture_result.workload_captured || !capture_result.release_captured ||
+        !capture_result.identity_complete ||
+        !capture_result.observations_fresh ||
+        !capture_result.observations_healthy ||
+        !capture_result.uncertainty_bound_verified ||
+        !capture_result.safety_margin_verified) {
+        return result_for(ProfilingTransactionStatus::EvidenceUnavailable,
+                          capture_result.diagnostic.empty()
+                              ? "profiling evidence is incomplete"
+                              : capture_result.diagnostic);
+    }
+    if (!capture_result.draft->attribution_complete ||
+        !capture_result.draft->external_demand_absent ||
+        !capture_result.draft->lifecycle_release_verified)
+        return result_for(ProfilingTransactionStatus::EvidenceUnavailable,
+                          "profiling evidence is not safe to publish");
+    if (capture_result.draft->profiling_transaction_id != transaction_id)
+        return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                          "profiling transaction ID does not match capture");
+
+    ParsedProfilingInputEnvelopeResult sealed;
+    try {
+        sealed = seal_profiling_input(std::move(*capture_result.draft));
+    } catch (...) {
+        if (auto aborted = check_abort())
+            return std::move(*aborted);
+        return result_for(ProfilingTransactionStatus::Failed,
+                          "profiling evidence sealing failed");
+    }
+    if (!sealed.accepted())
+        return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                          sealed.diagnostic.empty()
+                              ? "profiling evidence failed contract validation"
+                              : sealed.diagnostic);
+    if (auto aborted = check_abort())
+        return std::move(*aborted);
+
+    ProfilingTransactionResult result;
+    result.status = ProfilingTransactionStatus::Accepted;
+    result.diagnostic = "profiling evidence accepted";
+    result.candidate = std::move(sealed.candidate);
+    return result;
+}
+
+} // namespace lemon::residency

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -35,6 +35,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -101,6 +102,41 @@ public:
 
 private:
     Router* router_;
+};
+
+class ProfilingAdmissionGuard {
+public:
+    ProfilingAdmissionGuard(std::mutex& mutex, std::condition_variable& cv,
+                            std::size_t& admissions)
+        : mutex_(mutex), cv_(cv), admissions_(admissions) {}
+
+    ProfilingAdmissionGuard(const ProfilingAdmissionGuard&) = delete;
+    ProfilingAdmissionGuard& operator=(const ProfilingAdmissionGuard&) = delete;
+
+    ~ProfilingAdmissionGuard() { release(); }
+
+    void release_locked() noexcept {
+        if (!active_) return;
+        if (admissions_ > 0) --admissions_;
+        active_ = false;
+        cv_.notify_all();
+    }
+
+    void release() noexcept {
+        if (!active_) return;
+        try {
+            std::lock_guard<std::mutex> lock(mutex_);
+            release_locked();
+        } catch (...) {
+            std::terminate();
+        }
+    }
+
+private:
+    std::mutex& mutex_;
+    std::condition_variable& cv_;
+    std::size_t& admissions_;
+    bool active_ = true;
 };
 
 int hex_value(char c) {
@@ -434,6 +470,8 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
                                        backend_manager_.get(),
                                        [this]() { return get_vram_usage(); });
     router_->set_cloud_registry(cloud_registry_.get());
+    profiling_transaction_ =
+        std::make_unique<residency::ProfilingTransaction>(*router_);
 
     // When a router collection is added, edited, or removed (via the API or an
     // on-disk edit), reclaim any routing helper no remaining policy references.
@@ -2244,6 +2282,7 @@ void Server::run() {
     warn_if_unsecured(host, ipv4, ipv6);
 
     running_ = true;
+    profiling_accepting_.store(false);
 
     // Start WebSocket server for realtime API and log streaming
     if (websocket_server_) {
@@ -2328,6 +2367,12 @@ void Server::run() {
             break;
         }
 
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+            if (!shutdown_requested_.load() && !rebind_requested_.load())
+                profiling_accepting_.store(true);
+        }
+
         // Enumerate all RFC1918 interfaces to determine if we can broadcast.
         // The beacon will send per-interface with the correct IP in the payload.
         auto rfc1918Interfaces = udp_beacon_.getLocalRFC1918Interfaces();
@@ -2384,26 +2429,51 @@ void Server::run() {
             break;
         }
 
-        // If rebind was requested, stop() has already been called by apply_config_side_effects().
-        // Just join the threads so they can be restarted with new settings.
-        if (rebind_requested_.load()) {
-            // Wait for threads to finish (stop() was already called)
-            if (http_v4_thread_.joinable())
-                http_v4_thread_.join();
-            if (http_v6_thread_.joinable())
-                http_v6_thread_.join();
-            // Continue to rebind logic below (don't break)
-        } else {
-            // Normal path: threads exited naturally (no shutdown, no rebind)
-            // Join the threads
-            if (http_v4_thread_.joinable())
-                http_v4_thread_.join();
-            if (http_v6_thread_.joinable())
-                http_v6_thread_.join();
+        // Join the listener threads before deciding whether a rebind is still
+        // needed. A config update can arrive during the joins, so the
+        // admission barrier is applied from the final lifecycle snapshot.
+        if (rebind_requested_.load())
+            stop_http_listeners();
+        if (http_v4_thread_.joinable())
+            http_v4_thread_.join();
+        if (http_v6_thread_.joinable())
+            http_v6_thread_.join();
+
+        bool should_rebind = false;
+        uint64_t rebind_epoch = 0;
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+            should_rebind = rebind_requested_.load() &&
+                            !shutdown_requested_.load();
+            if (should_rebind)
+                rebind_epoch = profiling_lifecycle_epoch_.load();
+        }
+        if (!should_rebind) {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+            profiling_accepting_.store(false);
+            break;  // Normal exit or shutdown won the lifecycle race.
         }
 
-        if (!rebind_requested_) {
-            break;  // Normal exit (stop() was called)
+        if (profiling_transaction_ &&
+            profiling_transaction_->running_on_current_thread()) {
+            LOG(ERROR, "Server")
+                << "Cannot rebind from the profiling capture thread"
+                << std::endl;
+            stop();
+            break;
+        }
+        {
+            std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mutex_);
+            profiling_admission_cv_.wait(
+                lifecycle_lock, [this] { return profiling_admissions_ == 0; });
+        }
+        if (profiling_transaction_ &&
+            !profiling_transaction_->wait_for_idle()) {
+            LOG(ERROR, "Server")
+                << "Cannot rebind while profiling capture owns the server thread"
+                << std::endl;
+            stop();
+            break;
         }
 
         // Rebind requested: re-resolve host, recreate HTTP servers, loop back to bind+listen
@@ -2412,8 +2482,29 @@ void Server::run() {
         ipv6 = resolve_host_to_ip(AF_INET6, host);
         warn_if_unsecured(host, ipv4, ipv6);
         LOG(INFO, "Server") << "Rebinding to " << host << ":" << port_ << "..." << std::endl;
-        rebind_requested_ = false;
+        std::unique_lock<std::mutex> transition_lock(stop_mutex_);
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+            if (shutdown_requested_.load() || !rebind_requested_.load()) {
+                profiling_accepting_.store(false);
+                continue;
+            }
+            profiling_accepting_.store(false);
+        }
         setup_http_servers();
+        if (websocket_server_) {
+            websocket_server_->stop();
+            websocket_server_ = std::make_unique<WebSocketServer>(
+                router_.get(), config_->host(), config_->websocket_port());
+            if (running_)
+                websocket_server_->start();
+        }
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+            profiling_accepting_.store(false);
+            if (profiling_lifecycle_epoch_.load() == rebind_epoch)
+                rebind_requested_ = false;
+        }
     }
 }
 
@@ -2423,7 +2514,89 @@ bool Server::should_shutdown() const {
 }
 
 void Server::set_shutdown_requested(bool requested) {
+    // This setter is also called from the POSIX signal handler. Keep it
+    // limited to an atomic flag; the normal server thread performs the
+    // lifecycle abort before touching Router or synchronization primitives.
     shutdown_requested_.store(requested);
+}
+
+void Server::begin_residency_lifecycle_change() {
+    profiling_accepting_.store(false);
+    profiling_lifecycle_epoch_.fetch_add(1);
+    if (profiling_transaction_)
+        profiling_transaction_->request_abort(
+            residency::ProfilingAbortReason::Restarted);
+}
+
+residency::ProfilingTransactionResult
+Server::run_residency_profiling_transaction(
+    std::string transaction_id,
+    residency::ProfilingTransaction::Capture capture,
+    std::atomic<bool> *cancel) {
+    uint64_t lifecycle_epoch = 0;
+    residency::ProfilingTransaction *transaction = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        transaction = profiling_transaction_.get();
+        if (transaction == nullptr) {
+            residency::ProfilingTransactionResult result;
+            result.status = residency::ProfilingTransactionStatus::Failed;
+            result.diagnostic = "profiling transaction is unavailable";
+            return result;
+        }
+        if (!profiling_accepting_.load() || shutdown_requested_.load() ||
+            rebind_requested_.load()) {
+            residency::ProfilingTransactionResult result;
+            result.status = residency::ProfilingTransactionStatus::Restarted;
+            result.diagnostic = "server lifecycle is not accepting profiling";
+            return result;
+        }
+        lifecycle_epoch = profiling_lifecycle_epoch_.load();
+        ++profiling_admissions_;
+    }
+
+    ProfilingAdmissionGuard admission_guard(
+        lifecycle_mutex_, profiling_admission_cv_, profiling_admissions_);
+
+    auto finish = [this, lifecycle_epoch, &admission_guard](
+                      residency::ProfilingTransactionResult value) {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        const bool lifecycle_changed =
+            profiling_lifecycle_epoch_.load() != lifecycle_epoch ||
+            !profiling_accepting_.load() || shutdown_requested_.load() ||
+            rebind_requested_.load();
+        if (lifecycle_changed) {
+            value.status = residency::ProfilingTransactionStatus::Restarted;
+            value.diagnostic = "profiling lifecycle changed before publication";
+            value.candidate.reset();
+        } else if (value.status ==
+                       residency::ProfilingTransactionStatus::Accepted &&
+                   !value.candidate.has_value()) {
+            value.status = residency::ProfilingTransactionStatus::InvalidEvidence;
+            value.diagnostic = "profiling transaction returned no candidate";
+        }
+        if (value.status != residency::ProfilingTransactionStatus::Accepted)
+            value.candidate.reset();
+        admission_guard.release_locked();
+        return value;
+    };
+
+    residency::ProfilingTransactionResult result;
+    try {
+        result = transaction->run(
+            std::move(transaction_id), std::move(capture), cancel,
+            [this, lifecycle_epoch] {
+                return !profiling_accepting_.load() ||
+                       shutdown_requested_.load() || rebind_requested_.load() ||
+                       profiling_lifecycle_epoch_.load() != lifecycle_epoch;
+            });
+    } catch (...) {
+        residency::ProfilingTransactionResult failed;
+        failed.status = residency::ProfilingTransactionStatus::Failed;
+        failed.diagnostic = "profiling transaction failed";
+        return finish(std::move(failed));
+    }
+    return finish(std::move(result));
 }
 
 bool Server::is_running() const {
@@ -2435,7 +2608,36 @@ bool Server::startup_failed() const {
 }
 
 void Server::stop() {
+    if (profiling_transaction_ &&
+        profiling_transaction_->running_on_current_thread()) {
+        shutdown_requested_ = true;
+        begin_residency_lifecycle_change();
+        LOG(WARNING, "Server")
+            << "Shutdown requested by the profiling capture thread;"
+               " cleanup is deferred"
+            << std::endl;
+        return;
+    }
+
+    std::lock_guard<std::mutex> stop_lock(stop_mutex_);
+    std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mutex_);
     shutdown_requested_ = true;
+    begin_residency_lifecycle_change();
+
+    // Close the admission boundary before waiting. A caller that already
+    // reserved an admission may still be about to enter the transaction; it
+    // must finish that handoff before Router teardown can begin.
+    profiling_admission_cv_.wait(
+        lifecycle_lock, [this] { return profiling_admissions_ == 0; });
+    lifecycle_lock.unlock();
+
+    if (profiling_transaction_ && !profiling_transaction_->wait_for_idle()) {
+        LOG(WARNING, "Server")
+            << "Deferring shutdown cleanup until the profiling capture thread"
+               " releases the Router gate"
+            << std::endl;
+        return;
+    }
 
     if (running_) {
         LOG(INFO, "Server") << "Stopping HTTP server..." << std::endl;
@@ -2477,7 +2679,10 @@ void Server::stop() {
         pinned_model_loading_thread_.join();
     }
 
-    shutdown_requested_ = false;  // Reset for potential future use
+    {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        shutdown_requested_ = false;  // Permit an explicit later run() restart.
+    }
 }
 
 // Generates an actionable error message for model loading failures.
@@ -7386,29 +7591,21 @@ void Server::handle_jobs_delete(const httplib::Request& req, httplib::Response& 
 void Server::handle_shutdown(const httplib::Request& req, httplib::Response& res) {
     LOG(INFO, "Server") << "Shutdown request received" << std::endl;
 
-    // Unload all models SYNCHRONOUSLY before sending the response.
-    // This ensures child processes (llama-server, etc.) are terminated
-    // before the caller proceeds, avoiding zombie processes.
-    if (router_) {
-        LOG(INFO, "Server") << "Unloading models and stopping backend servers..." << std::endl;
-        try {
-            router_->unload_model();
-            LOG(INFO, "Server") << "All models unloaded" << std::endl;
-        } catch (const std::exception& e) {
-            LOG(ERROR, "Server") << "Error during unload: " << e.what() << std::endl;
-        }
+    // Close profiling admission before the asynchronous stop path tears down
+    // Router. A capture provider that owns this request thread cannot be
+    // waited on here; stop() performs the cleanup after the callback returns.
+    set_shutdown_requested(true);
+    {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        begin_residency_lifecycle_change();
     }
 
     nlohmann::json response = {{"status", "shutting down"}};
     res.set_content(response.dump(), "application/json");
 
-    // Stop the HTTP listener and exit asynchronously (allows response to be sent first)
-    std::thread([this]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        cancel_download_jobs();
-        stop();
-        std::exit(0);
-    }).detach();
+    // The serving thread observes shutdown_requested_ and owns listener/model
+    // teardown. Keeping cleanup on that thread avoids retaining a raw Server
+    // pointer in a detached callback after an embedded Server is destroyed.
 }
 
 void Server::handle_config_set(const httplib::Request& req, httplib::Response& res) {
@@ -7489,6 +7686,39 @@ void Server::handle_bin_change(const std::string& section,
         return;
     }
 
+    // A capture provider may run on the server thread. It cannot synchronously
+    // wait for its own Router lease to end, so leave the configured value in
+    // place and let the operator retry the hot-swap after the capture exits.
+    if (profiling_transaction_ &&
+        profiling_transaction_->running_on_current_thread()) {
+        begin_residency_lifecycle_change();
+        LOG(WARNING, "Server")
+            << "Deferring backend hot-swap until profiling capture exits"
+            << std::endl;
+        return;
+    }
+
+    std::unique_lock<std::mutex> transition_lock(stop_mutex_);
+    bool restore_profiling_admission = false;
+    uint64_t lifecycle_epoch = 0;
+    {
+        std::unique_lock<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        restore_profiling_admission = profiling_accepting_.load() &&
+                                      running_.load() &&
+                                      !shutdown_requested_.load() &&
+                                      !rebind_requested_.load();
+        begin_residency_lifecycle_change();
+        lifecycle_epoch = profiling_lifecycle_epoch_.load();
+        profiling_admission_cv_.wait(
+            lifecycle_lock, [this] { return profiling_admissions_ == 0; });
+    }
+    if (profiling_transaction_ && !profiling_transaction_->wait_for_idle()) {
+        LOG(WARNING, "Server")
+            << "Deferring backend hot-swap until profiling capture exits"
+            << std::endl;
+        return;
+    }
+
     LOG(INFO, "Server") << "*_bin config changed: " << section << "." << bin_key
                         << " = '" << new_value << "' — hot-swapping "
                         << recipe << ":" << backend << std::endl;
@@ -7556,6 +7786,14 @@ void Server::handle_bin_change(const std::string& section,
 
     SystemInfoCache::invalidate_recipes();
     model_manager_->invalidate_models_cache();
+
+    if (restore_profiling_admission) {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        if (profiling_lifecycle_epoch_.load() == lifecycle_epoch &&
+            !shutdown_requested_.load() && !rebind_requested_.load()) {
+            profiling_accepting_.store(true);
+        }
+    }
 }
 
 void Server::apply_config_side_effects(const json& applied_changes) {
@@ -7566,26 +7804,23 @@ void Server::apply_config_side_effects(const json& applied_changes) {
             if (new_port != current_port) {
                 LOG(INFO, "Server") << "Port change requested: " << current_port << " -> " << new_port << std::endl;
                 port_.store(new_port);
-                rebind_requested_ = true;
+                std::lock_guard<std::mutex> transition_lock(stop_mutex_);
+                {
+                    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+                    rebind_requested_ = true;
+                    begin_residency_lifecycle_change();
+                }
                 udp_beacon_.stopBroadcasting();
-                stop_http_listeners();
             }
         } else if (key == "host") {
             LOG(INFO, "Server") << "Host change requested to: " << config_->host() << std::endl;
-            rebind_requested_ = true;
-            udp_beacon_.stopBroadcasting();
-            stop_http_listeners();
-            // Restart websocket server with new host
-            if (websocket_server_) {
-                websocket_server_->stop();
-                websocket_server_ = std::make_unique<WebSocketServer>(
-                    router_.get(),
-                    config_->host(),
-                    config_->websocket_port());
-                if (running_) {
-                    websocket_server_->start();
-                }
+            std::lock_guard<std::mutex> transition_lock(stop_mutex_);
+            {
+                std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+                rebind_requested_ = true;
+                begin_residency_lifecycle_change();
             }
+            udp_beacon_.stopBroadcasting();
         } else if (key == "websocket_port") {
             if (websocket_server_) {
                 LOG(INFO, "Server") << "Restarting WebSocket server on requested port "

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2368,6 +2368,9 @@ void Server::run() {
         }
 
         {
+            // Config and backend transitions use the same lock order. Keep the
+            // bind-success admission transition atomic with respect to them.
+            std::lock_guard<std::mutex> transition_lock(stop_mutex_);
             std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
             if (!shutdown_requested_.load() && !rebind_requested_.load())
                 profiling_accepting_.store(true);
@@ -2432,8 +2435,12 @@ void Server::run() {
         // Join the listener threads before deciding whether a rebind is still
         // needed. A config update can arrive during the joins, so the
         // admission barrier is applied from the final lifecycle snapshot.
-        if (rebind_requested_.load())
+        if (rebind_requested_.load()) {
+            // Only the serving thread closes these fronts during a rebind, but
+            // serialize that close with stop() and config transitions.
+            std::lock_guard<std::mutex> transition_lock(stop_mutex_);
             stop_http_listeners();
+        }
         if (http_v4_thread_.joinable())
             http_v4_thread_.join();
         if (http_v6_thread_.joinable())
@@ -2442,16 +2449,17 @@ void Server::run() {
         bool should_rebind = false;
         uint64_t rebind_epoch = 0;
         {
+            std::lock_guard<std::mutex> transition_lock(stop_mutex_);
             std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
             should_rebind = rebind_requested_.load() &&
                             !shutdown_requested_.load();
             if (should_rebind)
                 rebind_epoch = profiling_lifecycle_epoch_.load();
-        }
-        if (!should_rebind) {
-            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
-            profiling_accepting_.store(false);
-            break;  // Normal exit or shutdown won the lifecycle race.
+            if (!should_rebind) {
+                profiling_accepting_.store(false);
+                running_ = false;
+                break;  // Normal exit or shutdown won the lifecycle race.
+            }
         }
 
         if (profiling_transaction_ &&
@@ -7807,6 +7815,12 @@ void Server::apply_config_side_effects(const json& applied_changes) {
                 std::lock_guard<std::mutex> transition_lock(stop_mutex_);
                 {
                     std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+                    if (!running_.load() || shutdown_requested_.load()) {
+                        LOG(INFO, "Server")
+                            << "Port change will apply on the next server run"
+                            << std::endl;
+                        continue;
+                    }
                     rebind_requested_ = true;
                     begin_residency_lifecycle_change();
                 }
@@ -7817,6 +7831,12 @@ void Server::apply_config_side_effects(const json& applied_changes) {
             std::lock_guard<std::mutex> transition_lock(stop_mutex_);
             {
                 std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+                if (!running_.load() || shutdown_requested_.load()) {
+                    LOG(INFO, "Server")
+                        << "Host change will apply on the next server run"
+                        << std::endl;
+                    continue;
+                }
                 rebind_requested_ = true;
                 begin_residency_lifecycle_change();
             }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2447,6 +2447,7 @@ void Server::run() {
             http_v6_thread_.join();
 
         bool should_rebind = false;
+        bool terminal = false;
         uint64_t rebind_epoch = 0;
         {
             std::lock_guard<std::mutex> transition_lock(stop_mutex_);
@@ -2457,9 +2458,13 @@ void Server::run() {
                 rebind_epoch = profiling_lifecycle_epoch_.load();
             if (!should_rebind) {
                 profiling_accepting_.store(false);
-                running_ = false;
-                break;  // Normal exit or shutdown won the lifecycle race.
+                shutdown_requested_ = true;
+                terminal = true;
             }
+        }
+        if (terminal) {
+            stop();
+            break;  // Normal exit or shutdown won the lifecycle race.
         }
 
         if (profiling_transaction_ &&

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2519,6 +2519,14 @@ void Server::run() {
                 rebind_requested_ = false;
         }
     }
+
+    // Keep shutdown latched while an external stop is still unwinding the
+    // serving thread; only the serving thread may reopen a completed run.
+    {
+        std::lock_guard<std::mutex> transition_lock(stop_mutex_);
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        shutdown_requested_ = false;
+    }
 }
 
 
@@ -2692,10 +2700,6 @@ void Server::stop() {
         pinned_model_loading_thread_.join();
     }
 
-    {
-        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
-        shutdown_requested_ = false;  // Permit an explicit later run() restart.
-    }
 }
 
 // Generates an actionable error message for model loading failures.

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -36,8 +36,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <fstream>
 #include <map>
@@ -2213,6 +2213,18 @@ void Server::setup_http_logger(httplib::Server &web_server) {
 void Server::run() {
     std::string host = config_->host();
     LOG(INFO, "Server") << "Starting HTTP server on " << host << ":" << port_ << std::endl;
+
+    // Recreate the WebSocket endpoint from the current host before a stopped
+    // server starts again; a host update received during shutdown cannot
+    // replace the serving object until the serving thread has returned.
+    {
+        std::lock_guard<std::mutex> transition_lock(stop_mutex_);
+        if (websocket_server_) {
+            websocket_server_->stop();
+        }
+        websocket_server_ = std::make_unique<WebSocketServer>(
+            router_.get(), config_->host(), config_->websocket_port());
+    }
 
     std::string ipv4 = resolve_host_to_ip(AF_INET, host);
     std::string ipv6 = resolve_host_to_ip(AF_INET6, host);
@@ -7608,9 +7620,9 @@ void Server::handle_jobs_delete(const httplib::Request& req, httplib::Response& 
 void Server::handle_shutdown(const httplib::Request& req, httplib::Response& res) {
     LOG(INFO, "Server") << "Shutdown request received" << std::endl;
 
-    // Close profiling admission before the asynchronous stop path tears down
-    // Router. A capture provider that owns this request thread cannot be
-    // waited on here; stop() performs the cleanup after the callback returns.
+    // Close profiling admission before the serving thread tears down Router.
+    // A capture provider that owns this request thread cannot be waited on here;
+    // stop() completes cleanup after the callback returns.
     set_shutdown_requested(true);
     {
         std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
@@ -7840,9 +7852,22 @@ void Server::apply_config_side_effects(const json& applied_changes) {
             std::lock_guard<std::mutex> transition_lock(stop_mutex_);
             {
                 std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
-                if (!running_.load() || shutdown_requested_.load()) {
+                if (!running_.load()) {
+                    if (websocket_server_) {
+                        websocket_server_->stop();
+                    }
+                    websocket_server_ = std::make_unique<WebSocketServer>(
+                        router_.get(),
+                        config_->host(),
+                        config_->websocket_port());
                     LOG(INFO, "Server")
                         << "Host change will apply on the next server run"
+                        << std::endl;
+                    continue;
+                }
+                if (shutdown_requested_.load()) {
+                    LOG(INFO, "Server")
+                        << "Host change deferred while server shutdown is in progress"
                         << std::endl;
                     continue;
                 }

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -442,14 +442,23 @@ void test_latched_abort_pulses(TestState &state, Router &router) {
                   "server lifecycle abort has no candidate");
 
     std::promise<void> precedence_entered;
+    std::promise<void> precedence_poll;
+    std::promise<void> precedence_observed;
     std::promise<void> precedence_release;
+    auto precedence_poll_signal = precedence_poll.get_future().share();
+    auto precedence_observed_signal = precedence_observed.get_future();
     auto precedence_signal = precedence_release.get_future().share();
     std::atomic<bool> precedence_cancel{false};
+    std::atomic<bool> precedence_cancel_observed{false};
     auto precedence_run = std::async(std::launch::async, [&] {
         return transaction.run(
             "profile/1",
-            [&](Router &, const ProfilingCancellationCheck &) {
+            [&](Router &, const ProfilingCancellationCheck &should_abort) {
                 precedence_entered.set_value();
+                precedence_poll_signal.wait();
+                if (should_abort())
+                    precedence_cancel_observed.store(true);
+                precedence_observed.set_value();
                 precedence_signal.wait();
                 return capture(draft());
             },
@@ -460,6 +469,13 @@ void test_latched_abort_pulses(TestState &state, Router &router) {
                       std::future_status::ready,
                   "abort precedence capture starts");
     precedence_cancel.store(true);
+    precedence_poll.set_value();
+    const bool cancellation_observed =
+        precedence_observed_signal.wait_for(1s) == std::future_status::ready;
+    state.require(cancellation_observed,
+                  "precedence capture observes cancellation before restart");
+    state.require(precedence_cancel_observed.load(),
+                  "precedence capture latches cancellation before restart");
     transaction.request_abort(ProfilingAbortReason::Restarted);
     precedence_release.set_value();
     auto precedence_result = precedence_run.get();

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -1,0 +1,647 @@
+#include "lemon/config_file.h"
+#include "lemon/residency/profiling_transaction.h"
+#include "lemon/router.h"
+
+#include <nlohmann/json.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+using namespace lemon;
+using namespace lemon::residency;
+
+std::string digest(char value) { return std::string(64, value); }
+
+std::vector<ClaimFamilyClosure> claims() {
+    return {
+        ClaimFamilyClosure{
+            ClaimFamily::ConsumableCapacity, ClaimCompleteness::KnownZero, {}},
+        ClaimFamilyClosure{
+            ClaimFamily::SafetyFloor, ClaimCompleteness::KnownZero, {}},
+        ClaimFamilyClosure{
+            ClaimFamily::CardinalityPool, ClaimCompleteness::KnownZero, {}},
+        ClaimFamilyClosure{ClaimFamily::CompatibilityExclusivity,
+                           ClaimCompleteness::NotApplicable,
+                           {}},
+    };
+}
+
+LocalOverlaySelectorIdentity selector() {
+    RuntimeCatalogSelector catalog;
+    catalog.source_support_baseline = std::string(40, 'a');
+    catalog.base_variant = "llamacpp-rocm";
+    catalog.platform = "linux-amd-rocm-llamacpp";
+    catalog.backend_channel = "stable";
+    catalog.model_type = "llm";
+    catalog.operation_template = OperationTemplate::Adm;
+    catalog.operation_kind = OperationKind::Admission;
+    catalog.constraints = {
+        ConstraintKind::Ownership,
+        ConstraintKind::GpuSharedResidency,
+        ConstraintKind::ModelTypePool,
+        ConstraintKind::HostMemAvailableFloor,
+    };
+    catalog.recovery = "native_subprocess_tree";
+    catalog.material_profiles = {
+        {"configuration_profile",
+         "profile-free-residency-estimation-v1-text-only"},
+        {"hardware_profile", "hatchery-gfx1151-shared-gtt-v1"},
+        {"workload_profile", "hatchery-text-generation-campaign-v1"},
+    };
+
+    return LocalOverlaySelectorIdentity{
+        digest('1'), std::move(catalog), "model/alpha", digest('2'),
+        digest('3'), digest('4'),        digest('5'),   digest('6'),
+        digest('7'), digest('8'),        digest('9'),   digest('a')};
+}
+
+ProfilingInputEnvelopeDraft draft(std::string transaction_id = "profile/1") {
+    ProfilingInputEnvelopeDraft value;
+    value.schema = supported_local_overlay_schema;
+    value.deployment_id = digest('b');
+    value.sequence = 1;
+    value.profiling_transaction_id = std::move(transaction_id);
+    value.selector = selector();
+    value.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    value.attributed_claims = claims();
+    value.baseline_observation_sha256 = digest('c');
+    value.workload_observation_sha256 = digest('d');
+    value.release_observation_sha256 = digest('e');
+    value.observation_contract_sha256 = digest('f');
+    value.predictor_contract_sha256 = digest('0');
+    value.observed_at = "2026-08-23T10:00:00Z";
+    value.fresh_until = "2026-08-23T10:05:00Z";
+    value.max_clock_skew_milliseconds = 1000;
+    value.attribution_complete = true;
+    value.external_demand_absent = true;
+    value.lifecycle_release_verified = true;
+    return value;
+}
+
+ProfilingTransactionCapture capture(ProfilingInputEnvelopeDraft value) {
+    ProfilingTransactionCapture result;
+    result.draft = std::move(value);
+    result.baseline_captured = true;
+    result.workload_captured = true;
+    result.release_captured = true;
+    result.identity_complete = true;
+    result.observations_fresh = true;
+    result.observations_healthy = true;
+    result.uncertainty_bound_verified = true;
+    result.safety_margin_verified = true;
+    return result;
+}
+
+ProfilingTransactionOptions options() {
+    ProfilingTransactionOptions value;
+    value.gate_timeout = 500ms;
+    value.retry_interval = 1ms;
+    return value;
+}
+
+RuntimeConfig make_config() {
+    nlohmann::json values = ConfigFile::get_defaults();
+    values["max_loaded_models"] = 2;
+    values["log_level"] = "error";
+    values["offline"] = true;
+    values["no_fetch_executables"] = true;
+    return RuntimeConfig(values);
+}
+
+bool acquire_gate(Router &router) {
+    for (int attempt = 0; attempt < 500; ++attempt) {
+        auto request = router.request_exclusive();
+        if (request.pending()) {
+            const auto result = router.try_begin_exclusive(request);
+            if (result == Router::ExclusiveAcquireResult::Acquired)
+                return true;
+            if (result != Router::ExclusiveAcquireResult::Retry)
+                return false;
+        } else if (request.result() != Router::ExclusiveAcquireResult::Retry) {
+            return false;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return false;
+}
+
+struct TestState {
+    std::atomic<bool> ok{true};
+
+    void require(bool condition, const char *message) {
+        if (!condition) {
+            std::cerr << "[FAIL] " << message << '\n';
+            ok.store(false);
+        }
+    }
+
+    void require(bool condition, const std::string &message) {
+        require(condition, message.c_str());
+    }
+};
+
+void test_accepts_and_releases_gate(TestState &state, Router &router) {
+    ProfilingTransaction transaction(router, options());
+
+    std::promise<void> capture_entered;
+    auto capture_entered_signal = capture_entered.get_future();
+    std::promise<void> release_capture;
+    auto release_capture_signal = release_capture.get_future().share();
+    std::promise<void> queued_started;
+    std::future<Router::PreparedModelLoad> queued;
+
+    auto run = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1",
+            [&](Router &gated_router, const ProfilingCancellationCheck &) {
+                capture_entered.set_value();
+                auto nested_request = gated_router.request_exclusive();
+                state.require(
+                    nested_request.result() ==
+                        Router::ExclusiveAcquireResult::InvalidOrder,
+                    "profiling capture cannot nest a Router exclusive gate");
+                release_capture_signal.wait();
+                return capture(draft());
+            });
+    });
+
+    state.require(capture_entered_signal.wait_for(1s) ==
+                      std::future_status::ready,
+                  "profiling capture acquires the gate before queued work");
+    queued = std::async(std::launch::async, [&] {
+        queued_started.set_value();
+        return router.prepare_model_load("queued.model",
+                                         LoadPurpose::UserInference);
+    });
+    state.require(queued_started.get_future().wait_for(1s) ==
+                      std::future_status::ready,
+                  "ordinary model work starts while profiling owns the gate");
+    state.require(queued.wait_for(50ms) == std::future_status::timeout,
+                  "ordinary model work queues behind profiling gate");
+    release_capture.set_value();
+    auto result = run.get();
+
+    state.require(result.accepted(), "valid profiling capture is accepted");
+    state.require(result.candidate.has_value(),
+                  "accepted capture returns candidate");
+    try {
+        auto preparation = queued.get();
+        router.abandon_prepared_model_load(std::move(preparation));
+    } catch (const std::exception &error) {
+        state.require(false, error.what());
+    }
+    const bool reacquired = acquire_gate(router);
+    state.require(reacquired, "profiling transaction releases Router gate");
+    if (reacquired)
+        router.end_exclusive();
+}
+
+void test_rejects_incomplete_capture(TestState &state, Router &router) {
+    ProfilingTransaction transaction(router, options());
+    auto result = transaction.run(
+        "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
+            auto value = capture(draft());
+            value.release_captured = false;
+            return value;
+        });
+    state.require(result.status ==
+                      ProfilingTransactionStatus::EvidenceUnavailable,
+                  "incomplete lifecycle evidence returns inactive result");
+    state.require(!result.candidate.has_value(),
+                  "incomplete evidence has no candidate");
+    const bool reacquired = acquire_gate(router);
+    state.require(reacquired, "failed capture releases Router gate");
+    if (reacquired)
+        router.end_exclusive();
+}
+
+void test_rejects_unsafe_evidence(TestState &state, Router &router) {
+    const auto expect_rejected =
+        [&](const char *label,
+            const std::function<void(ProfilingTransactionCapture &)> &mutate,
+            ProfilingTransactionStatus status) {
+            ProfilingTransaction transaction(router, options());
+            auto result = transaction.run(
+                "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
+                    auto value = capture(draft());
+                    mutate(value);
+                    return value;
+                });
+            state.require(result.status == status, label);
+            state.require(!result.candidate.has_value(),
+                          "unsafe profiling evidence has no candidate");
+            state.require(
+                result.diagnostic.size() <= max_local_overlay_diagnostic_bytes,
+                "profiling diagnostics stay within the local bound");
+            const bool reacquired = acquire_gate(router);
+            state.require(reacquired, "unsafe evidence releases Router gate");
+            if (reacquired)
+                router.end_exclusive();
+        };
+
+    expect_rejected(
+        "incomplete attribution returns inactive result",
+        [](auto &value) { value.draft->attribution_complete = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "external demand returns inactive result",
+        [](auto &value) { value.draft->external_demand_absent = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "unverified release returns inactive result",
+        [](auto &value) { value.draft->lifecycle_release_verified = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "stale observations return inactive result",
+        [](auto &value) { value.observations_fresh = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "incomplete identity returns inactive result",
+        [](auto &value) { value.identity_complete = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "unhealthy observations return inactive result",
+        [](auto &value) { value.observations_healthy = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "unbounded uncertainty returns inactive result",
+        [](auto &value) { value.uncertainty_bound_verified = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "unverified safety margin returns inactive result",
+        [](auto &value) { value.safety_margin_verified = false; },
+        ProfilingTransactionStatus::EvidenceUnavailable);
+    expect_rejected(
+        "unknown claim family returns invalid evidence",
+        [](auto &value) {
+            value.draft->attributed_claims.front().family =
+                static_cast<ClaimFamily>(99);
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "capture transaction ID must match request",
+        [](auto &value) {
+            value.draft->profiling_transaction_id = "profile/other";
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+}
+
+void test_rejects_concurrent_run(TestState &state, Router &router) {
+    ProfilingTransaction transaction(router, options());
+    std::promise<void> entered;
+    std::promise<void> release;
+    auto release_signal = release.get_future().share();
+    auto first = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
+                state.require(
+                    transaction.running(),
+                    "transaction marks itself running during capture");
+                state.require(!transaction.wait_for_idle(),
+                              "owner thread does not wait on itself");
+                entered.set_value();
+                release_signal.wait();
+                return capture(draft());
+            });
+    });
+    auto entered_signal = entered.get_future();
+    state.require(entered_signal.wait_for(1s) == std::future_status::ready,
+                  "first profiling transaction enters capture");
+    auto second = transaction.run(
+        "profile/2", [&](Router &, const ProfilingCancellationCheck &) {
+            return capture(draft("profile/2"));
+        });
+    state.require(
+        second.status == ProfilingTransactionStatus::AlreadyRunning,
+        "a second profiling transaction is rejected deterministically");
+    release.set_value();
+    state.require(first.get().accepted(),
+                  "the first profiling transaction completes");
+    state.require(!transaction.running(), "transaction clears running state");
+}
+
+void test_latched_abort_pulses(TestState &state, Router &router) {
+    ProfilingTransaction transaction(router, options());
+
+    {
+        std::promise<void> entered;
+        std::promise<void> observed;
+        std::promise<void> release;
+        auto release_signal = release.get_future().share();
+        std::atomic<bool> cancel{false};
+        std::atomic<bool> stop_capture{false};
+        auto entered_signal = entered.get_future();
+        auto observed_signal = observed.get_future();
+        auto run = std::async(std::launch::async, [&] {
+            return transaction.run(
+                "profile/1",
+                [&](Router &, const ProfilingCancellationCheck &should_abort) {
+                    entered.set_value();
+                    while (!should_abort() && !stop_capture.load())
+                        std::this_thread::sleep_for(1ms);
+                    observed.set_value();
+                    release_signal.wait();
+                    return capture(draft());
+                },
+                &cancel);
+        });
+        const bool entered_ready =
+            entered_signal.wait_for(1s) == std::future_status::ready;
+        state.require(entered_ready, "cancel pulse capture starts");
+        cancel.store(true);
+        const bool observed_ready =
+            observed_signal.wait_for(1s) == std::future_status::ready;
+        state.require(observed_ready, "capture observes cancellation pulse");
+        if (!observed_ready)
+            stop_capture.store(true);
+        if (observed_ready)
+            cancel.store(false);
+        release.set_value();
+        auto result = run.get();
+        state.require(result.status == ProfilingTransactionStatus::Cancelled,
+                      "latched cancellation survives source reset");
+        state.require(!result.candidate.has_value(),
+                      "latched cancellation has no candidate");
+    }
+
+    {
+        std::promise<void> entered;
+        std::promise<void> observed;
+        std::promise<void> release;
+        auto release_signal = release.get_future().share();
+        std::atomic<bool> restart{false};
+        std::atomic<bool> stop_capture{false};
+        auto entered_signal = entered.get_future();
+        auto observed_signal = observed.get_future();
+        auto run = std::async(std::launch::async, [&] {
+            return transaction.run(
+                "profile/1",
+                [&](Router &, const ProfilingCancellationCheck &should_abort) {
+                    entered.set_value();
+                    while (!should_abort() && !stop_capture.load())
+                        std::this_thread::sleep_for(1ms);
+                    observed.set_value();
+                    release_signal.wait();
+                    return capture(draft());
+                },
+                nullptr, [&] { return restart.load(); });
+        });
+        const bool entered_ready =
+            entered_signal.wait_for(1s) == std::future_status::ready;
+        state.require(entered_ready, "restart pulse capture starts");
+        restart.store(true);
+        const bool observed_ready =
+            observed_signal.wait_for(1s) == std::future_status::ready;
+        state.require(observed_ready, "capture observes restart pulse");
+        if (!observed_ready)
+            stop_capture.store(true);
+        if (observed_ready)
+            restart.store(false);
+        release.set_value();
+        auto result = run.get();
+        state.require(result.status == ProfilingTransactionStatus::Restarted,
+                      "latched restart survives source reset");
+        state.require(!result.candidate.has_value(),
+                      "latched restart has no candidate");
+    }
+
+    std::promise<void> entered;
+    std::promise<void> release;
+    auto release_signal = release.get_future().share();
+    auto entered_signal = entered.get_future();
+    auto run = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
+                entered.set_value();
+                release_signal.wait();
+                return capture(draft());
+            });
+    });
+    const bool entered_ready =
+        entered_signal.wait_for(1s) == std::future_status::ready;
+    state.require(entered_ready, "direct lifecycle abort capture starts");
+    transaction.request_abort(ProfilingAbortReason::Restarted);
+    release.set_value();
+    auto result = run.get();
+    state.require(result.status == ProfilingTransactionStatus::Restarted,
+                  "server lifecycle abort is sticky");
+    state.require(!result.candidate.has_value(),
+                  "server lifecycle abort has no candidate");
+
+    std::promise<void> precedence_entered;
+    std::promise<void> precedence_release;
+    auto precedence_signal = precedence_release.get_future().share();
+    std::atomic<bool> precedence_cancel{false};
+    auto precedence_run = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1",
+            [&](Router &, const ProfilingCancellationCheck &) {
+                precedence_entered.set_value();
+                precedence_signal.wait();
+                return capture(draft());
+            },
+            &precedence_cancel);
+    });
+    auto precedence_entered_signal = precedence_entered.get_future();
+    state.require(precedence_entered_signal.wait_for(1s) ==
+                      std::future_status::ready,
+                  "abort precedence capture starts");
+    precedence_cancel.store(true);
+    transaction.request_abort(ProfilingAbortReason::Restarted);
+    precedence_release.set_value();
+    auto precedence_result = precedence_run.get();
+    state.require(precedence_result.status ==
+                      ProfilingTransactionStatus::Restarted,
+                  "restart supersedes a latched cancellation");
+    state.require(!precedence_result.candidate.has_value(),
+                  "restart precedence has no candidate");
+
+    const bool reacquired = acquire_gate(router);
+    state.require(reacquired, "latched abort releases Router gate");
+    if (reacquired)
+        router.end_exclusive();
+}
+
+void test_cancellation_and_restart(TestState &state, Router &router) {
+    ProfilingTransactionOptions timeout_options = options();
+    timeout_options.gate_timeout = 100ms;
+    ProfilingTransaction timeout_transaction(router, timeout_options);
+    std::promise<void> timeout_gate_entered;
+    std::promise<void> timeout_gate_release;
+    auto timeout_release = timeout_gate_release.get_future().share();
+    auto timeout_holder = std::async(std::launch::async, [&] {
+        const bool acquired = acquire_gate(router);
+        state.require(acquired, "test owns Router gate for timeout");
+        if (acquired) {
+            timeout_gate_entered.set_value();
+            timeout_release.wait();
+            router.end_exclusive();
+        } else {
+            timeout_gate_entered.set_value();
+        }
+    });
+    auto timeout_entered_signal = timeout_gate_entered.get_future();
+    state.require(timeout_entered_signal.wait_for(1s) ==
+                      std::future_status::ready,
+                  "timeout test owns Router gate");
+    auto timeout_result = timeout_transaction.run(
+        "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
+            state.require(false, "timed-out transaction must not capture");
+            return capture(draft());
+        });
+    state.require(timeout_result.status ==
+                      ProfilingTransactionStatus::GateTimeout,
+                  "gate acquisition is bounded");
+    state.require(!timeout_result.candidate.has_value(),
+                  "gate timeout has no candidate");
+    timeout_gate_release.set_value();
+    timeout_holder.get();
+
+    ProfilingTransaction transaction(router, options());
+    const bool gate_acquired = acquire_gate(router);
+    state.require(gate_acquired, "test owns Router gate");
+    if (!gate_acquired)
+        return;
+
+    std::atomic<bool> cancelled{false};
+    auto waiting = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1",
+            [&](Router &, const ProfilingCancellationCheck &) {
+                state.require(false, "cancelled transaction must not capture");
+                return capture(draft());
+            },
+            &cancelled);
+    });
+    std::this_thread::sleep_for(50ms);
+    cancelled.store(true);
+    auto cancelled_result = waiting.get();
+    state.require(cancelled_result.status ==
+                      ProfilingTransactionStatus::Cancelled,
+                  "cancellation aborts a transaction waiting for the gate");
+    state.require(!cancelled_result.candidate.has_value(),
+                  "gate cancellation has no candidate");
+    router.end_exclusive();
+
+    std::promise<void> entered;
+    std::promise<void> release;
+    auto release_signal = release.get_future().share();
+    std::atomic<bool> capture_cancelled{false};
+    auto entered_signal = entered.get_future();
+    auto active_cancel = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1",
+            [&](Router &, const ProfilingCancellationCheck &should_abort) {
+                entered.set_value();
+                while (!should_abort() && !capture_cancelled.load())
+                    std::this_thread::sleep_for(1ms);
+                release_signal.wait();
+                return capture(draft());
+            },
+            &capture_cancelled);
+    });
+    const bool entered_ready =
+        entered_signal.wait_for(1s) == std::future_status::ready;
+    state.require(entered_ready, "active cancellation capture starts");
+    capture_cancelled.store(true);
+    release.set_value();
+    auto active_cancel_result = active_cancel.get();
+    state.require(active_cancel_result.status ==
+                      ProfilingTransactionStatus::Cancelled,
+                  "cancellation during capture releases Router gate");
+    state.require(!active_cancel_result.candidate.has_value(),
+                  "capture cancellation has no candidate");
+
+    std::promise<void> restart_entered;
+    std::promise<void> restart_release;
+    auto restart_signal = restart_release.get_future().share();
+    std::atomic<bool> restarting{false};
+    std::atomic<bool> stop_restart_capture{false};
+    auto restart_entered_signal = restart_entered.get_future();
+    auto active_restart = std::async(std::launch::async, [&] {
+        return transaction.run(
+            "profile/1",
+            [&](Router &, const ProfilingCancellationCheck &should_abort) {
+                restart_entered.set_value();
+                while (!should_abort() && !stop_restart_capture.load())
+                    std::this_thread::sleep_for(1ms);
+                restart_signal.wait();
+                return capture(draft());
+            },
+            nullptr, [&] { return restarting.load(); });
+    });
+    const bool restart_entered_ready =
+        restart_entered_signal.wait_for(1s) == std::future_status::ready;
+    state.require(restart_entered_ready, "active restart capture starts");
+    restarting.store(true);
+    if (!restart_entered_ready)
+        stop_restart_capture.store(true);
+    restart_release.set_value();
+    auto active_restart_result = active_restart.get();
+    state.require(active_restart_result.status ==
+                      ProfilingTransactionStatus::Restarted,
+                  "restart during capture releases Router gate");
+    state.require(!active_restart_result.candidate.has_value(),
+                  "capture restart has no candidate");
+
+    auto restarted = transaction.run(
+        "profile/1",
+        [&](Router &, const ProfilingCancellationCheck &) {
+            state.require(false, "restart abort must not capture");
+            return capture(draft());
+        },
+        nullptr, [] { return true; });
+    state.require(restarted.status == ProfilingTransactionStatus::Restarted,
+                  "restart aborts a transaction before gate acquisition");
+}
+
+void test_exception_releases_gate(TestState &state, Router &router) {
+    ProfilingTransaction transaction(router, options());
+    auto result = transaction.run(
+        "profile/1",
+        [&](Router &,
+            const ProfilingCancellationCheck &) -> ProfilingTransactionCapture {
+            throw std::runtime_error("capture failed");
+        });
+    state.require(result.status == ProfilingTransactionStatus::Failed,
+                  "capture exception returns failed result");
+    state.require(!result.candidate.has_value(),
+                  "capture exception has no candidate");
+    const bool reacquired = acquire_gate(router);
+    state.require(reacquired, "capture exception releases Router gate");
+    if (reacquired)
+        router.end_exclusive();
+}
+
+} // namespace
+
+int main() {
+    TestState state;
+    RuntimeConfig config = make_config();
+    RuntimeConfig::set_global(&config);
+    {
+        Router router(&config, nullptr, nullptr);
+        test_accepts_and_releases_gate(state, router);
+        test_rejects_incomplete_capture(state, router);
+        test_rejects_unsafe_evidence(state, router);
+        test_rejects_concurrent_run(state, router);
+        test_latched_abort_pulses(state, router);
+        test_cancellation_and_restart(state, router);
+        test_exception_releases_gate(state, router);
+    }
+    RuntimeConfig::set_global(nullptr);
+    return state.ok.load() ? 0 : 1;
+}


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 906 additions, 63 deletions" src="https://img.shields.io/badge/IMPL-%2B906%20%E2%88%9263-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 663 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B663%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 6 touched" src="https://img.shields.io/badge/FILES-6-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 906 additions, 63 deletions" src="https://img.shields.io/badge/IMPL-%2B906%20%E2%88%9263-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 5 implementation files" src="https://img.shields.io/badge/FILES-5-5F6B78?style=flat" height="16"></picture>
  - [`CMakeLists.txt`](https://github.com/nisavid/lemonade/pull/129/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) <picture><img alt="20 additions, 0 deletions" title="20 additions, 0 deletions" src="https://img.shields.io/badge/%2B20-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/profiling_transaction.h`](https://github.com/nisavid/lemonade/pull/129/files#diff-c9cf2ca0c9baf8c161c1fc26386953492f8c626f60c96e56f7d2ddd8d0b109db) <picture><img alt="127 additions, 0 deletions" title="127 additions, 0 deletions" src="https://img.shields.io/badge/%2B127-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/server.h`](https://github.com/nisavid/lemonade/pull/129/files#diff-422e93385c59a644069286b4b8fcf44e3e1a168ed89ab0099c342dacd8cf7973) <picture><img alt="31 additions, 11 deletions" title="31 additions, 11 deletions" src="https://img.shields.io/badge/%2B31-%E2%88%9211-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/129/files#diff-ea5131019f6fd33b90980405887b634fb161b5fd8367c8acf451c849fa3f24a5) <picture><img alt="387 additions, 0 deletions" title="387 additions, 0 deletions" src="https://img.shields.io/badge/%2B387-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/server.cpp`](https://github.com/nisavid/lemonade/pull/129/files#diff-69b799dde63dbc74c434ff8c0d4df45824f2f134a059eb42f9cb6b994486d673) <picture><img alt="341 additions, 52 deletions" title="341 additions, 52 deletions" src="https://img.shields.io/badge/%2B341-%E2%88%9252-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 663 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B663%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 1 test file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/129/files#diff-6eccc8288ec167c7e83b3691fca7a50b36c196c464b41e557e3303ecbd1c2004) <picture><img alt="663 additions, 0 deletions" title="663 additions, 0 deletions" src="https://img.shields.io/badge/%2B663-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Refs #120. This PR adds the server-owned profiling transaction boundary: exclusive Router admission, queued ordinary model work, fail-closed envelope checks, lifecycle abort fencing, and deterministic coverage. It is intentionally a trusted internal seam; it does not expose an HTTP route, run a live benchmark provider, or publish shared catalog or campaign evidence.

## Route

This is the transaction-boundary slice on the [first-release portable-residency map](https://github.com/nisavid/lemonade/issues/115). The existing route carries the remaining work: [method selection and local calibration](https://github.com/nisavid/lemonade/issues/121), [planner integration](https://github.com/nisavid/lemonade/issues/122), [revalidation and rollback](https://github.com/nisavid/lemonade/issues/123), [decision traces](https://github.com/nisavid/lemonade/issues/124), and [evidence retention/export](https://github.com/nisavid/lemonade/issues/118). The live provider, serialized health/freshness/uncertainty/safety attestations, publication handoff, and hard gate-deadline semantics remain follow-up work on that route; this PR does not claim those capabilities.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

Review entry points are `src/cpp/server/residency/profiling_transaction.cpp` for the transaction and `src/cpp/server/server.cpp` for server admission, abort, quiescence, and teardown fencing. The capture contract is synchronous and cooperative: the Server-owned provider must bind identity, freshness, health, uncertainty, and safety evidence before any later publication step.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build <configured-build-dir> --target cpp-ci-tests -j2` — passed.
- `ctest -L cpp-ci --output-on-failure` — 64/64 passed.
- `ctest -R '^ResidencyProfilingTransaction$' --output-on-failure` — passed; the focused test was repeated during final verification.
- `PYTHONDONTWRITEBYTECODE=1 python3 test/residency/contract/test_generated_contract.py` and `python3 tools/generate_residency_contract.py --check` — passed.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [x] This PR introduces breaking changes.
- [ ] This PR does not introduce breaking changes.

The internal shutdown path now keeps teardown on the serving thread instead of retaining a detached raw `Server` pointer. Embedded callers must keep the serving owner alive until its run loop completes. No new public profiling route or publication API is introduced.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated profiling transactions with exclusive capture, cancellation, restart handling, and detailed completion statuses.
  - Added validation for profiling evidence and runtime configuration.
  - Improved profiling safety during server shutdown, startup, rebinding, and backend changes.
  - Shutdown requests now return promptly while cleanup completes safely.

- **Bug Fixes**
  - Prevented profiling activity from conflicting with lifecycle transitions or server teardown.

- **Tests**
  - Added comprehensive coverage for concurrency, cancellation, timeouts, aborts, invalid evidence, and capture failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
