### PR TITLE
feat(residency/profiling): bind evidence under hard deadlines

### DIFF
--- a/docs/api/schemas/residency/profiling_phase_attestation.schema.json
+++ b/docs/api/schemas/residency/profiling_phase_attestation.schema.json
@@ -1,0 +1,1408 @@
+{
+  "$defs": {
+    "authority_status": {
+      "const": "active"
+    },
+    "claim_closure": {
+      "items": false,
+      "maxItems": 4,
+      "minItems": 4,
+      "prefixItems": [
+        {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "bounded"
+                },
+                "entries": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "maximum": 18446744073709551615,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "constraint_id": {
+                        "maxLength": 128,
+                        "minLength": 1,
+                        "pattern": "^[\\u0021-\\u007e]+$",
+                        "type": "string",
+                        "x-max-utf8-bytes": 128
+                      },
+                      "unit": {
+                        "const": "bytes"
+                      }
+                    },
+                    "required": [
+                      "amount",
+                      "constraint_id",
+                      "unit"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 256,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-canonical-order": true
+                },
+                "family": {
+                  "const": "consumable_capacity"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "known_zero"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "consumable_capacity"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "not_applicable"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "consumable_capacity"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "bounded"
+                },
+                "entries": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "maximum": 18446744073709551615,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "constraint_id": {
+                        "maxLength": 128,
+                        "minLength": 1,
+                        "pattern": "^[\\u0021-\\u007e]+$",
+                        "type": "string",
+                        "x-max-utf8-bytes": 128
+                      },
+                      "unit": {
+                        "const": "bytes"
+                      }
+                    },
+                    "required": [
+                      "amount",
+                      "constraint_id",
+                      "unit"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 256,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-canonical-order": true
+                },
+                "family": {
+                  "const": "safety_floor"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "known_zero"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "safety_floor"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "not_applicable"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "safety_floor"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "bounded"
+                },
+                "entries": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "maximum": 18446744073709551615,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "constraint_id": {
+                        "maxLength": 128,
+                        "minLength": 1,
+                        "pattern": "^[\\u0021-\\u007e]+$",
+                        "type": "string",
+                        "x-max-utf8-bytes": 128
+                      },
+                      "unit": {
+                        "const": "count"
+                      }
+                    },
+                    "required": [
+                      "amount",
+                      "constraint_id",
+                      "unit"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 256,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-canonical-order": true
+                },
+                "family": {
+                  "const": "cardinality_pool"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "known_zero"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "cardinality_pool"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "not_applicable"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "cardinality_pool"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "bounded"
+                },
+                "entries": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "amount": {
+                        "const": 1,
+                        "type": "integer"
+                      },
+                      "constraint_id": {
+                        "maxLength": 128,
+                        "minLength": 1,
+                        "pattern": "^[\\u0021-\\u007e]+$",
+                        "type": "string",
+                        "x-max-utf8-bytes": 128
+                      },
+                      "unit": {
+                        "const": "count"
+                      }
+                    },
+                    "required": [
+                      "amount",
+                      "constraint_id",
+                      "unit"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 256,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-canonical-order": true
+                },
+                "family": {
+                  "const": "compatibility_exclusivity"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "known_zero"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "compatibility_exclusivity"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "completeness": {
+                  "const": "not_applicable"
+                },
+                "entries": {
+                  "maxItems": 0,
+                  "type": "array"
+                },
+                "family": {
+                  "const": "compatibility_exclusivity"
+                }
+              },
+              "required": [
+                "completeness",
+                "entries",
+                "family"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      ],
+      "type": "array",
+      "x-canonical-order": true
+    },
+    "decision_trace_reference": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "deployment_identity": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "expiry": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "method_identity": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "scope": {
+                "const": "architecture_predicate"
+              }
+            },
+            "required": [
+              "scope"
+            ]
+          },
+          "then": {
+            "properties": {
+              "architecture_predicate_sha256": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "architecture_predicate_sha256"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "scope": {
+                "const": "deployment_exact"
+              }
+            },
+            "required": [
+              "scope"
+            ]
+          },
+          "then": {
+            "properties": {
+              "architecture_predicate_sha256": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "architecture_predicate_sha256"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "architecture_predicate_sha256": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string",
+              "x-max-utf8-bytes": 64
+            }
+          ]
+        },
+        "calibration_revision_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "method_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[\\u0021-\\u007e]+$",
+          "type": "string",
+          "x-max-utf8-bytes": 128
+        },
+        "method_revision_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "operation_kind": {
+          "enum": [
+            "admission",
+            "explicit_unload",
+            "force_unload",
+            "pressure_reclamation",
+            "startup_load",
+            "service_termination",
+            "dead_backend_pruning",
+            "same_epoch_recovery_cleanup",
+            "prior_epoch_owner_cleanup",
+            "artifact_scope_recovery_cleanup",
+            "saved_pin_mutation",
+            "runtime_pin_mutation",
+            "legacy_pin_batch",
+            "resident_state_recovery_cleanup"
+          ],
+          "maxLength": 31,
+          "minLength": 1,
+          "type": "string"
+        },
+        "scope": {
+          "enum": [
+            "architecture_predicate",
+            "deployment_exact"
+          ],
+          "maxLength": 22,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "architecture_predicate_sha256",
+        "calibration_revision_sha256",
+        "method_id",
+        "method_revision_sha256",
+        "operation_kind",
+        "scope"
+      ],
+      "type": "object"
+    },
+    "object_status": {
+      "const": "qualified"
+    },
+    "previous_root_reference": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        }
+      ]
+    },
+    "root_transition": {
+      "enum": [
+        "qualification",
+        "rollback"
+      ],
+      "maxLength": 13,
+      "minLength": 1,
+      "type": "string"
+    },
+    "safety_margin_claim_closure": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/claim_closure"
+        },
+        {
+          "contains": {
+            "properties": {
+              "completeness": {
+                "const": "bounded"
+              }
+            },
+            "required": [
+              "completeness"
+            ],
+            "type": "object"
+          },
+          "minContains": 1
+        }
+      ]
+    },
+    "schema_version": {
+      "additionalProperties": false,
+      "properties": {
+        "major": {
+          "const": 1
+        },
+        "minor": {
+          "const": 0
+        }
+      },
+      "required": [
+        "major",
+        "minor"
+      ],
+      "type": "object"
+    },
+    "selector_identity": {
+      "additionalProperties": false,
+      "properties": {
+        "backend_build_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "canonical_model_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[\\u0021-\\u007e]+$",
+          "type": "string",
+          "x-max-utf8-bytes": 128
+        },
+        "catalog": {
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "ADM"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "admission"
+                    ],
+                    "maxLength": 9,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "LFR"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "admission"
+                    ],
+                    "maxLength": 9,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "NPC"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "admission"
+                    ],
+                    "maxLength": 9,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "PIN"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "legacy_pin_batch",
+                      "resident_state_recovery_cleanup",
+                      "runtime_pin_mutation",
+                      "saved_pin_mutation"
+                    ],
+                    "maxLength": 31,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "PRE"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "pressure_reclamation"
+                    ],
+                    "maxLength": 20,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "REC"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "artifact_scope_recovery_cleanup",
+                      "dead_backend_pruning",
+                      "prior_epoch_owner_cleanup",
+                      "same_epoch_recovery_cleanup",
+                      "service_termination"
+                    ],
+                    "maxLength": 31,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "STA"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "startup_load"
+                    ],
+                    "maxLength": 12,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "operation_template": {
+                    "const": "UNL"
+                  }
+                },
+                "required": [
+                  "operation_template"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "operation_kind": {
+                    "enum": [
+                      "explicit_unload",
+                      "force_unload"
+                    ],
+                    "maxLength": 15,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "operation_kind"
+                ]
+              }
+            }
+          ],
+          "properties": {
+            "backend_channel": {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[\\u0021-\\u007e]+$",
+              "type": "string",
+              "x-max-utf8-bytes": 128
+            },
+            "base_variant": {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[\\u0021-\\u007e]+$",
+              "type": "string",
+              "x-max-utf8-bytes": 128
+            },
+            "constraints": {
+              "items": {
+                "enum": [
+                  "flm_type_slot",
+                  "gpu_provider_resolved_capacity",
+                  "gpu_shared_residency",
+                  "host_effects_provider_resolved",
+                  "host_memavailable_floor",
+                  "model_type_pool",
+                  "npu_cross_family",
+                  "npu_exclusive",
+                  "ownership"
+                ],
+                "maxLength": 30,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 9,
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true,
+              "x-canonical-order": true
+            },
+            "material_profiles": {
+              "additionalProperties": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[\\u0021-\\u007e]+$",
+                "type": "string",
+                "x-max-utf8-bytes": 128
+              },
+              "maxProperties": 32,
+              "minProperties": 1,
+              "propertyNames": {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[\\u0021-\\u007e]+$",
+                "type": "string",
+                "x-max-utf8-bytes": 128
+              },
+              "type": "object"
+            },
+            "model_type": {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[\\u0021-\\u007e]+$",
+              "type": "string",
+              "x-max-utf8-bytes": 128
+            },
+            "operation_kind": {
+              "enum": [
+                "admission",
+                "explicit_unload",
+                "force_unload",
+                "pressure_reclamation",
+                "startup_load",
+                "service_termination",
+                "dead_backend_pruning",
+                "same_epoch_recovery_cleanup",
+                "prior_epoch_owner_cleanup",
+                "artifact_scope_recovery_cleanup",
+                "saved_pin_mutation",
+                "runtime_pin_mutation",
+                "legacy_pin_batch",
+                "resident_state_recovery_cleanup"
+              ],
+              "maxLength": 31,
+              "minLength": 1,
+              "type": "string"
+            },
+            "operation_template": {
+              "enum": [
+                "ADM",
+                "LFR",
+                "NPC",
+                "PIN",
+                "PRE",
+                "REC",
+                "STA",
+                "UNL"
+              ],
+              "maxLength": 3,
+              "minLength": 1,
+              "type": "string"
+            },
+            "platform": {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[\\u0021-\\u007e]+$",
+              "type": "string",
+              "x-max-utf8-bytes": 128
+            },
+            "recovery": {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[\\u0021-\\u007e]+$",
+              "type": "string",
+              "x-max-utf8-bytes": 128
+            },
+            "source_support_baseline": {
+              "maxLength": 40,
+              "minLength": 40,
+              "pattern": "^[0-9a-f]{40}$",
+              "type": "string",
+              "x-max-utf8-bytes": 40
+            }
+          },
+          "required": [
+            "backend_channel",
+            "base_variant",
+            "constraints",
+            "material_profiles",
+            "model_type",
+            "operation_kind",
+            "operation_template",
+            "platform",
+            "recovery",
+            "source_support_baseline"
+          ],
+          "type": "object"
+        },
+        "catalog_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "configuration_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "dependency_set_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "device_identity_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "driver_identity_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "model_artifact_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "operation_contract_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "topology_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "workload_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        }
+      },
+      "required": [
+        "backend_build_sha256",
+        "canonical_model_id",
+        "catalog",
+        "catalog_sha256",
+        "configuration_sha256",
+        "dependency_set_sha256",
+        "device_identity_sha256",
+        "driver_identity_sha256",
+        "model_artifact_sha256",
+        "operation_contract_sha256",
+        "topology_sha256",
+        "workload_sha256"
+      ],
+      "type": "object"
+    },
+    "source_generations": {
+      "additionalProperties": false,
+      "properties": {
+        "backend": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "configuration": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "device": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "driver": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "model": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "topology": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "workload": {
+          "maximum": 18446744073709551615,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "backend",
+        "configuration",
+        "device",
+        "driver",
+        "model",
+        "topology",
+        "workload"
+      ],
+      "type": "object"
+    },
+    "timestamp": {
+      "format": "date-time",
+      "maxLength": 20,
+      "minLength": 20,
+      "pattern": "^(?:(?:[0-9]{3}[1-9]|[0-9]{2}[1-9][0-9]|[0-9][1-9][0-9]{2}|[1-9][0-9]{3})-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))|(?:[0-9]{2}(?:0[48]|[2468][048]|[13579][26])|(?:0[48]|[2468][048]|[13579][26])00)-02-29)T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
+      "type": "string",
+      "x-max-utf8-bytes": 20
+    }
+  },
+  "$id": "residency.profiling_phase_attestation/1.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "x-residency-assert": {
+        "field": "observed_at",
+        "less_than_path": "fresh_until"
+      }
+    },
+    {
+      "x-residency-assert": {
+        "field": "source_skew_milliseconds",
+        "less_than_or_equal_path": "max_source_skew_milliseconds"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "phase": {
+            "const": "baseline"
+          }
+        },
+        "required": [
+          "phase"
+        ]
+      },
+      "then": {
+        "properties": {
+          "lifecycle_state": {
+            "const": "baseline_quiescent"
+          }
+        },
+        "required": [
+          "lifecycle_state"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "phase": {
+            "const": "workload"
+          }
+        },
+        "required": [
+          "phase"
+        ]
+      },
+      "then": {
+        "properties": {
+          "lifecycle_state": {
+            "const": "workload_complete"
+          }
+        },
+        "required": [
+          "lifecycle_state"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "phase": {
+            "const": "release"
+          }
+        },
+        "required": [
+          "phase"
+        ]
+      },
+      "then": {
+        "properties": {
+          "lifecycle_state": {
+            "const": "release_verified"
+          }
+        },
+        "required": [
+          "lifecycle_state"
+        ]
+      }
+    }
+  ],
+  "properties": {
+    "attributed_claims": {
+      "$ref": "#/$defs/claim_closure"
+    },
+    "checksum_sha256": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "deployment_id": {
+      "$ref": "#/$defs/deployment_identity"
+    },
+    "external_change_claims": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/claim_closure"
+        },
+        {
+          "not": {
+            "contains": {
+              "properties": {
+                "completeness": {
+                  "const": "bounded"
+                }
+              },
+              "required": [
+                "completeness"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "fresh_until": {
+      "$ref": "#/$defs/expiry"
+    },
+    "generations": {
+      "$ref": "#/$defs/source_generations"
+    },
+    "health": {
+      "const": "valid"
+    },
+    "lifecycle_state": {
+      "enum": [
+        "baseline_quiescent",
+        "workload_complete",
+        "release_verified"
+      ],
+      "maxLength": 18,
+      "minLength": 1,
+      "type": "string"
+    },
+    "max_source_skew_milliseconds": {
+      "maximum": 18446744073709551615,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "observation_contract_sha256": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "observation_generation": {
+      "maximum": 18446744073709551615,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "observed_at": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "observed_claims": {
+      "$ref": "#/$defs/claim_closure"
+    },
+    "owner_coverage": {
+      "const": "complete"
+    },
+    "phase": {
+      "enum": [
+        "baseline",
+        "workload",
+        "release"
+      ],
+      "maxLength": 8,
+      "minLength": 1,
+      "type": "string"
+    },
+    "predictor_contract_sha256": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "profiling_transaction_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[\\u0021-\\u007e]+$",
+      "type": "string",
+      "x-max-utf8-bytes": 128
+    },
+    "provenance_sha256": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "provider_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[\\u0021-\\u007e]+$",
+      "type": "string",
+      "x-max-utf8-bytes": 128
+    },
+    "provider_revision_sha256": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "safety_margin_claims": {
+      "$ref": "#/$defs/safety_margin_claim_closure"
+    },
+    "schema": {
+      "$ref": "#/$defs/schema_version"
+    },
+    "selector_sha256": {
+      "maxLength": 64,
+      "minLength": 64,
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string",
+      "x-max-utf8-bytes": 64
+    },
+    "source_skew_milliseconds": {
+      "maximum": 18446744073709551615,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "unattributed_claims": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/claim_closure"
+        },
+        {
+          "not": {
+            "contains": {
+              "properties": {
+                "completeness": {
+                  "const": "bounded"
+                }
+              },
+              "required": [
+                "completeness"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "uncertainty_claims": {
+      "$ref": "#/$defs/claim_closure"
+    }
+  },
+  "required": [
+    "schema",
+    "phase",
+    "deployment_id",
+    "profiling_transaction_id",
+    "selector_sha256",
+    "provider_id",
+    "provider_revision_sha256",
+    "provenance_sha256",
+    "observation_contract_sha256",
+    "predictor_contract_sha256",
+    "generations",
+    "observation_generation",
+    "observed_at",
+    "fresh_until",
+    "source_skew_milliseconds",
+    "max_source_skew_milliseconds",
+    "health",
+    "owner_coverage",
+    "observed_claims",
+    "attributed_claims",
+    "external_change_claims",
+    "unattributed_claims",
+    "uncertainty_claims",
+    "safety_margin_claims",
+    "lifecycle_state",
+    "checksum_sha256"
+  ],
+  "title": "Profiling Phase Attestation",
+  "type": "object",
+  "x-residency-required-keywords": [
+    "x-max-utf8-bytes",
+    "x-residency-assert"
+  ]
+}

--- a/docs/research/portable-residency-capability-inventory.json
+++ b/docs/research/portable-residency-capability-inventory.json
@@ -4983,6 +4983,163 @@
           }
         ]
       },
+      "profiling_phase_attestation": {
+        "version": {
+          "major": 1,
+          "minor": 0
+        },
+        "output": "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
+        "schema_type": "residency.profiling_phase_attestation/1.0",
+        "fields": {
+          "schema": {
+            "type": "local_overlay_schema_version",
+            "required": true
+          },
+          "phase": {
+            "type": "local_overlay_profiling_phase",
+            "required": true
+          },
+          "deployment_id": {
+            "type": "local_overlay_deployment_identity",
+            "required": true
+          },
+          "profiling_transaction_id": {
+            "type": "opaque",
+            "required": true,
+            "max_bytes": 128
+          },
+          "selector_sha256": {
+            "type": "sha256",
+            "required": true
+          },
+          "provider_id": {
+            "type": "opaque",
+            "required": true,
+            "max_bytes": 128
+          },
+          "provider_revision_sha256": {
+            "type": "sha256",
+            "required": true
+          },
+          "provenance_sha256": {
+            "type": "sha256",
+            "required": true
+          },
+          "observation_contract_sha256": {
+            "type": "sha256",
+            "required": true
+          },
+          "predictor_contract_sha256": {
+            "type": "sha256",
+            "required": true
+          },
+          "generations": {
+            "type": "local_overlay_source_generations",
+            "required": true
+          },
+          "observation_generation": {
+            "type": "local_overlay_positive_uint64",
+            "required": true
+          },
+          "observed_at": {
+            "type": "local_overlay_timestamp",
+            "required": true
+          },
+          "fresh_until": {
+            "type": "local_overlay_expiry",
+            "required": true
+          },
+          "source_skew_milliseconds": {
+            "type": "local_overlay_nonnegative_uint64",
+            "required": true
+          },
+          "max_source_skew_milliseconds": {
+            "type": "local_overlay_positive_uint64",
+            "required": true
+          },
+          "health": {
+            "type": "local_overlay_profiling_health",
+            "required": true
+          },
+          "owner_coverage": {
+            "type": "local_overlay_profiling_owner_coverage",
+            "required": true
+          },
+          "observed_claims": {
+            "type": "local_overlay_claim_closure",
+            "required": true
+          },
+          "attributed_claims": {
+            "type": "local_overlay_claim_closure",
+            "required": true
+          },
+          "external_change_claims": {
+            "type": "local_overlay_zero_claim_closure",
+            "required": true
+          },
+          "unattributed_claims": {
+            "type": "local_overlay_zero_claim_closure",
+            "required": true
+          },
+          "uncertainty_claims": {
+            "type": "local_overlay_claim_closure",
+            "required": true
+          },
+          "safety_margin_claims": {
+            "type": "local_overlay_safety_margin_claim_closure",
+            "required": true
+          },
+          "lifecycle_state": {
+            "type": "local_overlay_profiling_lifecycle_state",
+            "required": true
+          },
+          "checksum_sha256": {
+            "type": "sha256",
+            "required": true
+          }
+        },
+        "conditionals": [
+          {
+            "assert": {
+              "field": "observed_at",
+              "less_than_path": "fresh_until"
+            }
+          },
+          {
+            "assert": {
+              "field": "source_skew_milliseconds",
+              "less_than_or_equal_path": "max_source_skew_milliseconds"
+            }
+          },
+          {
+            "if": {
+              "field": "phase",
+              "equals": "baseline"
+            },
+            "require_values": {
+              "lifecycle_state": "baseline_quiescent"
+            }
+          },
+          {
+            "if": {
+              "field": "phase",
+              "equals": "workload"
+            },
+            "require_values": {
+              "lifecycle_state": "workload_complete"
+            }
+          },
+          {
+            "if": {
+              "field": "phase",
+              "equals": "release"
+            },
+            "require_values": {
+              "lifecycle_state": "release_verified"
+            }
+          }
+        ]
+      },
       "reason": {
         "version": {
           "major": 1,

--- a/src/cpp/include/lemon/residency/generated_contract.h
+++ b/src/cpp/include/lemon/residency/generated_contract.h
@@ -9,7 +9,7 @@
 
 namespace lemon::residency {
 
-inline constexpr std::string_view packaged_catalog_sha256 = "de567a516d6dc5b731d5acf0f66fe84ab7cae1d1329d6f6bd9735510a5684d65";
+inline constexpr std::string_view packaged_catalog_sha256 = "c3b8fcd06079c8733515b04a8082c164562636681c197e7ee686406a95f2bd55";
 inline constexpr std::string_view explanation_schema_id = "residency.explanation/1.0";
 inline constexpr SchemaVersion explanation_schema_version{1, 0};
 inline constexpr std::size_t max_explanation_reasons = 16;

--- a/src/cpp/include/lemon/residency/local_overlay.h
+++ b/src/cpp/include/lemon/residency/local_overlay.h
@@ -82,6 +82,62 @@ struct OverlaySourceGenerations {
     std::uint64_t workload = 0;
 };
 
+enum class ProfilingPhase {
+    Baseline,
+    Workload,
+    Release,
+};
+
+enum class ProfilingObservationHealth {
+    Valid,
+    Missing,
+    Stale,
+    Unhealthy,
+    Incoherent,
+    Superseded,
+};
+
+enum class ProfilingOwnerCoverage {
+    Complete,
+    Incomplete,
+    Unknown,
+};
+
+enum class ProfilingLifecycleState {
+    BaselineQuiescent,
+    WorkloadComplete,
+    ReleaseVerified,
+};
+
+struct ProfilingPhaseAttestationDraft {
+    SchemaVersion schema = supported_local_overlay_schema;
+    ProfilingPhase phase = ProfilingPhase::Baseline;
+    std::string deployment_id;
+    std::string profiling_transaction_id;
+    std::string selector_sha256;
+    std::string provider_id;
+    std::string provider_revision_sha256;
+    std::string provenance_sha256;
+    std::string observation_contract_sha256;
+    std::string predictor_contract_sha256;
+    OverlaySourceGenerations generations;
+    std::uint64_t observation_generation = 0;
+    std::string observed_at;
+    std::string fresh_until;
+    std::uint64_t source_skew_milliseconds = 0;
+    std::uint64_t max_source_skew_milliseconds = 0;
+    ProfilingObservationHealth health = ProfilingObservationHealth::Missing;
+    ProfilingOwnerCoverage owner_coverage = ProfilingOwnerCoverage::Unknown;
+    std::vector<ClaimFamilyClosure> observed_claims;
+    std::vector<ClaimFamilyClosure> attributed_claims;
+    std::vector<ClaimFamilyClosure> external_change_claims;
+    std::vector<ClaimFamilyClosure> unattributed_claims;
+    std::vector<ClaimFamilyClosure> uncertainty_claims;
+    std::vector<ClaimFamilyClosure> safety_margin_claims;
+    ProfilingLifecycleState lifecycle_state =
+        ProfilingLifecycleState::BaselineQuiescent;
+};
+
 struct ProfilingInputEnvelopeDraft {
     SchemaVersion schema = supported_local_overlay_schema;
     std::string deployment_id;
@@ -147,9 +203,11 @@ struct OverlayActivationRootDraft {
 };
 
 class ParsedProfilingInputEnvelope;
+class ParsedProfilingPhaseAttestation;
 class ParsedLocalOverlayObject;
 class ParsedOverlayActivationRoot;
 struct ParsedProfilingInputEnvelopeResult;
+struct ParsedProfilingPhaseAttestationResult;
 struct ParsedLocalOverlayObjectResult;
 struct ParsedOverlayActivationRootResult;
 
@@ -198,6 +256,58 @@ private:
     seal_profiling_input(ProfilingInputEnvelopeDraft draft);
     friend ParsedProfilingInputEnvelopeResult
     parse_profiling_input(std::string_view bytes);
+};
+
+class ParsedProfilingPhaseAttestation {
+public:
+    ParsedProfilingPhaseAttestation() = delete;
+    ParsedProfilingPhaseAttestation(
+        const ParsedProfilingPhaseAttestation &) = default;
+    ParsedProfilingPhaseAttestation &
+    operator=(const ParsedProfilingPhaseAttestation &) = default;
+
+    SchemaVersion schema() const noexcept;
+    ProfilingPhase phase() const noexcept;
+    std::string_view deployment_id() const noexcept;
+    std::string_view profiling_transaction_id() const noexcept;
+    std::string_view selector_sha256() const noexcept;
+    std::string_view provider_id() const noexcept;
+    std::string_view provider_revision_sha256() const noexcept;
+    std::string_view provenance_sha256() const noexcept;
+    std::string_view observation_contract_sha256() const noexcept;
+    std::string_view predictor_contract_sha256() const noexcept;
+    const OverlaySourceGenerations &generations() const noexcept;
+    std::uint64_t observation_generation() const noexcept;
+    std::string_view observed_at() const noexcept;
+    std::string_view fresh_until() const noexcept;
+    std::uint64_t source_skew_milliseconds() const noexcept;
+    std::uint64_t max_source_skew_milliseconds() const noexcept;
+    ProfilingObservationHealth health() const noexcept;
+    ProfilingOwnerCoverage owner_coverage() const noexcept;
+    const std::vector<ClaimFamilyClosure> &observed_claims() const noexcept;
+    const std::vector<ClaimFamilyClosure> &attributed_claims() const noexcept;
+    const std::vector<ClaimFamilyClosure> &
+    external_change_claims() const noexcept;
+    const std::vector<ClaimFamilyClosure> &unattributed_claims() const noexcept;
+    const std::vector<ClaimFamilyClosure> &uncertainty_claims() const noexcept;
+    const std::vector<ClaimFamilyClosure> &safety_margin_claims() const noexcept;
+    ProfilingLifecycleState lifecycle_state() const noexcept;
+    std::string_view checksum_sha256() const noexcept;
+    std::string_view canonical_bytes() const noexcept;
+
+private:
+    ParsedProfilingPhaseAttestation(ProfilingPhaseAttestationDraft draft,
+                                    std::string checksum_sha256,
+                                    std::string canonical_bytes);
+
+    ProfilingPhaseAttestationDraft draft_;
+    std::string checksum_sha256_;
+    std::string canonical_bytes_;
+
+    friend ParsedProfilingPhaseAttestationResult
+    seal_profiling_phase_attestation(ProfilingPhaseAttestationDraft draft);
+    friend ParsedProfilingPhaseAttestationResult
+    parse_profiling_phase_attestation(std::string_view bytes);
 };
 
 class ParsedLocalOverlayObject {
@@ -295,6 +405,14 @@ struct ParsedProfilingInputEnvelopeResult {
     bool accepted() const noexcept;
 };
 
+struct ParsedProfilingPhaseAttestationResult {
+    OverlayContractStatus status = OverlayContractStatus::InvalidValue;
+    std::string diagnostic;
+    std::optional<ParsedProfilingPhaseAttestation> candidate;
+
+    bool accepted() const noexcept;
+};
+
 struct ParsedLocalOverlayObjectResult {
     OverlayContractStatus status = OverlayContractStatus::InvalidValue;
     std::string diagnostic;
@@ -315,6 +433,10 @@ ParsedProfilingInputEnvelopeResult
 seal_profiling_input(ProfilingInputEnvelopeDraft draft);
 ParsedProfilingInputEnvelopeResult
 parse_profiling_input(std::string_view bytes);
+ParsedProfilingPhaseAttestationResult
+seal_profiling_phase_attestation(ProfilingPhaseAttestationDraft draft);
+ParsedProfilingPhaseAttestationResult
+parse_profiling_phase_attestation(std::string_view bytes);
 ParsedLocalOverlayObjectResult
 seal_local_overlay(LocalOverlayObjectDraft draft);
 ParsedLocalOverlayObjectResult parse_local_overlay(std::string_view bytes);

--- a/src/cpp/include/lemon/residency/local_overlay.h
+++ b/src/cpp/include/lemon/residency/local_overlay.h
@@ -216,8 +216,12 @@ public:
     ParsedProfilingInputEnvelope() = delete;
     ParsedProfilingInputEnvelope(const ParsedProfilingInputEnvelope &) =
         default;
+    ParsedProfilingInputEnvelope(ParsedProfilingInputEnvelope &&) noexcept =
+        default;
     ParsedProfilingInputEnvelope &
     operator=(const ParsedProfilingInputEnvelope &) = default;
+    ParsedProfilingInputEnvelope &
+    operator=(ParsedProfilingInputEnvelope &&) noexcept = default;
 
     SchemaVersion schema() const noexcept;
     std::string_view deployment_id() const noexcept;
@@ -263,8 +267,12 @@ public:
     ParsedProfilingPhaseAttestation() = delete;
     ParsedProfilingPhaseAttestation(
         const ParsedProfilingPhaseAttestation &) = default;
+    ParsedProfilingPhaseAttestation(
+        ParsedProfilingPhaseAttestation &&) noexcept = default;
     ParsedProfilingPhaseAttestation &
     operator=(const ParsedProfilingPhaseAttestation &) = default;
+    ParsedProfilingPhaseAttestation &
+    operator=(ParsedProfilingPhaseAttestation &&) noexcept = default;
 
     SchemaVersion schema() const noexcept;
     ProfilingPhase phase() const noexcept;

--- a/src/cpp/include/lemon/residency/profiling_transaction.h
+++ b/src/cpp/include/lemon/residency/profiling_transaction.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -37,54 +38,84 @@ enum class ProfilingAbortReason {
 
 using ProfilingCancellationCheck = std::function<bool()>;
 
+struct ProfilingTransactionContext {
+    std::string deployment_id;
+    std::uint64_t sequence = 0;
+    std::string profiling_transaction_id;
+    LocalOverlaySelectorIdentity selector;
+    std::string selector_sha256;
+    OverlaySourceGenerations generations;
+    std::string observation_contract_sha256;
+    std::string predictor_contract_sha256;
+};
+
 struct ProfilingTransactionCapture {
-    std::optional<ProfilingInputEnvelopeDraft> draft;
-    // These attestations come from the server-owned observation provider. The
-    // transaction never infers identity, freshness, health, uncertainty, or
-    // safety from aggregate benchmark output.
-    bool baseline_captured = false;
-    bool workload_captured = false;
-    bool release_captured = false;
-    bool identity_complete = false;
-    bool observations_fresh = false;
-    bool observations_healthy = false;
-    bool uncertainty_bound_verified = false;
-    bool safety_margin_verified = false;
+    std::string baseline_attestation;
+    std::string workload_attestation;
+    std::string release_attestation;
     std::string diagnostic;
+};
+
+class AcceptedProfilingEvidence {
+public:
+    AcceptedProfilingEvidence(const AcceptedProfilingEvidence &) = default;
+    AcceptedProfilingEvidence(AcceptedProfilingEvidence &&) noexcept = default;
+    AcceptedProfilingEvidence &operator=(const AcceptedProfilingEvidence &) = default;
+    AcceptedProfilingEvidence &operator=(AcceptedProfilingEvidence &&) noexcept = default;
+
+    const ParsedProfilingInputEnvelope &input() const noexcept;
+    const ParsedProfilingPhaseAttestation &baseline() const noexcept;
+    const ParsedProfilingPhaseAttestation &workload() const noexcept;
+    const ParsedProfilingPhaseAttestation &release() const noexcept;
+
+private:
+    AcceptedProfilingEvidence(ParsedProfilingInputEnvelope input,
+                              ParsedProfilingPhaseAttestation baseline,
+                              ParsedProfilingPhaseAttestation workload,
+                              ParsedProfilingPhaseAttestation release);
+
+    ParsedProfilingInputEnvelope input_;
+    ParsedProfilingPhaseAttestation baseline_;
+    ParsedProfilingPhaseAttestation workload_;
+    ParsedProfilingPhaseAttestation release_;
+
+    friend class ProfilingTransaction;
 };
 
 struct ProfilingTransactionResult {
     ProfilingTransactionStatus status = ProfilingTransactionStatus::Failed;
     std::string diagnostic;
-    std::optional<ParsedProfilingInputEnvelope> candidate;
+    std::optional<AcceptedProfilingEvidence> evidence;
 
     bool accepted() const noexcept {
-        return status == ProfilingTransactionStatus::Accepted &&
-               candidate.has_value();
+        return status == ProfilingTransactionStatus::Accepted && evidence.has_value();
     }
 };
 
 struct ProfilingTransactionOptions {
+    // Bounds pending-to-active Router admission. Capture duration remains
+    // provider-controlled and ends cooperatively through should_abort.
     std::chrono::milliseconds gate_timeout{std::chrono::seconds(30)};
     std::chrono::milliseconds retry_interval{25};
+    std::function<std::string()> utc_now;
 };
 
 class ProfilingTransaction {
 public:
     // Server owns one instance per Router. That instance is the admission point
     // for profiling; callers must not create parallel coordinators. Capture is
-    // synchronous: it must not retain Router, the cancellation check, or the
-    // cancel pointer, and it must join any work it starts before returning.
+    // synchronous: it must not retain Router, the transaction context, the
+    // cancellation check, or the cancel pointer, and it must join any work it
+    // starts before returning.
     // Capture code must poll the cancellation check at bounded points, must
     // not call Router::end_exclusive(), and must not invoke Server lifecycle
     // or configuration mutations (directly or from spawned work) while the
     // exclusive lease is held. It must also avoid nested HTTP/jobs calls and
     // Router work from non-owner threads, which would queue behind this lease.
     using Capture = std::function<ProfilingTransactionCapture(
-        Router &, const ProfilingCancellationCheck &)>;
+        Router &, const ProfilingTransactionContext &, const ProfilingCancellationCheck &)>;
 
-    explicit ProfilingTransaction(Router &router,
-                                  ProfilingTransactionOptions options = {});
+    explicit ProfilingTransaction(Router &router, ProfilingTransactionOptions options = {});
     // Destruction must occur outside the synchronous capture callback. An
     // owner-thread destruction cannot safely wait for the active Router lease.
     ~ProfilingTransaction();
@@ -95,14 +126,13 @@ public:
     // restart_detected is a cheap, non-blocking lifecycle predicate owned by
     // the Server. Capture providers must not use it as a substitute for their
     // own bounded cancellation checks.
-    ProfilingTransactionResult run(std::string transaction_id, Capture capture,
+    ProfilingTransactionResult run(ProfilingTransactionContext context, Capture capture,
                                    std::atomic<bool> *cancel = nullptr,
                                    std::function<bool()> restart_detected = {});
 
     // Latch a lifecycle abort for the active run. The latch is scoped to that
     // run and remains set even when an external flag is later cleared.
-    void request_abort(
-        ProfilingAbortReason reason = ProfilingAbortReason::Restarted) noexcept;
+    void request_abort(ProfilingAbortReason reason = ProfilingAbortReason::Restarted) noexcept;
 
     bool running() const noexcept;
     bool running_on_current_thread() const noexcept;

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -1,19 +1,20 @@
 #pragma once
 
 #include <atomic>
-#include <string>
-#include <memory>
+#include <chrono>
+#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
-#include <condition_variable>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-#include <optional>
 #include <nlohmann/json.hpp>
 #include <httplib.h>
 #include "gpu_memory_planner.h"
@@ -130,6 +131,7 @@ public:
     // servers, seed the needed set, drive prune). Defined in the test binary.
     friend struct RoutingHelperTestHook;
     friend struct RouterModelLifecycleTestHook;
+    friend struct ProfilingTransactionTestHook;
     Router(RuntimeConfig* config,
 
            ModelManager* model_manager,
@@ -153,6 +155,7 @@ public:
         Acquired,
         Retry,
         Cancelled,
+        DeadlineExceeded,
         InvalidOrder,
     };
 
@@ -173,12 +176,16 @@ public:
         ExclusiveRequest(
             Router* router,
             uint64_t generation,
-            ExclusiveAcquireResult result)
-            : router_(router), generation_(generation), result_(result) {}
+            ExclusiveAcquireResult result,
+            std::optional<std::chrono::steady_clock::time_point> deadline =
+                std::nullopt)
+            : router_(router), generation_(generation), result_(result),
+              deadline_(deadline) {}
 
         Router* router_ = nullptr;
         uint64_t generation_ = 0;
         ExclusiveAcquireResult result_ = ExclusiveAcquireResult::Retry;
+        std::optional<std::chrono::steady_clock::time_point> deadline_;
     };
 
     class PreparedModelLoad {
@@ -378,6 +385,9 @@ public:
     // fence continues blocking fresh work. Destruction abandons that intent.
     [[nodiscard]] ExclusiveRequest request_exclusive(
         std::atomic<bool>* cancel = nullptr);
+    [[nodiscard]] ExclusiveRequest request_exclusive_until(
+        std::chrono::steady_clock::time_point deadline,
+        std::atomic<bool>* cancel = nullptr);
     [[nodiscard]] ExclusiveAcquireResult try_begin_exclusive(
         ExclusiveRequest& request,
         std::atomic<bool>* cancel = nullptr);
@@ -459,10 +469,38 @@ private:
 
     bool exclusive_active_ = false;
     std::thread::id exclusive_owner_;
-    bool exclusive_pending_ = false;
     uint64_t next_exclusive_generation_ = 0;
-    uint64_t exclusive_pending_generation_ = 0;
+    std::atomic<uint64_t> exclusive_pending_generation_{0};
     uint64_t exclusive_admission_generation_ = 0;
+    bool exclusive_pending() const noexcept;
+    ExclusiveRequest request_exclusive_impl(
+        std::atomic<bool>* cancel,
+        std::optional<std::chrono::steady_clock::time_point> deadline);
+    ExclusiveAcquireResult try_begin_exclusive_impl(
+        ExclusiveRequest& request, std::atomic<bool>* cancel);
+    template <typename Predicate>
+    void wait_for_load_state(std::unique_lock<std::mutex>& lock,
+                             Predicate predicate) {
+        // Timed retries are required while lock-free cancellation can clear a
+        // pending generation between predicate evaluation and a CV wait.
+        while (true) {
+            const auto pending_before = exclusive_pending_generation_.load(
+                std::memory_order_acquire);
+            if (predicate()) {
+                return;
+            }
+            const auto pending_after = exclusive_pending_generation_.load(
+                std::memory_order_acquire);
+            if (pending_before != pending_after) {
+                continue;
+            }
+            if (pending_after != 0) {
+                load_cv_.wait_for(lock, std::chrono::milliseconds(25));
+            } else {
+                load_cv_.wait(lock);
+            }
+        }
+    }
     void wait_for_slot_clearance(std::unique_lock<std::mutex>& lock);
     std::string resolve_model_name_after_mutation_gate_locked(
         std::unique_lock<std::mutex>& lock,

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -82,7 +82,7 @@ private:
     // Server-owned provider that binds every observation attestation before
     // the result reaches durable overlay activation or a transport.
     residency::ProfilingTransactionResult run_residency_profiling_transaction(
-        std::string transaction_id,
+        residency::ProfilingTransactionContext context,
         residency::ProfilingTransaction::Capture capture,
         std::atomic<bool> *cancel = nullptr);
 

--- a/src/cpp/resources/residency_profiles.json
+++ b/src/cpp/resources/residency_profiles.json
@@ -4982,6 +4982,163 @@
           "minor": 0
         }
       },
+      "profiling_phase_attestation": {
+        "conditionals": [
+          {
+            "assert": {
+              "field": "observed_at",
+              "less_than_path": "fresh_until"
+            }
+          },
+          {
+            "assert": {
+              "field": "source_skew_milliseconds",
+              "less_than_or_equal_path": "max_source_skew_milliseconds"
+            }
+          },
+          {
+            "if": {
+              "equals": "baseline",
+              "field": "phase"
+            },
+            "require_values": {
+              "lifecycle_state": "baseline_quiescent"
+            }
+          },
+          {
+            "if": {
+              "equals": "workload",
+              "field": "phase"
+            },
+            "require_values": {
+              "lifecycle_state": "workload_complete"
+            }
+          },
+          {
+            "if": {
+              "equals": "release",
+              "field": "phase"
+            },
+            "require_values": {
+              "lifecycle_state": "release_verified"
+            }
+          }
+        ],
+        "fields": {
+          "attributed_claims": {
+            "required": true,
+            "type": "local_overlay_claim_closure"
+          },
+          "checksum_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "deployment_id": {
+            "required": true,
+            "type": "local_overlay_deployment_identity"
+          },
+          "external_change_claims": {
+            "required": true,
+            "type": "local_overlay_zero_claim_closure"
+          },
+          "fresh_until": {
+            "required": true,
+            "type": "local_overlay_expiry"
+          },
+          "generations": {
+            "required": true,
+            "type": "local_overlay_source_generations"
+          },
+          "health": {
+            "required": true,
+            "type": "local_overlay_profiling_health"
+          },
+          "lifecycle_state": {
+            "required": true,
+            "type": "local_overlay_profiling_lifecycle_state"
+          },
+          "max_source_skew_milliseconds": {
+            "required": true,
+            "type": "local_overlay_positive_uint64"
+          },
+          "observation_contract_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "observation_generation": {
+            "required": true,
+            "type": "local_overlay_positive_uint64"
+          },
+          "observed_at": {
+            "required": true,
+            "type": "local_overlay_timestamp"
+          },
+          "observed_claims": {
+            "required": true,
+            "type": "local_overlay_claim_closure"
+          },
+          "owner_coverage": {
+            "required": true,
+            "type": "local_overlay_profiling_owner_coverage"
+          },
+          "phase": {
+            "required": true,
+            "type": "local_overlay_profiling_phase"
+          },
+          "predictor_contract_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "profiling_transaction_id": {
+            "max_bytes": 128,
+            "required": true,
+            "type": "opaque"
+          },
+          "provenance_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "provider_id": {
+            "max_bytes": 128,
+            "required": true,
+            "type": "opaque"
+          },
+          "provider_revision_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "safety_margin_claims": {
+            "required": true,
+            "type": "local_overlay_safety_margin_claim_closure"
+          },
+          "schema": {
+            "required": true,
+            "type": "local_overlay_schema_version"
+          },
+          "selector_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "source_skew_milliseconds": {
+            "required": true,
+            "type": "local_overlay_nonnegative_uint64"
+          },
+          "unattributed_claims": {
+            "required": true,
+            "type": "local_overlay_zero_claim_closure"
+          },
+          "uncertainty_claims": {
+            "required": true,
+            "type": "local_overlay_claim_closure"
+          }
+        },
+        "output": "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
+        "schema_type": "residency.profiling_phase_attestation/1.0",
+        "version": {
+          "major": 1,
+          "minor": 0
+        }
+      },
       "reason": {
         "conditionals": [
           {
@@ -7267,6 +7424,6 @@
     }
   ],
   "schema": "residency.profiles/1.0",
-  "selection_registry_sha256": "bd040081cc1286047433bfe14ac6556636620176fd02c2a2c934561ac7e9ed28",
+  "selection_registry_sha256": "9dbdfad20160c82f3905493d2d5c4bdcf40f2249b25ad919c57fd4462a51b4b7",
   "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
 }

--- a/src/cpp/server/eviction_engine.cpp
+++ b/src/cpp/server/eviction_engine.cpp
@@ -65,7 +65,7 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
 
         // An exclusive job session owns model residency; auto-eviction and
         // downsizing would yank models out from under its next step.
-        if (router_->exclusive_active_ || router_->exclusive_pending_) return;
+        if (router_->exclusive_active_ || router_->exclusive_pending()) return;
 
         auto now = std::chrono::steady_clock::now();
         double threshold = RuntimeConfig::global()->auto_evict_threshold_pct();
@@ -162,7 +162,7 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
         WrappedServer* s = nullptr;
         {
             std::lock_guard<std::mutex> lk(router_->load_mutex_);
-            if (router_->exclusive_active_ || router_->exclusive_pending_) break;
+            if (router_->exclusive_active_ || router_->exclusive_pending()) break;
             s = router_->find_server_by_model_name(name);
             if (!s || !s->try_begin_downsize()) {
                 continue;  // gone, busy, or no longer idle since phase 1

--- a/src/cpp/server/residency/generated_contract.cpp
+++ b/src/cpp/server/residency/generated_contract.cpp
@@ -85,7 +85,7 @@ constexpr std::array<std::string_view, 14> fallback_ids{{
     "residency_unload_preserve_live_use_v1",
 }};
 
-constexpr std::array<std::string_view, 15> schema_types{{
+constexpr std::array<std::string_view, 16> schema_types{{
     "residency.artifact_quarantine_record/1.0",
     "residency.artifact_writer_job_revision/1.0",
     "residency.artifact_writer_request_result/1.0",
@@ -95,6 +95,7 @@ constexpr std::array<std::string_view, 15> schema_types{{
     "residency.operation_revision/1.0",
     "residency.overlay_activation_root/1.0",
     "residency.profiling_input_envelope/1.0",
+    "residency.profiling_phase_attestation/1.0",
     "residency.reason/1.0",
     "residency.request_error/1.0",
     "residency.profiles/1.0",

--- a/src/cpp/server/residency/local_overlay.cpp
+++ b/src/cpp/server/residency/local_overlay.cpp
@@ -26,6 +26,8 @@ using json = nlohmann::json;
 
 constexpr char profiling_input_domain[] =
     "lemonade.residency.local-overlay-profiling-input/v1\0";
+constexpr char profiling_phase_attestation_domain[] =
+    "lemonade.residency.profiling-phase-attestation/v1\0";
 constexpr char local_overlay_domain[] =
     "lemonade.residency.local-overlay-object/v1\0";
 constexpr char activation_root_domain[] =
@@ -886,6 +888,376 @@ OverlaySourceGenerations parse_generations(const json &value) {
     };
 }
 
+std::string canonical_document(json payload, std::string_view checksum);
+
+std::string_view profiling_phase_wire(ProfilingPhase phase) noexcept {
+    switch (phase) {
+    case ProfilingPhase::Baseline:
+        return "baseline";
+    case ProfilingPhase::Workload:
+        return "workload";
+    case ProfilingPhase::Release:
+        return "release";
+    }
+    return {};
+}
+
+ProfilingPhase parse_profiling_phase(std::string_view wire) {
+    if (wire == "baseline") {
+        return ProfilingPhase::Baseline;
+    }
+    if (wire == "workload") {
+        return ProfilingPhase::Workload;
+    }
+    if (wire == "release") {
+        return ProfilingPhase::Release;
+    }
+    reject(OverlayContractStatus::UnknownValue, "profiling phase is unknown");
+}
+
+std::string_view
+profiling_health_wire(ProfilingObservationHealth health) noexcept {
+    switch (health) {
+    case ProfilingObservationHealth::Valid:
+        return "valid";
+    case ProfilingObservationHealth::Missing:
+        return "missing";
+    case ProfilingObservationHealth::Stale:
+        return "stale";
+    case ProfilingObservationHealth::Unhealthy:
+        return "unhealthy";
+    case ProfilingObservationHealth::Incoherent:
+        return "incoherent";
+    case ProfilingObservationHealth::Superseded:
+        return "superseded";
+    }
+    return {};
+}
+
+ProfilingObservationHealth parse_profiling_health(std::string_view wire) {
+    if (wire == "valid") {
+        return ProfilingObservationHealth::Valid;
+    }
+    if (wire == "missing") {
+        return ProfilingObservationHealth::Missing;
+    }
+    if (wire == "stale") {
+        return ProfilingObservationHealth::Stale;
+    }
+    if (wire == "unhealthy") {
+        return ProfilingObservationHealth::Unhealthy;
+    }
+    if (wire == "incoherent") {
+        return ProfilingObservationHealth::Incoherent;
+    }
+    if (wire == "superseded") {
+        return ProfilingObservationHealth::Superseded;
+    }
+    reject(OverlayContractStatus::UnknownValue,
+           "profiling observation health is unknown");
+}
+
+std::string_view
+profiling_owner_coverage_wire(ProfilingOwnerCoverage coverage) noexcept {
+    switch (coverage) {
+    case ProfilingOwnerCoverage::Complete:
+        return "complete";
+    case ProfilingOwnerCoverage::Incomplete:
+        return "incomplete";
+    case ProfilingOwnerCoverage::Unknown:
+        return "unknown";
+    }
+    return {};
+}
+
+ProfilingOwnerCoverage parse_profiling_owner_coverage(std::string_view wire) {
+    if (wire == "complete") {
+        return ProfilingOwnerCoverage::Complete;
+    }
+    if (wire == "incomplete") {
+        return ProfilingOwnerCoverage::Incomplete;
+    }
+    if (wire == "unknown") {
+        return ProfilingOwnerCoverage::Unknown;
+    }
+    reject(OverlayContractStatus::UnknownValue,
+           "profiling owner coverage is unknown");
+}
+
+std::string_view
+profiling_lifecycle_state_wire(ProfilingLifecycleState state) noexcept {
+    switch (state) {
+    case ProfilingLifecycleState::BaselineQuiescent:
+        return "baseline_quiescent";
+    case ProfilingLifecycleState::WorkloadComplete:
+        return "workload_complete";
+    case ProfilingLifecycleState::ReleaseVerified:
+        return "release_verified";
+    }
+    return {};
+}
+
+ProfilingLifecycleState
+parse_profiling_lifecycle_state(std::string_view wire) {
+    if (wire == "baseline_quiescent") {
+        return ProfilingLifecycleState::BaselineQuiescent;
+    }
+    if (wire == "workload_complete") {
+        return ProfilingLifecycleState::WorkloadComplete;
+    }
+    if (wire == "release_verified") {
+        return ProfilingLifecycleState::ReleaseVerified;
+    }
+    reject(OverlayContractStatus::UnknownValue,
+           "profiling lifecycle state is unknown");
+}
+
+ProfilingLifecycleState expected_lifecycle_state(ProfilingPhase phase) {
+    switch (phase) {
+    case ProfilingPhase::Baseline:
+        return ProfilingLifecycleState::BaselineQuiescent;
+    case ProfilingPhase::Workload:
+        return ProfilingLifecycleState::WorkloadComplete;
+    case ProfilingPhase::Release:
+        return ProfilingLifecycleState::ReleaseVerified;
+    }
+    reject(OverlayContractStatus::UnknownValue, "profiling phase is unknown");
+}
+
+std::vector<ClaimFamilyClosure>
+normalize_phase_claims(std::vector<ClaimFamilyClosure> closure) {
+    return claim_closure(checked_claims(std::move(closure)));
+}
+
+bool has_positive_claim(
+    const std::vector<ClaimFamilyClosure> &closure) noexcept {
+    for (const auto &family : closure) {
+        for (const auto &entry : family.entries) {
+            if (entry.amount > 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void normalize_profiling_phase_draft(ProfilingPhaseAttestationDraft &draft) {
+    if (!schema_is_supported(draft.schema)) {
+        reject(OverlayContractStatus::UnsupportedSchema,
+               "profiling phase attestation schema is unsupported");
+    }
+    if (profiling_phase_wire(draft.phase).empty()) {
+        reject(OverlayContractStatus::UnknownValue,
+               "profiling phase is unknown");
+    }
+    require_digest(draft.deployment_id, "deployment ID");
+    require_identifier(draft.profiling_transaction_id,
+                       "profiling transaction ID");
+    require_digest(draft.selector_sha256, "selector digest");
+    require_identifier(draft.provider_id, "provider ID");
+    require_digest(draft.provider_revision_sha256,
+                   "provider revision digest");
+    require_digest(draft.provenance_sha256, "provenance digest");
+    require_digest(draft.observation_contract_sha256,
+                   "observation contract digest");
+    require_digest(draft.predictor_contract_sha256,
+                   "predictor contract digest");
+    normalize_generations(draft.generations);
+    if (draft.observation_generation == 0) {
+        reject(OverlayContractStatus::IncompleteIdentity,
+               "observation generation must be nonzero");
+    }
+    require_advancing_time(draft.observed_at, draft.fresh_until,
+                           "fresh-until timestamp");
+    if (draft.max_source_skew_milliseconds == 0 ||
+        draft.source_skew_milliseconds >
+            draft.max_source_skew_milliseconds) {
+        reject(OverlayContractStatus::InvalidValue,
+               "source skew exceeds the accepted bound");
+    }
+    if (draft.health != ProfilingObservationHealth::Valid) {
+        reject(OverlayContractStatus::InvalidValue,
+               "profiling observation health is not valid");
+    }
+    if (draft.owner_coverage != ProfilingOwnerCoverage::Complete) {
+        reject(OverlayContractStatus::IncompleteIdentity,
+               "profiling owner coverage is incomplete");
+    }
+    if (draft.lifecycle_state != expected_lifecycle_state(draft.phase)) {
+        reject(OverlayContractStatus::InvalidValue,
+               "profiling phase and lifecycle state do not match");
+    }
+
+    draft.observed_claims =
+        normalize_phase_claims(std::move(draft.observed_claims));
+    draft.attributed_claims =
+        normalize_phase_claims(std::move(draft.attributed_claims));
+    draft.external_change_claims =
+        normalize_phase_claims(std::move(draft.external_change_claims));
+    draft.unattributed_claims =
+        normalize_phase_claims(std::move(draft.unattributed_claims));
+    draft.uncertainty_claims =
+        normalize_phase_claims(std::move(draft.uncertainty_claims));
+    draft.safety_margin_claims =
+        normalize_phase_claims(std::move(draft.safety_margin_claims));
+
+    if (has_positive_claim(draft.external_change_claims) ||
+        has_positive_claim(draft.unattributed_claims)) {
+        reject(OverlayContractStatus::InvalidClaimClosure,
+               "profiling evidence contains external or unattributed change");
+    }
+    if (!has_positive_claim(draft.safety_margin_claims)) {
+        reject(OverlayContractStatus::InvalidClaimClosure,
+               "safety-margin claims must contain positive bounded slack");
+    }
+}
+
+json profiling_phase_payload(const ProfilingPhaseAttestationDraft &draft) {
+    return json{
+        {"attributed_claims", claim_closure_document(draft.attributed_claims)},
+        {"deployment_id", draft.deployment_id},
+        {"external_change_claims",
+         claim_closure_document(draft.external_change_claims)},
+        {"fresh_until", draft.fresh_until},
+        {"generations", generations_document(draft.generations)},
+        {"health", profiling_health_wire(draft.health)},
+        {"lifecycle_state",
+         profiling_lifecycle_state_wire(draft.lifecycle_state)},
+        {"max_source_skew_milliseconds",
+         draft.max_source_skew_milliseconds},
+        {"observation_contract_sha256",
+         draft.observation_contract_sha256},
+        {"observation_generation", draft.observation_generation},
+        {"observed_at", draft.observed_at},
+        {"observed_claims", claim_closure_document(draft.observed_claims)},
+        {"owner_coverage",
+         profiling_owner_coverage_wire(draft.owner_coverage)},
+        {"phase", profiling_phase_wire(draft.phase)},
+        {"predictor_contract_sha256", draft.predictor_contract_sha256},
+        {"profiling_transaction_id", draft.profiling_transaction_id},
+        {"provenance_sha256", draft.provenance_sha256},
+        {"provider_id", draft.provider_id},
+        {"provider_revision_sha256", draft.provider_revision_sha256},
+        {"safety_margin_claims",
+         claim_closure_document(draft.safety_margin_claims)},
+        {"schema", schema_document(draft.schema)},
+        {"selector_sha256", draft.selector_sha256},
+        {"source_skew_milliseconds", draft.source_skew_milliseconds},
+        {"unattributed_claims",
+         claim_closure_document(draft.unattributed_claims)},
+        {"uncertainty_claims",
+         claim_closure_document(draft.uncertainty_claims)},
+    };
+}
+
+struct SealedProfilingPhaseData {
+    ProfilingPhaseAttestationDraft draft;
+    std::string checksum;
+    std::string canonical;
+};
+
+SealedProfilingPhaseData
+seal_profiling_phase_data(ProfilingPhaseAttestationDraft draft) {
+    normalize_profiling_phase_draft(draft);
+    const auto payload = profiling_phase_payload(draft);
+    const auto payload_bytes = payload.dump();
+    const auto checksum = sha256_hex(
+        std::string_view(profiling_phase_attestation_domain,
+                         sizeof(profiling_phase_attestation_domain) - 1),
+        payload_bytes);
+    auto canonical = canonical_document(payload, checksum);
+    if (canonical.size() > max_local_overlay_input_bytes) {
+        reject(OverlayContractStatus::LimitExceeded,
+               "sealed profiling phase attestation exceeds the input limit");
+    }
+    return SealedProfilingPhaseData{std::move(draft), checksum,
+                                    std::move(canonical)};
+}
+
+struct ParsedProfilingPhaseDocument {
+    ProfilingPhaseAttestationDraft draft;
+    std::string checksum;
+};
+
+ParsedProfilingPhaseDocument
+parse_profiling_phase_document(const json &document) {
+    require_exact_keys(
+        document,
+        {"attributed_claims", "checksum_sha256", "deployment_id",
+         "external_change_claims", "fresh_until", "generations", "health",
+         "lifecycle_state", "max_source_skew_milliseconds",
+         "observation_contract_sha256", "observation_generation",
+         "observed_at", "observed_claims", "owner_coverage", "phase",
+         "predictor_contract_sha256", "profiling_transaction_id",
+         "provenance_sha256", "provider_id", "provider_revision_sha256",
+         "safety_margin_claims", "schema", "selector_sha256",
+         "source_skew_milliseconds", "unattributed_claims",
+         "uncertainty_claims"},
+        "profiling phase attestation");
+    ProfilingPhaseAttestationDraft draft;
+    draft.schema = parse_schema(required(document, "schema"));
+    draft.phase = parse_profiling_phase(
+        require_string(required(document, "phase"), "profiling phase"));
+    draft.deployment_id =
+        require_string(required(document, "deployment_id"), "deployment ID");
+    draft.profiling_transaction_id =
+        require_string(required(document, "profiling_transaction_id"),
+                       "profiling transaction ID");
+    draft.selector_sha256 = require_string(
+        required(document, "selector_sha256"), "selector digest");
+    draft.provider_id =
+        require_string(required(document, "provider_id"), "provider ID");
+    draft.provider_revision_sha256 = require_string(
+        required(document, "provider_revision_sha256"),
+        "provider revision digest");
+    draft.provenance_sha256 = require_string(
+        required(document, "provenance_sha256"), "provenance digest");
+    draft.observation_contract_sha256 = require_string(
+        required(document, "observation_contract_sha256"),
+        "observation contract digest");
+    draft.predictor_contract_sha256 = require_string(
+        required(document, "predictor_contract_sha256"),
+        "predictor contract digest");
+    draft.generations = parse_generations(required(document, "generations"));
+    draft.observation_generation =
+        require_u64(required(document, "observation_generation"),
+                    "observation generation");
+    draft.observed_at =
+        require_string(required(document, "observed_at"), "observed timestamp");
+    draft.fresh_until = require_string(required(document, "fresh_until"),
+                                       "fresh-until timestamp");
+    draft.source_skew_milliseconds =
+        require_u64(required(document, "source_skew_milliseconds"),
+                    "source skew");
+    draft.max_source_skew_milliseconds =
+        require_u64(required(document, "max_source_skew_milliseconds"),
+                    "maximum source skew");
+    draft.health = parse_profiling_health(require_string(
+        required(document, "health"), "profiling observation health"));
+    draft.owner_coverage = parse_profiling_owner_coverage(require_string(
+        required(document, "owner_coverage"), "profiling owner coverage"));
+    draft.observed_claims = parse_claim_closure(
+        required(document, "observed_claims"), "observed claims");
+    draft.attributed_claims = parse_claim_closure(
+        required(document, "attributed_claims"), "attributed claims");
+    draft.external_change_claims = parse_claim_closure(
+        required(document, "external_change_claims"),
+        "external-change claims");
+    draft.unattributed_claims = parse_claim_closure(
+        required(document, "unattributed_claims"), "unattributed claims");
+    draft.uncertainty_claims = parse_claim_closure(
+        required(document, "uncertainty_claims"), "uncertainty claims");
+    draft.safety_margin_claims = parse_claim_closure(
+        required(document, "safety_margin_claims"), "safety-margin claims");
+    draft.lifecycle_state = parse_profiling_lifecycle_state(require_string(
+        required(document, "lifecycle_state"), "profiling lifecycle state"));
+    return ParsedProfilingPhaseDocument{
+        std::move(draft),
+        require_string(required(document, "checksum_sha256"),
+                       "profiling phase attestation checksum"),
+    };
+}
+
 void normalize_profiling_draft(ProfilingInputEnvelopeDraft &draft) {
     if (!schema_is_supported(draft.schema)) {
         reject(OverlayContractStatus::UnsupportedSchema,
@@ -1460,6 +1832,12 @@ rejected_profiling(const OverlayFailure &failure) {
         failure.status(), bounded_diagnostic(failure.what()), std::nullopt};
 }
 
+ParsedProfilingPhaseAttestationResult
+rejected_profiling_phase(const OverlayFailure &failure) {
+    return ParsedProfilingPhaseAttestationResult{
+        failure.status(), bounded_diagnostic(failure.what()), std::nullopt};
+}
+
 ParsedLocalOverlayObjectResult rejected_overlay(const OverlayFailure &failure) {
     return ParsedLocalOverlayObjectResult{
         failure.status(), bounded_diagnostic(failure.what()), std::nullopt};
@@ -1573,6 +1951,145 @@ ParsedProfilingInputEnvelope::checksum_sha256() const noexcept {
 
 std::string_view
 ParsedProfilingInputEnvelope::canonical_bytes() const noexcept {
+    return canonical_bytes_;
+}
+
+ParsedProfilingPhaseAttestation::ParsedProfilingPhaseAttestation(
+    ProfilingPhaseAttestationDraft draft, std::string checksum_sha256,
+    std::string canonical_bytes)
+    : draft_(std::move(draft)), checksum_sha256_(std::move(checksum_sha256)),
+      canonical_bytes_(std::move(canonical_bytes)) {}
+
+SchemaVersion ParsedProfilingPhaseAttestation::schema() const noexcept {
+    return draft_.schema;
+}
+
+ProfilingPhase ParsedProfilingPhaseAttestation::phase() const noexcept {
+    return draft_.phase;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::deployment_id() const noexcept {
+    return draft_.deployment_id;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::profiling_transaction_id() const noexcept {
+    return draft_.profiling_transaction_id;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::selector_sha256() const noexcept {
+    return draft_.selector_sha256;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::provider_id() const noexcept {
+    return draft_.provider_id;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::provider_revision_sha256() const noexcept {
+    return draft_.provider_revision_sha256;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::provenance_sha256() const noexcept {
+    return draft_.provenance_sha256;
+}
+
+std::string_view ParsedProfilingPhaseAttestation::observation_contract_sha256()
+    const noexcept {
+    return draft_.observation_contract_sha256;
+}
+
+std::string_view ParsedProfilingPhaseAttestation::predictor_contract_sha256()
+    const noexcept {
+    return draft_.predictor_contract_sha256;
+}
+
+const OverlaySourceGenerations &
+ParsedProfilingPhaseAttestation::generations() const noexcept {
+    return draft_.generations;
+}
+
+std::uint64_t
+ParsedProfilingPhaseAttestation::observation_generation() const noexcept {
+    return draft_.observation_generation;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::observed_at() const noexcept {
+    return draft_.observed_at;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::fresh_until() const noexcept {
+    return draft_.fresh_until;
+}
+
+std::uint64_t
+ParsedProfilingPhaseAttestation::source_skew_milliseconds() const noexcept {
+    return draft_.source_skew_milliseconds;
+}
+
+std::uint64_t ParsedProfilingPhaseAttestation::max_source_skew_milliseconds()
+    const noexcept {
+    return draft_.max_source_skew_milliseconds;
+}
+
+ProfilingObservationHealth
+ParsedProfilingPhaseAttestation::health() const noexcept {
+    return draft_.health;
+}
+
+ProfilingOwnerCoverage
+ParsedProfilingPhaseAttestation::owner_coverage() const noexcept {
+    return draft_.owner_coverage;
+}
+
+const std::vector<ClaimFamilyClosure> &
+ParsedProfilingPhaseAttestation::observed_claims() const noexcept {
+    return draft_.observed_claims;
+}
+
+const std::vector<ClaimFamilyClosure> &
+ParsedProfilingPhaseAttestation::attributed_claims() const noexcept {
+    return draft_.attributed_claims;
+}
+
+const std::vector<ClaimFamilyClosure> &
+ParsedProfilingPhaseAttestation::external_change_claims() const noexcept {
+    return draft_.external_change_claims;
+}
+
+const std::vector<ClaimFamilyClosure> &
+ParsedProfilingPhaseAttestation::unattributed_claims() const noexcept {
+    return draft_.unattributed_claims;
+}
+
+const std::vector<ClaimFamilyClosure> &
+ParsedProfilingPhaseAttestation::uncertainty_claims() const noexcept {
+    return draft_.uncertainty_claims;
+}
+
+const std::vector<ClaimFamilyClosure> &
+ParsedProfilingPhaseAttestation::safety_margin_claims() const noexcept {
+    return draft_.safety_margin_claims;
+}
+
+ProfilingLifecycleState
+ParsedProfilingPhaseAttestation::lifecycle_state() const noexcept {
+    return draft_.lifecycle_state;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::checksum_sha256() const noexcept {
+    return checksum_sha256_;
+}
+
+std::string_view
+ParsedProfilingPhaseAttestation::canonical_bytes() const noexcept {
     return canonical_bytes_;
 }
 
@@ -1755,6 +2272,10 @@ bool ParsedProfilingInputEnvelopeResult::accepted() const noexcept {
     return status == OverlayContractStatus::Accepted && candidate.has_value();
 }
 
+bool ParsedProfilingPhaseAttestationResult::accepted() const noexcept {
+    return status == OverlayContractStatus::Accepted && candidate.has_value();
+}
+
 bool ParsedLocalOverlayObjectResult::accepted() const noexcept {
     return status == OverlayContractStatus::Accepted && candidate.has_value();
 }
@@ -1802,6 +2323,49 @@ parse_profiling_input(std::string_view bytes) {
         };
     } catch (const OverlayFailure &failure) {
         return rejected_profiling(failure);
+    }
+}
+
+ParsedProfilingPhaseAttestationResult seal_profiling_phase_attestation(
+    ProfilingPhaseAttestationDraft draft) {
+    try {
+        auto sealed = seal_profiling_phase_data(std::move(draft));
+        return ParsedProfilingPhaseAttestationResult{
+            OverlayContractStatus::Accepted,
+            {},
+            ParsedProfilingPhaseAttestation(
+                std::move(sealed.draft), std::move(sealed.checksum),
+                std::move(sealed.canonical)),
+        };
+    } catch (const OverlayFailure &failure) {
+        return rejected_profiling_phase(failure);
+    }
+}
+
+ParsedProfilingPhaseAttestationResult
+parse_profiling_phase_attestation(std::string_view bytes) {
+    try {
+        auto parsed = parse_profiling_phase_document(parse_json(bytes));
+        require_digest(parsed.checksum,
+                       "profiling phase attestation checksum");
+        auto sealed = seal_profiling_phase_data(std::move(parsed.draft));
+        if (parsed.checksum != sealed.checksum) {
+            reject(OverlayContractStatus::DigestMismatch,
+                   "profiling phase attestation checksum does not match");
+        }
+        if (bytes != sealed.canonical) {
+            reject(OverlayContractStatus::NonCanonical,
+                   "profiling phase attestation is not canonical JSON");
+        }
+        return ParsedProfilingPhaseAttestationResult{
+            OverlayContractStatus::Accepted,
+            {},
+            ParsedProfilingPhaseAttestation(
+                std::move(sealed.draft), std::move(sealed.checksum),
+                std::move(sealed.canonical)),
+        };
+    } catch (const OverlayFailure &failure) {
+        return rejected_profiling_phase(failure);
     }
 }
 

--- a/src/cpp/server/residency/profiling_transaction.cpp
+++ b/src/cpp/server/residency/profiling_transaction.cpp
@@ -2,9 +2,17 @@
 
 #include "lemon/router.h"
 
+#include <mbedtls/md.h>
+
+#include <array>
 #include <chrono>
+#include <ctime>
 #include <exception>
+#include <iomanip>
+#include <limits>
 #include <memory>
+#include <sstream>
+#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -13,11 +21,102 @@ namespace {
 
 using Clock = std::chrono::steady_clock;
 
+std::string system_utc_now() {
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm utc{};
+#ifdef _WIN32
+    gmtime_s(&utc, &time);
+#else
+    gmtime_r(&time, &utc);
+#endif
+    std::ostringstream output;
+    output << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+    return output.str();
+}
+
+std::optional<std::string> raw_sha256(std::string_view bytes) {
+    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    if (info == nullptr) {
+        return std::nullopt;
+    }
+    mbedtls_md_context_t context;
+    mbedtls_md_init(&context);
+    std::array<unsigned char, 32> digest{};
+    const bool failed =
+        mbedtls_md_setup(&context, info, 0) != 0 || mbedtls_md_starts(&context) != 0 ||
+        mbedtls_md_update(&context, reinterpret_cast<const unsigned char *>(bytes.data()),
+                          bytes.size()) != 0 ||
+        mbedtls_md_finish(&context, digest.data()) != 0;
+    mbedtls_md_free(&context);
+    if (failed) {
+        return std::nullopt;
+    }
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(64);
+    for (const auto byte : digest) {
+        result.push_back(hex[(byte >> 4) & 0x0f]);
+        result.push_back(hex[byte & 0x0f]);
+    }
+    return result;
+}
+
+std::int64_t days_from_civil(int year, unsigned month, unsigned day) noexcept {
+    year -= month <= 2;
+    const auto era = (year >= 0 ? year : year - 399) / 400;
+    const auto year_of_era = static_cast<unsigned>(year - era * 400);
+    const auto adjusted_month = month > 2 ? month - 3 : month + 9;
+    const auto day_of_year = (153U * adjusted_month + 2U) / 5U + day - 1U;
+    const auto day_of_era =
+        year_of_era * 365U + year_of_era / 4U - year_of_era / 100U + day_of_year;
+    return static_cast<std::int64_t>(era) * 146097 + static_cast<std::int64_t>(day_of_era) - 719468;
+}
+
+std::optional<std::int64_t> utc_seconds(std::string_view value) noexcept {
+    if (value.size() != 20 || value[4] != '-' || value[7] != '-' || value[10] != 'T' ||
+        value[13] != ':' || value[16] != ':' || value[19] != 'Z') {
+        return std::nullopt;
+    }
+    auto number = [&](std::size_t offset, std::size_t count) {
+        int result = 0;
+        for (std::size_t index = 0; index < count; ++index) {
+            const auto character = value[offset + index];
+            if (character < '0' || character > '9') {
+                return -1;
+            }
+            result = result * 10 + character - '0';
+        }
+        return result;
+    };
+    const auto year = number(0, 4);
+    const auto month = number(5, 2);
+    const auto day = number(8, 2);
+    const auto hour = number(11, 2);
+    const auto minute = number(14, 2);
+    const auto second = number(17, 2);
+    if (year <= 0 || month <= 0 || month > 12 || day <= 0 || hour < 0 || hour > 23 || minute < 0 ||
+        minute > 59 || second < 0 || second > 59) {
+        return std::nullopt;
+    }
+    static constexpr std::array<unsigned, 12> days_per_month{
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+    };
+    auto maximum_day = days_per_month[static_cast<std::size_t>(month - 1)];
+    if (month == 2 && (year % 400 == 0 || (year % 4 == 0 && year % 100 != 0))) {
+        maximum_day = 29;
+    }
+    if (static_cast<unsigned>(day) > maximum_day) {
+        return std::nullopt;
+    }
+    return days_from_civil(year, static_cast<unsigned>(month), static_cast<unsigned>(day)) * 86400 +
+           hour * 3600 + minute * 60 + second;
+}
+
 std::string bounded_diagnostic(std::string value) {
     if (value.size() > max_local_overlay_diagnostic_bytes) {
         std::size_t boundary = max_local_overlay_diagnostic_bytes;
-        while (boundary > 0 &&
-               (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u)
+        while (boundary > 0 && (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u)
             --boundary;
         value.resize(boundary);
     }
@@ -26,8 +125,8 @@ std::string bounded_diagnostic(std::string value) {
 
 ProfilingTransactionResult result_for(ProfilingTransactionStatus status,
                                       std::string diagnostic = {}) {
-    return ProfilingTransactionResult{
-        status, bounded_diagnostic(std::move(diagnostic)), std::nullopt};
+    return ProfilingTransactionResult{status, bounded_diagnostic(std::move(diagnostic)),
+                                      std::nullopt};
 }
 
 class RouterExclusiveLease {
@@ -38,15 +137,82 @@ public:
     RouterExclusiveLease &operator=(const RouterExclusiveLease &) = delete;
 
     ~RouterExclusiveLease() {
-        if (router_ != nullptr)
-            router_->end_exclusive();
+        if (router_ != nullptr) router_->end_exclusive();
     }
 
 private:
     Router *router_;
 };
 
+bool generations_equal(const OverlaySourceGenerations &left,
+                       const OverlaySourceGenerations &right) noexcept {
+    return left.model == right.model && left.backend == right.backend &&
+           left.device == right.device && left.topology == right.topology &&
+           left.driver == right.driver && left.configuration == right.configuration &&
+           left.workload == right.workload;
+}
+
+bool claim_sets_equal(const std::vector<ClaimFamilyClosure> &left,
+                      const std::vector<ClaimFamilyClosure> &right) {
+    auto checked_left = check_claim_closure(left);
+    auto checked_right = check_claim_closure(right);
+    return checked_left.accepted() && checked_right.accepted() &&
+           *checked_left.claims == *checked_right.claims;
+}
+
+bool release_is_bounded(const ParsedProfilingPhaseAttestation &baseline,
+                        const ParsedProfilingPhaseAttestation &release) {
+    auto baseline_claims = check_claim_closure(baseline.observed_claims());
+    auto uncertainty_claims = check_claim_closure(release.uncertainty_claims());
+    auto release_claims = check_claim_closure(release.observed_claims());
+    if (!baseline_claims.accepted() || !uncertainty_claims.accepted() ||
+        !release_claims.accepted()) {
+        return false;
+    }
+    auto upper_bound = checked_add(*baseline_claims.claims, *uncertainty_claims.claims);
+    if (!upper_bound.accepted()) {
+        return false;
+    }
+    return checked_subtract(*upper_bound.claims, *release_claims.claims).accepted();
+}
+
+std::string earliest_fresh_until(const ParsedProfilingPhaseAttestation &baseline,
+                                 const ParsedProfilingPhaseAttestation &workload,
+                                 const ParsedProfilingPhaseAttestation &release) {
+    auto earliest = std::string(baseline.fresh_until());
+    if (workload.fresh_until() < earliest) {
+        earliest = workload.fresh_until();
+    }
+    if (release.fresh_until() < earliest) {
+        earliest = release.fresh_until();
+    }
+    return earliest;
+}
+
 } // namespace
+
+AcceptedProfilingEvidence::AcceptedProfilingEvidence(ParsedProfilingInputEnvelope input,
+                                                     ParsedProfilingPhaseAttestation baseline,
+                                                     ParsedProfilingPhaseAttestation workload,
+                                                     ParsedProfilingPhaseAttestation release)
+    : input_(std::move(input)), baseline_(std::move(baseline)), workload_(std::move(workload)),
+      release_(std::move(release)) {}
+
+const ParsedProfilingInputEnvelope &AcceptedProfilingEvidence::input() const noexcept {
+    return input_;
+}
+
+const ParsedProfilingPhaseAttestation &AcceptedProfilingEvidence::baseline() const noexcept {
+    return baseline_;
+}
+
+const ParsedProfilingPhaseAttestation &AcceptedProfilingEvidence::workload() const noexcept {
+    return workload_;
+}
+
+const ParsedProfilingPhaseAttestation &AcceptedProfilingEvidence::release() const noexcept {
+    return release_;
+}
 
 struct ProfilingTransaction::RunState {
     // Zero means no abort. A single atomic keeps restart precedence ordered
@@ -54,26 +220,23 @@ struct ProfilingTransaction::RunState {
     std::atomic<int> abort_reason{0};
 
     void latch(ProfilingAbortReason reason) noexcept {
-        const auto status = reason == ProfilingAbortReason::Restarted
-                                ? ProfilingTransactionStatus::Restarted
-                            : reason == ProfilingAbortReason::Cancelled
-                                ? ProfilingTransactionStatus::Cancelled
-                                : ProfilingTransactionStatus::Failed;
+        const auto status =
+            reason == ProfilingAbortReason::Restarted   ? ProfilingTransactionStatus::Restarted
+            : reason == ProfilingAbortReason::Cancelled ? ProfilingTransactionStatus::Cancelled
+                                                        : ProfilingTransactionStatus::Failed;
         // A lifecycle restart always wins over an ordinary caller cancel.
         if (status == ProfilingTransactionStatus::Restarted) {
-            abort_reason.store(static_cast<int>(status),
-                               std::memory_order_seq_cst);
+            abort_reason.store(static_cast<int>(status), std::memory_order_seq_cst);
         } else {
             int expected = 0;
-            abort_reason.compare_exchange_strong(
-                expected, static_cast<int>(status), std::memory_order_seq_cst);
+            abort_reason.compare_exchange_strong(expected, static_cast<int>(status),
+                                                 std::memory_order_seq_cst);
         }
     }
 
     std::optional<ProfilingTransactionStatus> reason() const noexcept {
         const int raw = abort_reason.load(std::memory_order_seq_cst);
-        if (raw == 0)
-            return std::nullopt;
+        if (raw == 0) return std::nullopt;
         const auto value = static_cast<ProfilingTransactionStatus>(raw);
         if (value == ProfilingTransactionStatus::Restarted ||
             value == ProfilingTransactionStatus::Cancelled ||
@@ -86,8 +249,7 @@ struct ProfilingTransaction::RunState {
 
 class ProfilingTransaction::RunningGuard {
 public:
-    RunningGuard(ProfilingTransaction &transaction,
-                 std::shared_ptr<RunState> state)
+    RunningGuard(ProfilingTransaction &transaction, std::shared_ptr<RunState> state)
         : transaction_(transaction), state_(std::move(state)) {}
 
     RunningGuard(const RunningGuard &) = delete;
@@ -95,8 +257,7 @@ public:
 
     ~RunningGuard() {
         std::lock_guard<std::mutex> lock(transaction_.mutex_);
-        if (transaction_.active_run_ == state_)
-            transaction_.active_run_.reset();
+        if (transaction_.active_run_ == state_) transaction_.active_run_.reset();
         transaction_.owner_thread_ = std::thread::id{};
         transaction_.running_ = false;
         transaction_.idle_cv_.notify_all();
@@ -107,13 +268,13 @@ private:
     std::shared_ptr<RunState> state_;
 };
 
-ProfilingTransaction::ProfilingTransaction(Router &router,
-                                           ProfilingTransactionOptions options)
+ProfilingTransaction::ProfilingTransaction(Router &router, ProfilingTransactionOptions options)
     : router_(router), options_(std::move(options)) {
     if (options_.gate_timeout <= std::chrono::milliseconds::zero())
         options_.gate_timeout = std::chrono::milliseconds(1);
     if (options_.retry_interval <= std::chrono::milliseconds::zero())
         options_.retry_interval = std::chrono::milliseconds(1);
+    if (!options_.utc_now) options_.utc_now = system_utc_now;
 }
 
 ProfilingTransaction::~ProfilingTransaction() {
@@ -144,25 +305,21 @@ void ProfilingTransaction::request_abort(ProfilingAbortReason reason) noexcept {
     } catch (...) {
         return;
     }
-    if (state)
-        state->latch(reason);
+    if (state) state->latch(reason);
     idle_cv_.notify_all();
 }
 
 bool ProfilingTransaction::wait_for_idle() {
     std::unique_lock<std::mutex> lock(mutex_);
-    if (!running_)
-        return true;
-    if (owner_thread_ == std::this_thread::get_id())
-        return false;
+    if (!running_) return true;
+    if (owner_thread_ == std::this_thread::get_id()) return false;
     idle_cv_.wait(lock, [this] { return !running_; });
     return true;
 }
 
-ProfilingTransactionResult
-ProfilingTransaction::run(std::string transaction_id, Capture capture,
-                          std::atomic<bool> *cancel,
-                          std::function<bool()> restart_detected) {
+ProfilingTransactionResult ProfilingTransaction::run(ProfilingTransactionContext context,
+                                                     Capture capture, std::atomic<bool> *cancel,
+                                                     std::function<bool()> restart_detected) {
     auto state = std::make_shared<RunState>();
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -182,8 +339,7 @@ ProfilingTransaction::run(std::string transaction_id, Capture capture,
     auto check_abort = [&]() -> std::optional<ProfilingTransactionResult> {
         const auto latched = state->reason();
         if (latched && *latched == ProfilingTransactionStatus::Restarted)
-            return result_for(*latched,
-                              "profiling transaction interrupted by restart");
+            return result_for(*latched, "profiling transaction interrupted by restart");
         if (latched) {
             try {
                 if (restart_detected && restart_detected())
@@ -191,12 +347,11 @@ ProfilingTransaction::run(std::string transaction_id, Capture capture,
             } catch (...) {
             }
             const auto reason = state->reason().value_or(*latched);
-            const char *message =
-                reason == ProfilingTransactionStatus::Restarted
-                    ? "profiling transaction interrupted by restart"
-                : reason == ProfilingTransactionStatus::Cancelled
-                    ? "profiling transaction cancelled"
-                    : "profiling lifecycle check failed";
+            const char *message = reason == ProfilingTransactionStatus::Restarted
+                                      ? "profiling transaction interrupted by restart"
+                                  : reason == ProfilingTransactionStatus::Cancelled
+                                      ? "profiling transaction cancelled"
+                                      : "profiling lifecycle check failed";
             return result_for(reason, message);
         }
         try {
@@ -208,85 +363,74 @@ ProfilingTransaction::run(std::string transaction_id, Capture capture,
             state->latch(ProfilingAbortReason::Failed);
         }
         if (const auto reason = state->reason()) {
-            const char *message =
-                *reason == ProfilingTransactionStatus::Restarted
-                    ? "profiling transaction interrupted by restart"
-                : *reason == ProfilingTransactionStatus::Cancelled
-                    ? "profiling transaction cancelled"
-                    : "profiling lifecycle check failed";
+            const char *message = *reason == ProfilingTransactionStatus::Restarted
+                                      ? "profiling transaction interrupted by restart"
+                                  : *reason == ProfilingTransactionStatus::Cancelled
+                                      ? "profiling transaction cancelled"
+                                      : "profiling lifecycle check failed";
             return result_for(*reason, message);
         }
         return std::nullopt;
     };
 
-    if (auto aborted = check_abort())
-        return std::move(*aborted);
-    if (transaction_id.empty())
+    if (auto aborted = check_abort()) return std::move(*aborted);
+    if (context.profiling_transaction_id.empty())
         return result_for(ProfilingTransactionStatus::InvalidEvidence,
                           "profiling transaction ID is missing");
 
     const auto deadline = Clock::now() + options_.gate_timeout;
     auto wait_for_retry = [&]() {
         const auto remaining =
-            std::chrono::duration_cast<std::chrono::milliseconds>(deadline -
-                                                                  Clock::now());
-        if (remaining <= std::chrono::milliseconds::zero())
-            return;
-        const auto delay = options_.retry_interval < remaining
-                               ? options_.retry_interval
-                               : remaining;
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - Clock::now());
+        if (remaining <= std::chrono::milliseconds::zero()) return;
+        const auto delay =
+            options_.retry_interval < remaining ? options_.retry_interval : remaining;
         std::this_thread::sleep_for(delay);
     };
     auto timeout_or_abort = [&]() {
-        if (auto aborted = check_abort())
-            return std::move(*aborted);
+        if (auto aborted = check_abort()) return std::move(*aborted);
         return result_for(ProfilingTransactionStatus::GateTimeout,
                           "profiling Router gate timed out");
     };
     bool acquired = false;
     try {
         while (!acquired) {
-            if (auto aborted = check_abort())
-                return std::move(*aborted);
-            if (Clock::now() >= deadline)
-                return timeout_or_abort();
+            if (auto aborted = check_abort()) return std::move(*aborted);
+            if (Clock::now() >= deadline) return timeout_or_abort();
 
-            auto request = router_.request_exclusive(cancel);
+            auto request = router_.request_exclusive_until(deadline, cancel);
             while (request.pending()) {
-                if (auto aborted = check_abort())
-                    return std::move(*aborted);
-                const auto acquire_result =
-                    router_.try_begin_exclusive(request, cancel);
-                if (acquire_result ==
-                    Router::ExclusiveAcquireResult::Acquired) {
+                if (auto aborted = check_abort()) return std::move(*aborted);
+                const auto acquire_result = router_.try_begin_exclusive(request, cancel);
+                if (acquire_result == Router::ExclusiveAcquireResult::Acquired) {
                     acquired = true;
                     break;
                 }
-                if (acquire_result ==
-                    Router::ExclusiveAcquireResult::Cancelled) {
+                if (acquire_result == Router::ExclusiveAcquireResult::Cancelled) {
                     state->latch(ProfilingAbortReason::Cancelled);
-                    if (auto aborted = check_abort())
-                        return std::move(*aborted);
+                    if (auto aborted = check_abort()) return std::move(*aborted);
                     return result_for(ProfilingTransactionStatus::Cancelled,
                                       "profiling transaction cancelled");
                 }
-                if (acquire_result != Router::ExclusiveAcquireResult::Retry)
-                    return result_for(
-                        ProfilingTransactionStatus::Failed,
-                        "profiling Router gate acquisition failed");
-                if (Clock::now() >= deadline)
+                if (acquire_result == Router::ExclusiveAcquireResult::DeadlineExceeded) {
                     return timeout_or_abort();
+                }
+                if (acquire_result != Router::ExclusiveAcquireResult::Retry)
+                    return result_for(ProfilingTransactionStatus::Failed,
+                                      "profiling Router gate acquisition failed");
+                if (Clock::now() >= deadline) return timeout_or_abort();
                 wait_for_retry();
             }
-            if (acquired)
-                break;
+            if (acquired) break;
 
             if (request.result() == Router::ExclusiveAcquireResult::Cancelled) {
                 state->latch(ProfilingAbortReason::Cancelled);
-                if (auto aborted = check_abort())
-                    return std::move(*aborted);
+                if (auto aborted = check_abort()) return std::move(*aborted);
                 return result_for(ProfilingTransactionStatus::Cancelled,
                                   "profiling transaction cancelled");
+            }
+            if (request.result() == Router::ExclusiveAcquireResult::DeadlineExceeded) {
+                return timeout_or_abort();
             }
             if (request.result() != Router::ExclusiveAcquireResult::Retry)
                 return result_for(ProfilingTransactionStatus::Failed,
@@ -294,22 +438,19 @@ ProfilingTransaction::run(std::string transaction_id, Capture capture,
             wait_for_retry();
         }
     } catch (...) {
-        if (auto aborted = check_abort())
-            return std::move(*aborted);
+        if (auto aborted = check_abort()) return std::move(*aborted);
         return result_for(ProfilingTransactionStatus::Failed,
                           "profiling Router gate acquisition failed");
     }
 
     RouterExclusiveLease lease(router_);
-    if (auto aborted = check_abort())
-        return std::move(*aborted);
+    if (auto aborted = check_abort()) return std::move(*aborted);
 
     ProfilingTransactionCapture capture_result;
     try {
         const ProfilingCancellationCheck should_abort = [&]() noexcept {
             const auto latched = state->reason();
-            if (latched && *latched == ProfilingTransactionStatus::Restarted)
-                return true;
+            if (latched && *latched == ProfilingTransactionStatus::Restarted) return true;
             if (latched) {
                 try {
                     if (restart_detected && restart_detected())
@@ -328,60 +469,187 @@ ProfilingTransaction::run(std::string transaction_id, Capture capture,
             }
             return state->reason().has_value();
         };
-        capture_result = capture(router_, should_abort);
+        capture_result = capture(router_, context, should_abort);
     } catch (...) {
-        if (auto aborted = check_abort())
-            return std::move(*aborted);
-        return result_for(ProfilingTransactionStatus::Failed,
-                          "profiling capture failed");
+        if (auto aborted = check_abort()) return std::move(*aborted);
+        return result_for(ProfilingTransactionStatus::Failed, "profiling capture failed");
     }
 
-    if (auto aborted = check_abort())
-        return std::move(*aborted);
-    if (!capture_result.draft.has_value() ||
-        !capture_result.baseline_captured ||
-        !capture_result.workload_captured || !capture_result.release_captured ||
-        !capture_result.identity_complete ||
-        !capture_result.observations_fresh ||
-        !capture_result.observations_healthy ||
-        !capture_result.uncertainty_bound_verified ||
-        !capture_result.safety_margin_verified) {
-        return result_for(ProfilingTransactionStatus::EvidenceUnavailable,
-                          capture_result.diagnostic.empty()
-                              ? "profiling evidence is incomplete"
-                              : capture_result.diagnostic);
-    }
-    if (!capture_result.draft->attribution_complete ||
-        !capture_result.draft->external_demand_absent ||
-        !capture_result.draft->lifecycle_release_verified)
-        return result_for(ProfilingTransactionStatus::EvidenceUnavailable,
-                          "profiling evidence is not safe to publish");
-    if (capture_result.draft->profiling_transaction_id != transaction_id)
-        return result_for(ProfilingTransactionStatus::InvalidEvidence,
-                          "profiling transaction ID does not match capture");
-
-    ParsedProfilingInputEnvelopeResult sealed;
+    if (auto aborted = check_abort()) return std::move(*aborted);
     try {
-        sealed = seal_profiling_input(std::move(*capture_result.draft));
-    } catch (...) {
-        if (auto aborted = check_abort())
-            return std::move(*aborted);
-        return result_for(ProfilingTransactionStatus::Failed,
-                          "profiling evidence sealing failed");
-    }
-    if (!sealed.accepted())
-        return result_for(ProfilingTransactionStatus::InvalidEvidence,
-                          sealed.diagnostic.empty()
-                              ? "profiling evidence failed contract validation"
-                              : sealed.diagnostic);
-    if (auto aborted = check_abort())
-        return std::move(*aborted);
+        if (capture_result.baseline_attestation.empty() ||
+            capture_result.workload_attestation.empty() ||
+            capture_result.release_attestation.empty()) {
+            return result_for(
+                ProfilingTransactionStatus::EvidenceUnavailable,
+                capture_result.diagnostic.empty() ? "profiling evidence is incomplete"
+                                                  : capture_result.diagnostic);
+        }
+        auto baseline = parse_profiling_phase_attestation(capture_result.baseline_attestation);
+        auto workload = parse_profiling_phase_attestation(capture_result.workload_attestation);
+        auto release = parse_profiling_phase_attestation(capture_result.release_attestation);
+        if (!baseline.accepted() || !workload.accepted() || !release.accepted()) {
+            const auto &diagnostic = !baseline.accepted()   ? baseline.diagnostic
+                                     : !workload.accepted() ? workload.diagnostic
+                                                            : release.diagnostic;
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              diagnostic.empty() ? "profiling phase attestation is invalid"
+                                                 : diagnostic);
+        }
 
-    ProfilingTransactionResult result;
-    result.status = ProfilingTransactionStatus::Accepted;
-    result.diagnostic = "profiling evidence accepted";
-    result.candidate = std::move(sealed.candidate);
-    return result;
+        const auto &baseline_phase = *baseline.candidate;
+        const auto &workload_phase = *workload.candidate;
+        const auto &release_phase = *release.candidate;
+        const auto common_reference_matches =
+            baseline_phase.deployment_id() == context.deployment_id &&
+            workload_phase.deployment_id() == context.deployment_id &&
+            release_phase.deployment_id() == context.deployment_id &&
+            baseline_phase.profiling_transaction_id() == context.profiling_transaction_id &&
+            workload_phase.profiling_transaction_id() == context.profiling_transaction_id &&
+            release_phase.profiling_transaction_id() == context.profiling_transaction_id &&
+            baseline_phase.selector_sha256() == context.selector_sha256 &&
+            workload_phase.selector_sha256() == context.selector_sha256 &&
+            release_phase.selector_sha256() == context.selector_sha256 &&
+            baseline_phase.provider_id() == workload_phase.provider_id() &&
+            workload_phase.provider_id() == release_phase.provider_id() &&
+            baseline_phase.provider_revision_sha256() ==
+                workload_phase.provider_revision_sha256() &&
+            workload_phase.provider_revision_sha256() == release_phase.provider_revision_sha256() &&
+            baseline_phase.observation_contract_sha256() == context.observation_contract_sha256 &&
+            workload_phase.observation_contract_sha256() == context.observation_contract_sha256 &&
+            release_phase.observation_contract_sha256() == context.observation_contract_sha256 &&
+            baseline_phase.predictor_contract_sha256() == context.predictor_contract_sha256 &&
+            workload_phase.predictor_contract_sha256() == context.predictor_contract_sha256 &&
+            release_phase.predictor_contract_sha256() == context.predictor_contract_sha256 &&
+            generations_equal(baseline_phase.generations(), context.generations) &&
+            generations_equal(workload_phase.generations(), context.generations) &&
+            generations_equal(release_phase.generations(), context.generations);
+        const auto phase_order_is_valid =
+            baseline_phase.phase() == ProfilingPhase::Baseline &&
+            workload_phase.phase() == ProfilingPhase::Workload &&
+            release_phase.phase() == ProfilingPhase::Release &&
+            baseline_phase.observation_generation() < workload_phase.observation_generation() &&
+            workload_phase.observation_generation() < release_phase.observation_generation() &&
+            baseline_phase.observed_at() < workload_phase.observed_at() &&
+            workload_phase.observed_at() < release_phase.observed_at();
+        const auto attribution_is_closed =
+            claim_sets_equal(baseline_phase.observed_claims(),
+                             baseline_phase.attributed_claims()) &&
+            claim_sets_equal(workload_phase.observed_claims(),
+                             workload_phase.attributed_claims()) &&
+            claim_sets_equal(release_phase.observed_claims(), release_phase.attributed_claims()) &&
+            release_is_bounded(baseline_phase, release_phase);
+        if (!common_reference_matches || !phase_order_is_valid || !attribution_is_closed) {
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              "profiling phase attestations do not form a closed transaction");
+        }
+        if (auto aborted = check_abort()) return std::move(*aborted);
+
+        std::string accepted_at;
+        try {
+            accepted_at = options_.utc_now();
+        } catch (...) {
+            if (auto aborted = check_abort()) return std::move(*aborted);
+            return result_for(ProfilingTransactionStatus::Failed,
+                              "profiling acceptance clock failed");
+        }
+        const auto accepted_at_seconds = utc_seconds(accepted_at);
+        const auto release_at_seconds = utc_seconds(release_phase.observed_at());
+        const auto common_skew = baseline_phase.max_source_skew_milliseconds();
+        if (!accepted_at_seconds.has_value() || !release_at_seconds.has_value()) {
+            return result_for(ProfilingTransactionStatus::Failed,
+                              "profiling acceptance clock is invalid");
+        }
+        const auto skew_seconds_unsigned = common_skew / 1000 + (common_skew % 1000 == 0 ? 0 : 1);
+        if (skew_seconds_unsigned >
+            static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())) {
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              "profiling source skew bound is invalid");
+        }
+        const auto skew_seconds = static_cast<std::int64_t>(skew_seconds_unsigned);
+        if (*accepted_at_seconds > std::numeric_limits<std::int64_t>::max() - skew_seconds) {
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              "profiling source skew bound is invalid");
+        }
+        const auto fresh_until =
+            earliest_fresh_until(baseline_phase, workload_phase, release_phase);
+        const auto fresh_until_seconds = utc_seconds(fresh_until);
+        if (!fresh_until_seconds.has_value()) {
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              "profiling freshness timestamp is invalid");
+        }
+        if (workload_phase.max_source_skew_milliseconds() != common_skew ||
+            release_phase.max_source_skew_milliseconds() != common_skew) {
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              "profiling source skew contracts do not match");
+        }
+        if (*accepted_at_seconds >= *fresh_until_seconds ||
+            *release_at_seconds > *accepted_at_seconds + skew_seconds) {
+            return result_for(ProfilingTransactionStatus::EvidenceUnavailable,
+                              "profiling evidence is stale or future-dated");
+        }
+
+        const auto baseline_sha256 = raw_sha256(capture_result.baseline_attestation);
+        const auto workload_sha256 = raw_sha256(capture_result.workload_attestation);
+        const auto release_sha256 = raw_sha256(capture_result.release_attestation);
+        if (!baseline_sha256.has_value() || !workload_sha256.has_value() ||
+            !release_sha256.has_value()) {
+            return result_for(ProfilingTransactionStatus::Failed,
+                              "profiling evidence digest is unavailable");
+        }
+
+        ProfilingInputEnvelopeDraft input;
+        input.schema = supported_local_overlay_schema;
+        input.deployment_id = std::move(context.deployment_id);
+        input.sequence = context.sequence;
+        input.profiling_transaction_id = std::move(context.profiling_transaction_id);
+        input.selector = std::move(context.selector);
+        input.generations = context.generations;
+        input.attributed_claims = workload_phase.attributed_claims();
+        input.baseline_observation_sha256 = *baseline_sha256;
+        input.workload_observation_sha256 = *workload_sha256;
+        input.release_observation_sha256 = *release_sha256;
+        input.observation_contract_sha256 = std::move(context.observation_contract_sha256);
+        input.predictor_contract_sha256 = std::move(context.predictor_contract_sha256);
+        input.observed_at = release_phase.observed_at();
+        input.fresh_until = std::move(fresh_until);
+        input.max_clock_skew_milliseconds = common_skew;
+        input.attribution_complete = true;
+        input.external_demand_absent = true;
+        input.lifecycle_release_verified = true;
+
+        ParsedProfilingInputEnvelopeResult sealed;
+        try {
+            sealed = seal_profiling_input(std::move(input));
+        } catch (...) {
+            if (auto aborted = check_abort()) return std::move(*aborted);
+            return result_for(ProfilingTransactionStatus::Failed,
+                              "profiling evidence sealing failed");
+        }
+        if (!sealed.accepted())
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              sealed.diagnostic.empty()
+                                  ? "profiling evidence failed contract validation"
+                                  : sealed.diagnostic);
+        if (auto aborted = check_abort()) return std::move(*aborted);
+        if (sealed.candidate->selector_sha256() != context.selector_sha256) {
+            return result_for(ProfilingTransactionStatus::InvalidEvidence,
+                              "profiling selector attestation does not match input");
+        }
+        if (auto aborted = check_abort()) return std::move(*aborted);
+
+        ProfilingTransactionResult result;
+        result.status = ProfilingTransactionStatus::Accepted;
+        result.diagnostic = "profiling evidence accepted";
+        result.evidence = AcceptedProfilingEvidence(
+            std::move(*sealed.candidate), std::move(*baseline.candidate),
+            std::move(*workload.candidate), std::move(*release.candidate));
+        return result;
+    } catch (...) {
+        if (auto aborted = check_abort()) return std::move(*aborted);
+        return result_for(ProfilingTransactionStatus::Failed,
+                          "profiling evidence validation failed");
+    }
 }
 
 } // namespace lemon::residency

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -131,7 +131,8 @@ Router::ExclusiveRequest::ExclusiveRequest(
     ExclusiveRequest&& other) noexcept
     : router_(other.router_),
       generation_(other.generation_),
-      result_(other.result_) {
+      result_(other.result_),
+      deadline_(other.deadline_) {
     other.router_ = nullptr;
 }
 
@@ -343,11 +344,10 @@ void Router::release_prepared_model_load(
 }
 
 void Router::cancel_exclusive_request(uint64_t generation) noexcept {
-    std::lock_guard<std::mutex> lock(load_mutex_);
-    if (exclusive_pending_ &&
-        exclusive_pending_generation_ == generation) {
-        exclusive_pending_ = false;
-        exclusive_pending_generation_ = 0;
+    auto expected = generation;
+    if (exclusive_pending_generation_.compare_exchange_strong(
+            expected, 0, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
         load_cv_.notify_all();
     }
 }
@@ -549,7 +549,7 @@ Router::PreparedModelLoad Router::prepare_model_load_internal(
     std::string canonical_model_name;
     while (true) {
         canonical_model_name = resolve_model_name(model_name);
-        load_cv_.wait(lock, [this, &canonical_model_name] {
+        wait_for_load_state(lock, [this, &canonical_model_name] {
             auto pending = pending_reload_states_.find(canonical_model_name);
             const bool mutation_in_progress =
                 pending != pending_reload_states_.end() &&
@@ -559,7 +559,7 @@ Router::PreparedModelLoad Router::prepare_model_load_internal(
                 prepared_load_counts_.end();
             return !all_model_mutation_active_ && !is_loading_ &&
                    !mutation_in_progress && !preparation_in_progress &&
-                   !exclusive_pending_ &&
+                   !exclusive_pending() &&
                    (!exclusive_active_ ||
                     exclusive_owner_ == std::this_thread::get_id());
         });
@@ -681,9 +681,9 @@ void Router::apply_routing_helper_reconcile(std::set<std::string> needed, uint64
     // Only the eviction pass must wait for a quiet slot: evict_server mutates
     // loaded_servers_ and blocks on request drain, neither of which is safe to
     // interleave with an in-flight load.
-    load_cv_.wait(lock, [&] {
+    wait_for_load_state(lock, [&] {
         return !is_loading_ &&
-               !exclusive_pending_ &&
+               !exclusive_pending() &&
                (!exclusive_active_ ||
                 exclusive_owner_ == std::this_thread::get_id());
     });
@@ -737,10 +737,10 @@ void Router::reclaim_stale_helper_if_idle(const std::string& model_name) {
         // on a later prune (not guaranteed to run when the load / exclusive
         // session ends). The wait is broken on shutdown so the executor worker
         // can drain and join.
-        load_cv_.wait(lock, [&] {
+        wait_for_load_state(lock, [&] {
             return reclaim_shutdown_ ||
                    (!is_loading_ &&
-                    !exclusive_pending_ &&
+                    !exclusive_pending() &&
                     (!exclusive_active_ || exclusive_owner_ == std::this_thread::get_id()));
         });
         if (reclaim_shutdown_) {
@@ -979,7 +979,36 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
 
 Router::ExclusiveRequest Router::request_exclusive(
     std::atomic<bool>* cancel) {
-    std::lock_guard<std::mutex> lock(load_mutex_);
+    return request_exclusive_impl(cancel, std::nullopt);
+}
+
+Router::ExclusiveRequest Router::request_exclusive_until(
+    std::chrono::steady_clock::time_point deadline,
+    std::atomic<bool>* cancel) {
+    return request_exclusive_impl(cancel, deadline);
+}
+
+bool Router::exclusive_pending() const noexcept {
+    return exclusive_pending_generation_.load(std::memory_order_acquire) != 0;
+}
+
+Router::ExclusiveRequest Router::request_exclusive_impl(
+    std::atomic<bool>* cancel,
+    std::optional<std::chrono::steady_clock::time_point> deadline) {
+    std::unique_lock<std::mutex> lock(load_mutex_, std::defer_lock);
+    if (deadline.has_value()) {
+        if (std::chrono::steady_clock::now() >= *deadline)
+            return ExclusiveRequest(
+                nullptr, 0, ExclusiveAcquireResult::DeadlineExceeded);
+        if (!lock.try_lock())
+            return ExclusiveRequest(
+                nullptr, 0, ExclusiveAcquireResult::Retry);
+        if (std::chrono::steady_clock::now() >= *deadline)
+            return ExclusiveRequest(
+                nullptr, 0, ExclusiveAcquireResult::DeadlineExceeded);
+    } else {
+        lock.lock();
+    }
     const auto caller = std::this_thread::get_id();
     if (cancel && cancel->load()) {
         return ExclusiveRequest(
@@ -989,39 +1018,62 @@ Router::ExclusiveRequest Router::request_exclusive(
         return ExclusiveRequest(
             nullptr, 0, ExclusiveAcquireResult::InvalidOrder);
     }
-    if (exclusive_active_ || exclusive_pending_) {
+    if (exclusive_active_ || exclusive_pending()) {
         return ExclusiveRequest(
             nullptr, 0, ExclusiveAcquireResult::Retry);
     }
-    exclusive_pending_ = true;
-    exclusive_pending_generation_ = ++next_exclusive_generation_;
+    if (++next_exclusive_generation_ == 0)
+        ++next_exclusive_generation_;
     exclusive_admission_generation_ = next_load_generation_;
+    exclusive_pending_generation_.store(next_exclusive_generation_,
+                                        std::memory_order_release);
     load_cv_.notify_all();
     return ExclusiveRequest(
-        this,
-        exclusive_pending_generation_,
-        ExclusiveAcquireResult::Retry);
+        this, next_exclusive_generation_, ExclusiveAcquireResult::Retry,
+        deadline);
 }
 
 Router::ExclusiveAcquireResult Router::try_begin_exclusive(
     ExclusiveRequest& request,
     std::atomic<bool>* cancel) {
-    std::lock_guard<std::mutex> lock(load_mutex_);
+    return try_begin_exclusive_impl(request, cancel);
+}
+
+Router::ExclusiveAcquireResult Router::try_begin_exclusive_impl(
+    ExclusiveRequest& request,
+    std::atomic<bool>* cancel) {
     if (request.router_ != this) {
         return request.result_;
     }
-    if (!exclusive_pending_ ||
-        exclusive_pending_generation_ != request.generation_) {
+    auto deadline_exceeded = [&] {
+        cancel_exclusive_request(request.generation_);
+        request.router_ = nullptr;
+        request.result_ = ExclusiveAcquireResult::DeadlineExceeded;
+        return request.result_;
+    };
+    if (request.deadline_.has_value() &&
+        std::chrono::steady_clock::now() >= *request.deadline_) {
+        return deadline_exceeded();
+    }
+    std::unique_lock<std::mutex> lock(load_mutex_, std::defer_lock);
+    if (request.deadline_.has_value()) {
+        if (!lock.try_lock())
+            return ExclusiveAcquireResult::Retry;
+        if (std::chrono::steady_clock::now() >= *request.deadline_)
+            return deadline_exceeded();
+    } else {
+        lock.lock();
+    }
+    if (exclusive_pending_generation_.load(std::memory_order_acquire) !=
+        request.generation_) {
         request.router_ = nullptr;
         request.result_ = ExclusiveAcquireResult::InvalidOrder;
         return request.result_;
     }
     if (cancel && cancel->load()) {
-        exclusive_pending_ = false;
-        exclusive_pending_generation_ = 0;
+        cancel_exclusive_request(request.generation_);
         request.router_ = nullptr;
         request.result_ = ExclusiveAcquireResult::Cancelled;
-        load_cv_.notify_all();
         return request.result_;
     }
     const bool lifecycle_mutation_active = std::any_of(
@@ -1043,10 +1095,15 @@ Router::ExclusiveAcquireResult Router::try_begin_exclusive(
         return ExclusiveAcquireResult::Retry;
     }
 
-    exclusive_pending_ = false;
-    exclusive_pending_generation_ = 0;
     exclusive_active_ = true;
     exclusive_owner_ = std::this_thread::get_id();
+    if (request.deadline_.has_value() &&
+        std::chrono::steady_clock::now() >= *request.deadline_) {
+        exclusive_active_ = false;
+        exclusive_owner_ = std::thread::id{};
+        return deadline_exceeded();
+    }
+    exclusive_pending_generation_.store(0, std::memory_order_release);
     request.router_ = nullptr;
     request.result_ = ExclusiveAcquireResult::Acquired;
     load_cv_.notify_all();
@@ -1061,9 +1118,9 @@ void Router::end_exclusive() {
 }
 
 void Router::wait_for_slot_clearance(std::unique_lock<std::mutex>& lock) {
-    load_cv_.wait(lock, [&] {
+    wait_for_load_state(lock, [&] {
         return !all_model_mutation_active_ &&
-               !exclusive_pending_ &&
+               !exclusive_pending() &&
                (!exclusive_active_ ||
                 exclusive_owner_ == std::this_thread::get_id());
     });
@@ -1075,10 +1132,10 @@ std::string Router::resolve_model_name_after_mutation_gate_locked(
     while (true) {
         const std::string canonical_model_name = resolve_model_name(model_name);
         wait_for_slot_clearance(lock);
-        load_cv_.wait(lock, [this, &canonical_model_name] {
+        wait_for_load_state(lock, [this, &canonical_model_name] {
             auto pending = pending_reload_states_.find(canonical_model_name);
             return !all_model_mutation_active_ &&
-                   !exclusive_pending_ &&
+                   !exclusive_pending() &&
                    (!exclusive_active_ ||
                     exclusive_owner_ == std::this_thread::get_id()) &&
                    (pending == pending_reload_states_.end() ||
@@ -1343,20 +1400,22 @@ void Router::load_model_impl(
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);
 
-    load_cv_.wait(lock, [&] {
+    wait_for_load_state(lock, [&] {
+        const auto pending_generation =
+            exclusive_pending_generation_.load(std::memory_order_acquire);
         const bool claim_invalid = !reload_generation_matches_locked(
             canonical_model_name,
             load_generation,
             model_info,
             preparation.existing_model_policy_);
         const bool admitted_before_exclusive =
-            exclusive_pending_ &&
+            pending_generation != 0 &&
             load_generation <= exclusive_admission_generation_;
         return claim_invalid ||
                (!is_loading_ &&
                 (!exclusive_active_ ||
                  exclusive_owner_ == std::this_thread::get_id()) &&
-                (!exclusive_pending_ || admitted_before_exclusive));
+                (pending_generation == 0 || admitted_before_exclusive));
     });
 
     if (!reload_generation_matches_locked(
@@ -2086,7 +2145,7 @@ void Router::evict_if_committed(const std::string& model_name) {
     // An exclusive session may have started (and re-pinned this model via the
     // job snapshot reconcile) since the EVICTING mark was set. Neither state
     // was known when the eviction was decided, so abandon it.
-    if (exclusive_active_ || exclusive_pending_ || server->is_pinned()) {
+    if (exclusive_active_ || exclusive_pending() || server->is_pinned()) {
         server->rescue_from_eviction();
         LOG(INFO, "Router") << "Eviction of " << model_name << " cancelled ("
                             << (server->is_pinned() ? "pinned" : "exclusive session active")

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2563,7 +2563,7 @@ void Server::begin_residency_lifecycle_change() {
 
 residency::ProfilingTransactionResult
 Server::run_residency_profiling_transaction(
-    std::string transaction_id,
+    residency::ProfilingTransactionContext context,
     residency::ProfilingTransaction::Capture capture,
     std::atomic<bool> *cancel) {
     uint64_t lifecycle_epoch = 0;
@@ -2601,15 +2601,15 @@ Server::run_residency_profiling_transaction(
         if (lifecycle_changed) {
             value.status = residency::ProfilingTransactionStatus::Restarted;
             value.diagnostic = "profiling lifecycle changed before publication";
-            value.candidate.reset();
+            value.evidence.reset();
         } else if (value.status ==
                        residency::ProfilingTransactionStatus::Accepted &&
-                   !value.candidate.has_value()) {
+                   !value.evidence.has_value()) {
             value.status = residency::ProfilingTransactionStatus::InvalidEvidence;
-            value.diagnostic = "profiling transaction returned no candidate";
+            value.diagnostic = "profiling transaction returned no evidence";
         }
         if (value.status != residency::ProfilingTransactionStatus::Accepted)
-            value.candidate.reset();
+            value.evidence.reset();
         admission_guard.release_locked();
         return value;
     };
@@ -2617,7 +2617,7 @@ Server::run_residency_profiling_transaction(
     residency::ProfilingTransactionResult result;
     try {
         result = transaction->run(
-            std::move(transaction_id), std::move(capture), cancel,
+            std::move(context), std::move(capture), cancel,
             [this, lifecycle_epoch] {
                 return !profiling_accepting_.load() ||
                        shutdown_requested_.load() || rebind_requested_.load() ||

--- a/test/cpp/test_residency_contract_matrix.cpp
+++ b/test/cpp/test_residency_contract_matrix.cpp
@@ -15,7 +15,7 @@ namespace {
 using namespace lemon::residency;
 
 constexpr std::string_view expected_catalog_sha256 =
-    "de567a516d6dc5b731d5acf0f66fe84ab7cae1d1329d6f6bd9735510a5684d65";
+    "c3b8fcd06079c8733515b04a8082c164562636681c197e7ee686406a95f2bd55";
 
 template <typename T>
 T known_value(const DecodedValue<T> &decoded, std::string_view label) {
@@ -257,7 +257,7 @@ void require_generated_registries(const json &root) {
 
     const auto &registry = root.at("contract_registry");
     const auto &schemas = registry.at("schema_registry");
-    require(schemas.size() == 15, "schema registry count drifted");
+    require(schemas.size() == 16, "schema registry count drifted");
     std::set<std::string> schema_ids;
     for (const auto &[internal_key, schema] : schemas.items()) {
         const auto id = schema.at("schema_type").get<std::string>();

--- a/test/cpp/test_residency_local_overlay.cpp
+++ b/test/cpp/test_residency_local_overlay.cpp
@@ -135,6 +135,50 @@ ProfilingInputEnvelopeDraft profiling_draft() {
     return draft;
 }
 
+ProfilingPhaseAttestationDraft phase_draft(
+    ProfilingPhase phase, std::string selector_sha256) {
+    ProfilingPhaseAttestationDraft draft;
+    draft.schema = supported_local_overlay_schema;
+    draft.phase = phase;
+    draft.deployment_id = digest('b');
+    draft.profiling_transaction_id = "profiling/1";
+    draft.selector_sha256 = std::move(selector_sha256);
+    draft.provider_id = "provider/system-residency";
+    draft.provider_revision_sha256 = digest('1');
+    draft.provenance_sha256 = digest('2');
+    draft.observation_contract_sha256 = digest('f');
+    draft.predictor_contract_sha256 = digest('0');
+    draft.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    draft.observation_generation =
+        phase == ProfilingPhase::Baseline
+            ? 1
+            : phase == ProfilingPhase::Workload ? 2 : 3;
+    draft.observed_at =
+        phase == ProfilingPhase::Baseline
+            ? "2026-08-23T10:00:00Z"
+            : phase == ProfilingPhase::Workload
+                ? "2026-08-23T10:01:00Z"
+                : "2026-08-23T10:02:00Z";
+    draft.fresh_until = "2026-08-23T10:05:00Z";
+    draft.source_skew_milliseconds = 10;
+    draft.max_source_skew_milliseconds = 1000;
+    draft.health = ProfilingObservationHealth::Valid;
+    draft.owner_coverage = ProfilingOwnerCoverage::Complete;
+    draft.observed_claims = claims(4096);
+    draft.attributed_claims = claims(4096);
+    draft.external_change_claims = claims(0);
+    draft.unattributed_claims = claims(0);
+    draft.uncertainty_claims = claims(512);
+    draft.safety_margin_claims = claims(256);
+    draft.lifecycle_state =
+        phase == ProfilingPhase::Baseline
+            ? ProfilingLifecycleState::BaselineQuiescent
+            : phase == ProfilingPhase::Workload
+                ? ProfilingLifecycleState::WorkloadComplete
+                : ProfilingLifecycleState::ReleaseVerified;
+    return draft;
+}
+
 LocalOverlayMethodIdentity method() {
     return LocalOverlayMethodIdentity{
         "method/exact-profile",
@@ -275,6 +319,10 @@ void require_generated_schema_compatibility(
     const std::filesystem::path &repository_root) {
     auto profile = seal_profiling_input(profiling_draft());
     require(profile.accepted(), "schema fixture profile was rejected");
+    auto phase = seal_profiling_phase_attestation(
+        phase_draft(ProfilingPhase::Workload,
+                    std::string(profile.candidate->selector_sha256())));
+    require(phase.accepted(), "schema fixture phase was rejected");
     auto overlay = seal_local_overlay(overlay_draft(*profile.candidate));
     require(overlay.accepted(), "schema fixture overlay was rejected");
     auto root = seal_overlay_activation_root(root_draft(*overlay.candidate));
@@ -284,18 +332,24 @@ void require_generated_schema_compatibility(
         repository_root / "docs/api/schemas/residency";
     const auto profile_schema = load_json(
         schema_directory / "profiling_input_envelope.schema.json");
+    const auto phase_schema = load_json(
+        schema_directory / "profiling_phase_attestation.schema.json");
     const auto overlay_schema = load_json(
         schema_directory / "deployment_local_overlay_object.schema.json");
     const auto root_schema = load_json(
         schema_directory / "overlay_activation_root.schema.json");
     const auto profile_document =
         json::parse(profile.candidate->canonical_bytes());
+    const auto phase_document =
+        json::parse(phase.candidate->canonical_bytes());
     const auto overlay_document =
         json::parse(overlay.candidate->canonical_bytes());
     const auto root_document = json::parse(root.candidate->canonical_bytes());
 
     require_document_matches_schema(profile_document, profile_schema,
                                     "profiling input");
+    require_document_matches_schema(phase_document, phase_schema,
+                                    "profiling phase attestation");
     require_document_matches_schema(overlay_document, overlay_schema,
                                     "local overlay");
     require_document_matches_schema(root_document, root_schema,
@@ -309,6 +363,10 @@ void require_generated_schema_compatibility(
         profile_schema.at("$defs").at("source_generations"),
         "profiling source generations");
     require_document_matches_schema(
+        phase_document.at("generations"),
+        phase_schema.at("$defs").at("source_generations"),
+        "profiling phase source generations");
+    require_document_matches_schema(
         overlay_document.at("selector"),
         overlay_schema.at("$defs").at("selector_identity"),
         "overlay selector");
@@ -321,6 +379,10 @@ void require_generated_schema_compatibility(
 void emit_schema_validation_corpus() {
     auto profile = seal_profiling_input(profiling_draft());
     require(profile.accepted(), "schema corpus profile was rejected");
+    auto phase = seal_profiling_phase_attestation(
+        phase_draft(ProfilingPhase::Workload,
+                    std::string(profile.candidate->selector_sha256())));
+    require(phase.accepted(), "schema corpus phase was rejected");
 
     auto maximum_confidence_draft = overlay_draft(*profile.candidate);
     maximum_confidence_draft.confidence_basis_points = 10000;
@@ -342,6 +404,8 @@ void emit_schema_validation_corpus() {
          {{"deployment_local_overlay_object",
            overlay.candidate->canonical_bytes()},
           {"overlay_activation_root", root.candidate->canonical_bytes()},
+          {"profiling_phase_attestation",
+           phase.candidate->canonical_bytes()},
           {"profiling_input_envelope",
            profile.candidate->canonical_bytes()}}},
         {"confidence_basis_points_boundary",
@@ -371,12 +435,113 @@ std::string without_positive_safety_margin(std::string bytes) {
 void require_public_shape() {
     static_assert(
         !std::is_default_constructible_v<ParsedProfilingInputEnvelope>);
+    static_assert(
+        !std::is_default_constructible_v<ParsedProfilingPhaseAttestation>);
     static_assert(!std::is_default_constructible_v<ParsedLocalOverlayObject>);
     static_assert(
         !std::is_default_constructible_v<ParsedOverlayActivationRoot>);
     static_assert(std::is_copy_constructible_v<ParsedProfilingInputEnvelope>);
+    static_assert(
+        std::is_copy_constructible_v<ParsedProfilingPhaseAttestation>);
     static_assert(std::is_copy_constructible_v<ParsedLocalOverlayObject>);
     static_assert(std::is_copy_constructible_v<ParsedOverlayActivationRoot>);
+}
+
+void require_phase_attestation_codec() {
+    auto profile = seal_profiling_input(profiling_draft());
+    require(profile.accepted(), "phase fixture profile was rejected");
+    auto sealed = seal_profiling_phase_attestation(phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256())));
+    require(sealed.accepted(), sealed.diagnostic);
+    require(sealed.candidate->phase() == ProfilingPhase::Workload &&
+                sealed.candidate->lifecycle_state() ==
+                    ProfilingLifecycleState::WorkloadComplete &&
+                sealed.candidate->selector_sha256() ==
+                    profile.candidate->selector_sha256() &&
+                sealed.candidate->provider_id() ==
+                    "provider/system-residency" &&
+                sealed.candidate->provenance_sha256() == digest('2') &&
+                sealed.candidate->observation_generation() == 2 &&
+                amount(sealed.candidate->uncertainty_claims(),
+                       ClaimFamily::ConsumableCapacity, "gpu/gtt") == 512 &&
+                amount(sealed.candidate->safety_margin_claims(),
+                       ClaimFamily::ConsumableCapacity, "gpu/gtt") == 256,
+            "phase attestation lost serialized evidence");
+
+    const auto canonical = std::string(sealed.candidate->canonical_bytes());
+    auto reparsed = parse_profiling_phase_attestation(canonical);
+    require(reparsed.accepted(), reparsed.diagnostic);
+    require(reparsed.candidate->canonical_bytes() == canonical &&
+                reparsed.candidate->checksum_sha256() ==
+                    sealed.candidate->checksum_sha256(),
+            "phase attestation round-trip changed canonical identity");
+    require_rejected(
+        parse_profiling_phase_attestation(with_unknown_root_field(canonical)),
+        OverlayContractStatus::UnknownField,
+        "phase attestation accepted an unknown field");
+
+    auto unhealthy = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    unhealthy.health = ProfilingObservationHealth::Unhealthy;
+    require_rejected(seal_profiling_phase_attestation(std::move(unhealthy)),
+                     OverlayContractStatus::InvalidValue,
+                     "phase attestation accepted unhealthy evidence");
+
+    auto contaminated = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    contaminated.external_change_claims = claims(1);
+    require_rejected(
+        seal_profiling_phase_attestation(std::move(contaminated)),
+        OverlayContractStatus::InvalidClaimClosure,
+        "phase attestation accepted external-demand contamination");
+
+    auto incomplete_owner = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    incomplete_owner.owner_coverage = ProfilingOwnerCoverage::Incomplete;
+    require_rejected(
+        seal_profiling_phase_attestation(std::move(incomplete_owner)),
+        OverlayContractStatus::IncompleteIdentity,
+        "phase attestation accepted incomplete owner coverage");
+
+    auto wrong_lifecycle = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    wrong_lifecycle.lifecycle_state = ProfilingLifecycleState::ReleaseVerified;
+    require_rejected(
+        seal_profiling_phase_attestation(std::move(wrong_lifecycle)),
+        OverlayContractStatus::InvalidValue,
+        "phase attestation accepted a mismatched lifecycle state");
+
+    auto excessive_skew = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    excessive_skew.source_skew_milliseconds = 1001;
+    require_rejected(
+        seal_profiling_phase_attestation(std::move(excessive_skew)),
+        OverlayContractStatus::InvalidValue,
+        "phase attestation accepted excessive source skew");
+
+    auto unattributed = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    unattributed.unattributed_claims = claims(1);
+    require_rejected(
+        seal_profiling_phase_attestation(std::move(unattributed)),
+        OverlayContractStatus::InvalidClaimClosure,
+        "phase attestation accepted unattributed demand");
+
+    auto no_margin = phase_draft(
+        ProfilingPhase::Workload,
+        std::string(profile.candidate->selector_sha256()));
+    no_margin.safety_margin_claims = claims(0);
+    require_rejected(
+        seal_profiling_phase_attestation(std::move(no_margin)),
+        OverlayContractStatus::InvalidClaimClosure,
+        "phase attestation accepted a zero safety margin");
 }
 
 void require_profiling_input_codec() {
@@ -433,6 +598,7 @@ void require_profiling_input_codec() {
     require_rejected(seal_profiling_input(std::move(unknown_claims)),
                      OverlayContractStatus::IncompleteClaimClosure,
                      "profiling input accepted an unknown claim family");
+
 }
 
 void require_overlay_object_codec() {
@@ -632,6 +798,7 @@ int main(int argc, char **argv) {
         argc == 2 ? std::filesystem::path(argv[1])
                   : std::filesystem::current_path();
     require_public_shape();
+    require_phase_attestation_codec();
     require_profiling_input_codec();
     require_overlay_object_codec();
     require_activation_root_codec();

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -526,20 +526,15 @@ void test_rejects_unsafe_evidence(TestState &state, Router &router) {
             value.workload_attestation = phase_bytes(std::move(phase));
         },
         ProfilingTransactionStatus::InvalidEvidence);
-    expect_rejected(
-        "external demand contamination is rejected",
-        [](auto &, auto &value) {
-            auto document = json::parse(value.workload_attestation);
-            auto &family = document["external_change_claims"][0];
-            family["completeness"] = "bounded";
-            family["entries"] = json::array({json{
-                {"amount", 1},
-                {"constraint_id", "gpu/gtt"},
-                {"unit", "bytes"},
-            }});
-            value.workload_attestation = document.dump();
-        },
-        ProfilingTransactionStatus::InvalidEvidence);
+
+    auto contaminated_phase = phase_draft(context(), ProfilingPhase::Workload);
+    contaminated_phase.external_change_claims = claims(4096);
+    auto contaminated =
+        seal_profiling_phase_attestation(std::move(contaminated_phase));
+    state.require(contaminated.status ==
+                      OverlayContractStatus::InvalidClaimClosure &&
+                      !contaminated.candidate.has_value(),
+                  "phase attestation accepted external-demand contamination");
 
     auto stale_options = options();
     stale_options.utc_now = [] { return "2026-08-23T10:06:00Z"; };

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -2,20 +2,45 @@
 #include "lemon/residency/profiling_transaction.h"
 #include "lemon/router.h"
 
+#include <mbedtls/md.h>
 #include <nlohmann/json.hpp>
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <functional>
 #include <future>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
+#include <type_traits>
 #include <utility>
 #include <vector>
+
+namespace lemon {
+
+struct ProfilingTransactionTestHook {
+    static std::unique_lock<std::mutex> lock_load_state(Router &router) {
+        return std::unique_lock<std::mutex>(router.load_mutex_);
+    }
+
+    static bool exclusive_pending(const Router &router) { return router.exclusive_pending(); }
+
+    static std::uint64_t exclusive_pending_generation(const Router &router) {
+        return router.exclusive_pending_generation_.load(std::memory_order_acquire);
+    }
+
+    static void cancel_pending(Router &router, std::uint64_t generation) {
+        router.cancel_exclusive_request(generation);
+    }
+};
+
+} // namespace lemon
 
 namespace {
 
@@ -25,18 +50,58 @@ using namespace lemon::residency;
 
 std::string digest(char value) { return std::string(64, value); }
 
-std::vector<ClaimFamilyClosure> claims() {
+std::string raw_sha256(std::string_view bytes) {
+    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    if (info == nullptr) throw std::runtime_error("SHA-256 is unavailable");
+    mbedtls_md_context_t context;
+    mbedtls_md_init(&context);
+    std::array<unsigned char, 32> output{};
+    const bool failed =
+        mbedtls_md_setup(&context, info, 0) != 0 || mbedtls_md_starts(&context) != 0 ||
+        mbedtls_md_update(&context, reinterpret_cast<const unsigned char *>(bytes.data()),
+                          bytes.size()) != 0 ||
+        mbedtls_md_finish(&context, output.data()) != 0;
+    mbedtls_md_free(&context);
+    if (failed) throw std::runtime_error("SHA-256 failed");
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(64);
+    for (const auto byte : output) {
+        result.push_back(hex[(byte >> 4) & 0x0f]);
+        result.push_back(hex[byte & 0x0f]);
+    }
+    return result;
+}
+
+static_assert(!std::is_default_constructible_v<AcceptedProfilingEvidence>);
+static_assert(std::is_nothrow_move_constructible_v<ParsedProfilingInputEnvelope>);
+static_assert(std::is_nothrow_move_constructible_v<ParsedProfilingPhaseAttestation>);
+static_assert(std::is_nothrow_move_constructible_v<AcceptedProfilingEvidence>);
+static_assert(std::is_same_v<decltype(std::declval<const AcceptedProfilingEvidence &>().input()),
+                             const ParsedProfilingInputEnvelope &>);
+
+std::vector<ClaimFamilyClosure> claims(std::uint64_t bytes = 0) {
+    std::vector<ClaimAmount> capacity;
+    if (bytes != 0) {
+        capacity.push_back(ClaimAmount{"gpu/gtt", ClaimUnit::Bytes, bytes});
+    }
     return {
+        ClaimFamilyClosure{ClaimFamily::ConsumableCapacity,
+                           bytes == 0 ? ClaimCompleteness::KnownZero : ClaimCompleteness::Bounded,
+                           std::move(capacity)},
+        ClaimFamilyClosure{ClaimFamily::SafetyFloor, ClaimCompleteness::KnownZero, {}},
+        ClaimFamilyClosure{ClaimFamily::CardinalityPool, ClaimCompleteness::KnownZero, {}},
         ClaimFamilyClosure{
-            ClaimFamily::ConsumableCapacity, ClaimCompleteness::KnownZero, {}},
-        ClaimFamilyClosure{
-            ClaimFamily::SafetyFloor, ClaimCompleteness::KnownZero, {}},
-        ClaimFamilyClosure{
-            ClaimFamily::CardinalityPool, ClaimCompleteness::KnownZero, {}},
-        ClaimFamilyClosure{ClaimFamily::CompatibilityExclusivity,
-                           ClaimCompleteness::NotApplicable,
-                           {}},
+            ClaimFamily::CompatibilityExclusivity, ClaimCompleteness::NotApplicable, {}},
     };
+}
+
+bool claim_sets_equal(const std::vector<ClaimFamilyClosure> &left,
+                      const std::vector<ClaimFamilyClosure> &right) {
+    const auto checked_left = check_claim_closure(left);
+    const auto checked_right = check_claim_closure(right);
+    return checked_left.accepted() && checked_right.accepted() &&
+           *checked_left.claims == *checked_right.claims;
 }
 
 LocalOverlaySelectorIdentity selector() {
@@ -56,52 +121,110 @@ LocalOverlaySelectorIdentity selector() {
     };
     catalog.recovery = "native_subprocess_tree";
     catalog.material_profiles = {
-        {"configuration_profile",
-         "profile-free-residency-estimation-v1-text-only"},
+        {"configuration_profile", "profile-free-residency-estimation-v1-text-only"},
         {"hardware_profile", "hatchery-gfx1151-shared-gtt-v1"},
         {"workload_profile", "hatchery-text-generation-campaign-v1"},
     };
 
     return LocalOverlaySelectorIdentity{
-        digest('1'), std::move(catalog), "model/alpha", digest('2'),
-        digest('3'), digest('4'),        digest('5'),   digest('6'),
-        digest('7'), digest('8'),        digest('9'),   digest('a')};
+        digest('1'), std::move(catalog), "model/alpha", digest('2'), digest('3'), digest('4'),
+        digest('5'), digest('6'),        digest('7'),   digest('8'), digest('9'), digest('a')};
 }
 
-ProfilingInputEnvelopeDraft draft(std::string transaction_id = "profile/1") {
+ProfilingTransactionContext context(std::string transaction_id = "profile/1") {
+    ProfilingTransactionContext result;
+    result.deployment_id = digest('b');
+    result.sequence = 1;
+    result.profiling_transaction_id = std::move(transaction_id);
+    result.selector = selector();
+    result.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    result.observation_contract_sha256 = digest('f');
+    result.predictor_contract_sha256 = digest('0');
+
     ProfilingInputEnvelopeDraft value;
     value.schema = supported_local_overlay_schema;
-    value.deployment_id = digest('b');
-    value.sequence = 1;
-    value.profiling_transaction_id = std::move(transaction_id);
-    value.selector = selector();
-    value.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    value.deployment_id = result.deployment_id;
+    value.sequence = result.sequence;
+    value.profiling_transaction_id = result.profiling_transaction_id;
+    value.selector = result.selector;
+    value.generations = result.generations;
     value.attributed_claims = claims();
     value.baseline_observation_sha256 = digest('c');
     value.workload_observation_sha256 = digest('d');
     value.release_observation_sha256 = digest('e');
-    value.observation_contract_sha256 = digest('f');
-    value.predictor_contract_sha256 = digest('0');
+    value.observation_contract_sha256 = result.observation_contract_sha256;
+    value.predictor_contract_sha256 = result.predictor_contract_sha256;
     value.observed_at = "2026-08-23T10:00:00Z";
     value.fresh_until = "2026-08-23T10:05:00Z";
     value.max_clock_skew_milliseconds = 1000;
     value.attribution_complete = true;
     value.external_demand_absent = true;
     value.lifecycle_release_verified = true;
-    return value;
+    auto sealed = seal_profiling_input(std::move(value));
+    if (!sealed.accepted()) {
+        throw std::runtime_error("profiling context selector could not seal");
+    }
+    result.selector_sha256 = sealed.candidate->selector_sha256();
+    return result;
 }
 
-ProfilingTransactionCapture capture(ProfilingInputEnvelopeDraft value) {
+ProfilingPhaseAttestationDraft phase_draft(const ProfilingTransactionContext &context,
+                                           ProfilingPhase phase) {
+    ProfilingPhaseAttestationDraft draft;
+    draft.schema = supported_local_overlay_schema;
+    draft.phase = phase;
+    draft.deployment_id = context.deployment_id;
+    draft.profiling_transaction_id = context.profiling_transaction_id;
+    draft.selector_sha256 = context.selector_sha256;
+    draft.provider_id = "provider/system-residency";
+    draft.provider_revision_sha256 = digest('1');
+    draft.provenance_sha256 = phase == ProfilingPhase::Baseline   ? digest('2')
+                              : phase == ProfilingPhase::Workload ? digest('3')
+                                                                  : digest('4');
+    draft.observation_contract_sha256 = context.observation_contract_sha256;
+    draft.predictor_contract_sha256 = context.predictor_contract_sha256;
+    draft.generations = context.generations;
+    draft.observation_generation = phase == ProfilingPhase::Baseline   ? 1
+                                   : phase == ProfilingPhase::Workload ? 2
+                                                                       : 3;
+    draft.observed_at = phase == ProfilingPhase::Baseline   ? "2026-08-23T10:00:00Z"
+                        : phase == ProfilingPhase::Workload ? "2026-08-23T10:01:00Z"
+                                                            : "2026-08-23T10:02:00Z";
+    draft.fresh_until = "2026-08-23T10:05:00Z";
+    draft.source_skew_milliseconds = 10;
+    draft.max_source_skew_milliseconds = 1000;
+    draft.health = ProfilingObservationHealth::Valid;
+    draft.owner_coverage = ProfilingOwnerCoverage::Complete;
+    draft.observed_claims = claims(4096);
+    draft.attributed_claims = claims(4096);
+    draft.external_change_claims = claims();
+    draft.unattributed_claims = claims();
+    draft.uncertainty_claims = claims(512);
+    draft.safety_margin_claims = claims(256);
+    draft.lifecycle_state =
+        phase == ProfilingPhase::Baseline   ? ProfilingLifecycleState::BaselineQuiescent
+        : phase == ProfilingPhase::Workload ? ProfilingLifecycleState::WorkloadComplete
+                                            : ProfilingLifecycleState::ReleaseVerified;
+    return draft;
+}
+
+std::string phase_bytes(ProfilingPhaseAttestationDraft draft) {
+    auto sealed = seal_profiling_phase_attestation(std::move(draft));
+    if (!sealed.accepted()) {
+        throw std::runtime_error("profiling phase fixture could not seal");
+    }
+    return std::string(sealed.candidate->canonical_bytes());
+}
+
+std::string phase_bytes(const ProfilingTransactionContext &context, ProfilingPhase phase) {
+    return phase_bytes(phase_draft(context, phase));
+}
+
+ProfilingTransactionCapture capture(const ProfilingTransactionContext &context) {
     ProfilingTransactionCapture result;
-    result.draft = std::move(value);
-    result.baseline_captured = true;
-    result.workload_captured = true;
-    result.release_captured = true;
-    result.identity_complete = true;
-    result.observations_fresh = true;
-    result.observations_healthy = true;
-    result.uncertainty_bound_verified = true;
-    result.safety_margin_verified = true;
+    result.baseline_attestation = phase_bytes(context, ProfilingPhase::Baseline);
+    result.workload_attestation = phase_bytes(context, ProfilingPhase::Workload);
+    result.release_attestation = phase_bytes(context, ProfilingPhase::Release);
     return result;
 }
 
@@ -109,6 +232,7 @@ ProfilingTransactionOptions options() {
     ProfilingTransactionOptions value;
     value.gate_timeout = 500ms;
     value.retry_interval = 1ms;
+    value.utc_now = [] { return "2026-08-23T10:03:00Z"; };
     return value;
 }
 
@@ -126,10 +250,8 @@ bool acquire_gate(Router &router) {
         auto request = router.request_exclusive();
         if (request.pending()) {
             const auto result = router.try_begin_exclusive(request);
-            if (result == Router::ExclusiveAcquireResult::Acquired)
-                return true;
-            if (result != Router::ExclusiveAcquireResult::Retry)
-                return false;
+            if (result == Router::ExclusiveAcquireResult::Acquired) return true;
+            if (result != Router::ExclusiveAcquireResult::Retry) return false;
         } else if (request.result() != Router::ExclusiveAcquireResult::Retry) {
             return false;
         }
@@ -155,6 +277,14 @@ struct TestState {
 
 void test_accepts_and_releases_gate(TestState &state, Router &router) {
     ProfilingTransaction transaction(router, options());
+    const auto transaction_context = context();
+    auto captured = capture(transaction_context);
+    auto workload_fixture = phase_draft(transaction_context, ProfilingPhase::Workload);
+    workload_fixture.fresh_until = "2026-08-23T10:04:00Z";
+    captured.workload_attestation = phase_bytes(std::move(workload_fixture));
+    auto release_fixture = phase_draft(transaction_context, ProfilingPhase::Release);
+    release_fixture.fresh_until = "2026-08-23T10:06:00Z";
+    captured.release_attestation = phase_bytes(std::move(release_fixture));
 
     std::promise<void> capture_entered;
     auto capture_entered_signal = capture_entered.get_future();
@@ -163,31 +293,27 @@ void test_accepts_and_releases_gate(TestState &state, Router &router) {
     std::promise<void> queued_started;
     std::future<Router::PreparedModelLoad> queued;
 
-    auto run = std::async(std::launch::async, [&] {
-        return transaction.run(
-            "profile/1",
-            [&](Router &gated_router, const ProfilingCancellationCheck &) {
-                capture_entered.set_value();
-                auto nested_request = gated_router.request_exclusive();
-                state.require(
-                    nested_request.result() ==
-                        Router::ExclusiveAcquireResult::InvalidOrder,
-                    "profiling capture cannot nest a Router exclusive gate");
-                release_capture_signal.wait();
-                return capture(draft());
-            });
+    auto run = std::async(std::launch::async, [&, transaction_context, captured] {
+        return transaction.run(transaction_context, [&,
+                                                     captured](Router &gated_router,
+                                                               const ProfilingTransactionContext &,
+                                                               const ProfilingCancellationCheck &) {
+            capture_entered.set_value();
+            auto nested_request = gated_router.request_exclusive();
+            state.require(nested_request.result() == Router::ExclusiveAcquireResult::InvalidOrder,
+                          "profiling capture cannot nest a Router exclusive gate");
+            release_capture_signal.wait();
+            return captured;
+        });
     });
 
-    state.require(capture_entered_signal.wait_for(1s) ==
-                      std::future_status::ready,
+    state.require(capture_entered_signal.wait_for(1s) == std::future_status::ready,
                   "profiling capture acquires the gate before queued work");
     queued = std::async(std::launch::async, [&] {
         queued_started.set_value();
-        return router.prepare_model_load("queued.model",
-                                         LoadPurpose::UserInference);
+        return router.prepare_model_load("queued.model", LoadPurpose::UserInference);
     });
-    state.require(queued_started.get_future().wait_for(1s) ==
-                      std::future_status::ready,
+    state.require(queued_started.get_future().wait_for(1s) == std::future_status::ready,
                   "ordinary model work starts while profiling owns the gate");
     state.require(queued.wait_for(50ms) == std::future_status::timeout,
                   "ordinary model work queues behind profiling gate");
@@ -195,8 +321,38 @@ void test_accepts_and_releases_gate(TestState &state, Router &router) {
     auto result = run.get();
 
     state.require(result.accepted(), "valid profiling capture is accepted");
-    state.require(result.candidate.has_value(),
-                  "accepted capture returns candidate");
+    state.require(result.evidence.has_value(), "accepted capture returns evidence");
+    if (result.evidence.has_value()) {
+        state.require(result.evidence->baseline().phase() == ProfilingPhase::Baseline,
+                      "accepted evidence retains baseline attestation");
+        state.require(result.evidence->workload().phase() == ProfilingPhase::Workload,
+                      "accepted evidence retains workload attestation");
+        state.require(result.evidence->release().phase() == ProfilingPhase::Release,
+                      "accepted evidence retains release attestation");
+        state.require(result.evidence->input().observed_at() ==
+                          result.evidence->release().observed_at(),
+                      "profiling input derives its observation time");
+        state.require(result.evidence->input().fresh_until() == "2026-08-23T10:04:00Z",
+                      "profiling input uses the shortest phase freshness");
+        state.require(result.evidence->input().max_clock_skew_milliseconds() == 1000,
+                      "profiling input retains the common skew contract");
+        state.require(claim_sets_equal(
+                          result.evidence->input().attributed_claims(),
+                          result.evidence->workload().attributed_claims()),
+                      "profiling input derives attributed workload claims");
+        state.require(
+            result.evidence->baseline().canonical_bytes() == captured.baseline_attestation &&
+                result.evidence->workload().canonical_bytes() == captured.workload_attestation &&
+                result.evidence->release().canonical_bytes() == captured.release_attestation,
+            "accepted evidence retains exact canonical phase bytes");
+        state.require(result.evidence->input().baseline_observation_sha256() ==
+                              raw_sha256(captured.baseline_attestation) &&
+                          result.evidence->input().workload_observation_sha256() ==
+                              raw_sha256(captured.workload_attestation) &&
+                          result.evidence->input().release_observation_sha256() ==
+                              raw_sha256(captured.release_attestation),
+                      "profiling input binds raw phase-attestation digests");
+    }
     try {
         auto preparation = queued.get();
         router.abandon_prepared_model_load(std::move(preparation));
@@ -205,98 +361,233 @@ void test_accepts_and_releases_gate(TestState &state, Router &router) {
     }
     const bool reacquired = acquire_gate(router);
     state.require(reacquired, "profiling transaction releases Router gate");
-    if (reacquired)
-        router.end_exclusive();
+    if (reacquired) router.end_exclusive();
 }
 
 void test_rejects_incomplete_capture(TestState &state, Router &router) {
     ProfilingTransaction transaction(router, options());
-    auto result = transaction.run(
-        "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
-            auto value = capture(draft());
-            value.release_captured = false;
-            return value;
-        });
-    state.require(result.status ==
-                      ProfilingTransactionStatus::EvidenceUnavailable,
+    auto result = transaction.run(context(), [&](Router &, const ProfilingTransactionContext &ctx,
+                                                 const ProfilingCancellationCheck &) {
+        auto value = capture(ctx);
+        value.release_attestation.clear();
+        return value;
+    });
+    state.require(result.status == ProfilingTransactionStatus::EvidenceUnavailable,
                   "incomplete lifecycle evidence returns inactive result");
-    state.require(!result.candidate.has_value(),
-                  "incomplete evidence has no candidate");
+    state.require(!result.evidence.has_value(), "incomplete capture has no evidence");
     const bool reacquired = acquire_gate(router);
     state.require(reacquired, "failed capture releases Router gate");
-    if (reacquired)
-        router.end_exclusive();
+    if (reacquired) router.end_exclusive();
 }
 
 void test_rejects_unsafe_evidence(TestState &state, Router &router) {
     const auto expect_rejected =
         [&](const char *label,
-            const std::function<void(ProfilingTransactionCapture &)> &mutate,
+            const std::function<void(ProfilingTransactionContext &, ProfilingTransactionCapture &)>
+                &mutate,
             ProfilingTransactionStatus status) {
             ProfilingTransaction transaction(router, options());
+            auto transaction_context = context();
+            auto captured = capture(transaction_context);
+            mutate(transaction_context, captured);
             auto result = transaction.run(
-                "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
-                    auto value = capture(draft());
-                    mutate(value);
-                    return value;
+                std::move(transaction_context),
+                [captured = std::move(captured)](Router &, const ProfilingTransactionContext &,
+                                                 const ProfilingCancellationCheck &) mutable {
+                    return std::move(captured);
                 });
             state.require(result.status == status, label);
-            state.require(!result.candidate.has_value(),
-                          "unsafe profiling evidence has no candidate");
-            state.require(
-                result.diagnostic.size() <= max_local_overlay_diagnostic_bytes,
-                "profiling diagnostics stay within the local bound");
+            state.require(!result.evidence.has_value(), "unsafe profiling result has no evidence");
+            state.require(result.diagnostic.size() <= max_local_overlay_diagnostic_bytes,
+                          "profiling diagnostics stay within the local bound");
             const bool reacquired = acquire_gate(router);
             state.require(reacquired, "unsafe evidence releases Router gate");
-            if (reacquired)
-                router.end_exclusive();
+            if (reacquired) router.end_exclusive();
         };
 
     expect_rejected(
-        "incomplete attribution returns inactive result",
-        [](auto &value) { value.draft->attribution_complete = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
+        "noncanonical workload evidence is rejected",
+        [](auto &, auto &value) { value.workload_attestation.push_back(' '); },
+        ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
-        "external demand returns inactive result",
-        [](auto &value) { value.draft->external_demand_absent = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
+        "phase slots cannot be interchanged",
+        [](auto &, auto &value) { value.workload_attestation = value.baseline_attestation; },
+        ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
-        "unverified release returns inactive result",
-        [](auto &value) { value.draft->lifecycle_release_verified = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
+        "selector attestation must match context",
+        [](auto &ctx, auto &) { ctx.selector_sha256 = digest('9'); },
+        ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
-        "stale observations return inactive result",
-        [](auto &value) { value.observations_fresh = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
+        "selector identity must match its attested digest",
+        [](auto &ctx, auto &) { ctx.selector.canonical_model_id = "model/other"; },
+        ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
-        "incomplete identity returns inactive result",
-        [](auto &value) { value.identity_complete = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
-    expect_rejected(
-        "unhealthy observations return inactive result",
-        [](auto &value) { value.observations_healthy = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
-    expect_rejected(
-        "unbounded uncertainty returns inactive result",
-        [](auto &value) { value.uncertainty_bound_verified = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
-    expect_rejected(
-        "unverified safety margin returns inactive result",
-        [](auto &value) { value.safety_margin_verified = false; },
-        ProfilingTransactionStatus::EvidenceUnavailable);
-    expect_rejected(
-        "unknown claim family returns invalid evidence",
-        [](auto &value) {
-            value.draft->attributed_claims.front().family =
-                static_cast<ClaimFamily>(99);
+        "deployment identity must remain stable",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            phase.deployment_id = digest('c');
+            value.workload_attestation = phase_bytes(std::move(phase));
         },
         ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
-        "capture transaction ID must match request",
-        [](auto &value) {
-            value.draft->profiling_transaction_id = "profile/other";
+        "source generations must remain stable",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            ++phase.generations.model;
+            value.workload_attestation = phase_bytes(std::move(phase));
         },
         ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "observation contract must remain stable",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            phase.observation_contract_sha256 = digest('a');
+            value.workload_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "predictor contract must remain stable",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            phase.predictor_contract_sha256 = digest('a');
+            value.workload_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "provider identity must remain stable",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            phase.provider_id = "provider/other";
+            value.workload_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "provider revision must remain stable",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            phase.provider_revision_sha256 = digest('8');
+            value.workload_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "observation generations must advance",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Release);
+            phase.observation_generation = 2;
+            value.release_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "observation times must advance",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Release);
+            phase.observed_at = "2026-08-23T10:01:00Z";
+            value.release_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "baseline attribution must cover observed claims",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Baseline);
+            phase.attributed_claims = claims();
+            value.baseline_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "release attribution must cover observed claims",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Release);
+            phase.attributed_claims = claims();
+            value.release_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "release claims must return within uncertainty",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Release);
+            phase.observed_claims = claims(8192);
+            phase.attributed_claims = claims(8192);
+            value.release_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "source skew contracts must agree",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Release);
+            phase.max_source_skew_milliseconds = 2000;
+            value.release_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "phase transaction ID must match context",
+        [](auto &ctx, auto &value) {
+            auto phase = phase_draft(ctx, ProfilingPhase::Workload);
+            phase.profiling_transaction_id = "profile/other";
+            value.workload_attestation = phase_bytes(std::move(phase));
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "external demand contamination is rejected",
+        [](auto &, auto &value) {
+            auto document = json::parse(value.workload_attestation);
+            auto &family = document["external_change_claims"][0];
+            family["completeness"] = "bounded";
+            family["entries"] = json::array({json{
+                {"amount", 1},
+                {"constraint_id", "gpu/gtt"},
+                {"unit", "bytes"},
+            }});
+            value.workload_attestation = document.dump();
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+
+    auto stale_options = options();
+    stale_options.utc_now = [] { return "2026-08-23T10:06:00Z"; };
+    ProfilingTransaction stale_transaction(router, stale_options);
+    auto stale_context = context();
+    auto stale = stale_transaction.run(
+        stale_context, [](Router &, const ProfilingTransactionContext &ctx,
+                          const ProfilingCancellationCheck &) { return capture(ctx); });
+    state.require(stale.status == ProfilingTransactionStatus::EvidenceUnavailable,
+                  "expired observations return inactive evidence");
+    state.require(!stale.evidence.has_value(), "expired observations return no evidence");
+
+    auto future_options = options();
+    future_options.utc_now = [] { return "2026-08-23T10:00:00Z"; };
+    ProfilingTransaction future_transaction(router, future_options);
+    auto future_context = context();
+    auto future = future_transaction.run(
+        future_context, [](Router &, const ProfilingTransactionContext &ctx,
+                           const ProfilingCancellationCheck &) { return capture(ctx); });
+    state.require(future.status == ProfilingTransactionStatus::EvidenceUnavailable,
+                  "future-dated observations return inactive evidence");
+    state.require(!future.evidence.has_value(), "future-dated observations return no evidence");
+
+    auto invalid_clock_options = options();
+    invalid_clock_options.utc_now = [] { return "2026-02-31T10:03:00Z"; };
+    ProfilingTransaction invalid_clock_transaction(router, invalid_clock_options);
+    auto invalid_clock_context = context();
+    auto invalid_clock = invalid_clock_transaction.run(
+        invalid_clock_context, [](Router &, const ProfilingTransactionContext &ctx,
+                                  const ProfilingCancellationCheck &) { return capture(ctx); });
+    state.require(invalid_clock.status == ProfilingTransactionStatus::Failed,
+                  "invalid acceptance clock fails closed");
+    state.require(!invalid_clock.evidence.has_value(),
+                  "invalid acceptance clock returns no evidence");
+
+    auto throwing_clock_options = options();
+    throwing_clock_options.utc_now = []() -> std::string {
+        throw std::runtime_error("clock failed");
+    };
+    ProfilingTransaction throwing_clock_transaction(router, throwing_clock_options);
+    auto throwing_clock_context = context();
+    auto throwing_clock = throwing_clock_transaction.run(
+        throwing_clock_context, [](Router &, const ProfilingTransactionContext &ctx,
+                                   const ProfilingCancellationCheck &) { return capture(ctx); });
+    state.require(throwing_clock.status == ProfilingTransactionStatus::Failed,
+                  "throwing acceptance clock fails closed");
+    state.require(!throwing_clock.evidence.has_value(),
+                  "throwing acceptance clock returns no evidence");
 }
 
 void test_rejects_concurrent_run(TestState &state, Router &router) {
@@ -305,31 +596,25 @@ void test_rejects_concurrent_run(TestState &state, Router &router) {
     std::promise<void> release;
     auto release_signal = release.get_future().share();
     auto first = std::async(std::launch::async, [&] {
-        return transaction.run(
-            "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
-                state.require(
-                    transaction.running(),
-                    "transaction marks itself running during capture");
-                state.require(!transaction.wait_for_idle(),
-                              "owner thread does not wait on itself");
-                entered.set_value();
-                release_signal.wait();
-                return capture(draft());
-            });
+        return transaction.run(context(), [&](Router &, const ProfilingTransactionContext &ctx,
+                                              const ProfilingCancellationCheck &) {
+            state.require(transaction.running(), "transaction marks itself running during capture");
+            state.require(!transaction.wait_for_idle(), "owner thread does not wait on itself");
+            entered.set_value();
+            release_signal.wait();
+            return capture(ctx);
+        });
     });
     auto entered_signal = entered.get_future();
     state.require(entered_signal.wait_for(1s) == std::future_status::ready,
                   "first profiling transaction enters capture");
-    auto second = transaction.run(
-        "profile/2", [&](Router &, const ProfilingCancellationCheck &) {
-            return capture(draft("profile/2"));
-        });
-    state.require(
-        second.status == ProfilingTransactionStatus::AlreadyRunning,
-        "a second profiling transaction is rejected deterministically");
+    auto second = transaction.run(context("profile/2"),
+                                  [&](Router &, const ProfilingTransactionContext &ctx,
+                                      const ProfilingCancellationCheck &) { return capture(ctx); });
+    state.require(second.status == ProfilingTransactionStatus::AlreadyRunning,
+                  "a second profiling transaction is rejected deterministically");
     release.set_value();
-    state.require(first.get().accepted(),
-                  "the first profiling transaction completes");
+    state.require(first.get().accepted(), "the first profiling transaction completes");
     state.require(!transaction.running(), "transaction clears running state");
 }
 
@@ -347,34 +632,30 @@ void test_latched_abort_pulses(TestState &state, Router &router) {
         auto observed_signal = observed.get_future();
         auto run = std::async(std::launch::async, [&] {
             return transaction.run(
-                "profile/1",
-                [&](Router &, const ProfilingCancellationCheck &should_abort) {
+                context(),
+                [&](Router &, const ProfilingTransactionContext &ctx,
+                    const ProfilingCancellationCheck &should_abort) {
                     entered.set_value();
                     while (!should_abort() && !stop_capture.load())
                         std::this_thread::sleep_for(1ms);
                     observed.set_value();
                     release_signal.wait();
-                    return capture(draft());
+                    return capture(ctx);
                 },
                 &cancel);
         });
-        const bool entered_ready =
-            entered_signal.wait_for(1s) == std::future_status::ready;
+        const bool entered_ready = entered_signal.wait_for(1s) == std::future_status::ready;
         state.require(entered_ready, "cancel pulse capture starts");
         cancel.store(true);
-        const bool observed_ready =
-            observed_signal.wait_for(1s) == std::future_status::ready;
+        const bool observed_ready = observed_signal.wait_for(1s) == std::future_status::ready;
         state.require(observed_ready, "capture observes cancellation pulse");
-        if (!observed_ready)
-            stop_capture.store(true);
-        if (observed_ready)
-            cancel.store(false);
+        if (!observed_ready) stop_capture.store(true);
+        if (observed_ready) cancel.store(false);
         release.set_value();
         auto result = run.get();
         state.require(result.status == ProfilingTransactionStatus::Cancelled,
                       "latched cancellation survives source reset");
-        state.require(!result.candidate.has_value(),
-                      "latched cancellation has no candidate");
+        state.require(!result.evidence.has_value(), "latched cancellation has no evidence");
     }
 
     {
@@ -388,34 +669,30 @@ void test_latched_abort_pulses(TestState &state, Router &router) {
         auto observed_signal = observed.get_future();
         auto run = std::async(std::launch::async, [&] {
             return transaction.run(
-                "profile/1",
-                [&](Router &, const ProfilingCancellationCheck &should_abort) {
+                context(),
+                [&](Router &, const ProfilingTransactionContext &ctx,
+                    const ProfilingCancellationCheck &should_abort) {
                     entered.set_value();
                     while (!should_abort() && !stop_capture.load())
                         std::this_thread::sleep_for(1ms);
                     observed.set_value();
                     release_signal.wait();
-                    return capture(draft());
+                    return capture(ctx);
                 },
                 nullptr, [&] { return restart.load(); });
         });
-        const bool entered_ready =
-            entered_signal.wait_for(1s) == std::future_status::ready;
+        const bool entered_ready = entered_signal.wait_for(1s) == std::future_status::ready;
         state.require(entered_ready, "restart pulse capture starts");
         restart.store(true);
-        const bool observed_ready =
-            observed_signal.wait_for(1s) == std::future_status::ready;
+        const bool observed_ready = observed_signal.wait_for(1s) == std::future_status::ready;
         state.require(observed_ready, "capture observes restart pulse");
-        if (!observed_ready)
-            stop_capture.store(true);
-        if (observed_ready)
-            restart.store(false);
+        if (!observed_ready) stop_capture.store(true);
+        if (observed_ready) restart.store(false);
         release.set_value();
         auto result = run.get();
         state.require(result.status == ProfilingTransactionStatus::Restarted,
                       "latched restart survives source reset");
-        state.require(!result.candidate.has_value(),
-                      "latched restart has no candidate");
+        state.require(!result.evidence.has_value(), "latched restart has no evidence");
     }
 
     std::promise<void> entered;
@@ -423,23 +700,21 @@ void test_latched_abort_pulses(TestState &state, Router &router) {
     auto release_signal = release.get_future().share();
     auto entered_signal = entered.get_future();
     auto run = std::async(std::launch::async, [&] {
-        return transaction.run(
-            "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
-                entered.set_value();
-                release_signal.wait();
-                return capture(draft());
-            });
+        return transaction.run(context(), [&](Router &, const ProfilingTransactionContext &ctx,
+                                              const ProfilingCancellationCheck &) {
+            entered.set_value();
+            release_signal.wait();
+            return capture(ctx);
+        });
     });
-    const bool entered_ready =
-        entered_signal.wait_for(1s) == std::future_status::ready;
+    const bool entered_ready = entered_signal.wait_for(1s) == std::future_status::ready;
     state.require(entered_ready, "direct lifecycle abort capture starts");
     transaction.request_abort(ProfilingAbortReason::Restarted);
     release.set_value();
     auto result = run.get();
     state.require(result.status == ProfilingTransactionStatus::Restarted,
                   "server lifecycle abort is sticky");
-    state.require(!result.candidate.has_value(),
-                  "server lifecycle abort has no candidate");
+    state.require(!result.evidence.has_value(), "server lifecycle abort has no evidence");
 
     std::promise<void> precedence_entered;
     std::promise<void> precedence_poll;
@@ -452,43 +727,38 @@ void test_latched_abort_pulses(TestState &state, Router &router) {
     std::atomic<bool> precedence_cancel_observed{false};
     auto precedence_run = std::async(std::launch::async, [&] {
         return transaction.run(
-            "profile/1",
-            [&](Router &, const ProfilingCancellationCheck &should_abort) {
+            context(),
+            [&](Router &, const ProfilingTransactionContext &ctx,
+                const ProfilingCancellationCheck &should_abort) {
                 precedence_entered.set_value();
                 precedence_poll_signal.wait();
-                if (should_abort())
-                    precedence_cancel_observed.store(true);
+                if (should_abort()) precedence_cancel_observed.store(true);
                 precedence_observed.set_value();
                 precedence_signal.wait();
-                return capture(draft());
+                return capture(ctx);
             },
             &precedence_cancel);
     });
     auto precedence_entered_signal = precedence_entered.get_future();
-    state.require(precedence_entered_signal.wait_for(1s) ==
-                      std::future_status::ready,
+    state.require(precedence_entered_signal.wait_for(1s) == std::future_status::ready,
                   "abort precedence capture starts");
     precedence_cancel.store(true);
     precedence_poll.set_value();
     const bool cancellation_observed =
         precedence_observed_signal.wait_for(1s) == std::future_status::ready;
-    state.require(cancellation_observed,
-                  "precedence capture observes cancellation before restart");
+    state.require(cancellation_observed, "precedence capture observes cancellation before restart");
     state.require(precedence_cancel_observed.load(),
                   "precedence capture latches cancellation before restart");
     transaction.request_abort(ProfilingAbortReason::Restarted);
     precedence_release.set_value();
     auto precedence_result = precedence_run.get();
-    state.require(precedence_result.status ==
-                      ProfilingTransactionStatus::Restarted,
+    state.require(precedence_result.status == ProfilingTransactionStatus::Restarted,
                   "restart supersedes a latched cancellation");
-    state.require(!precedence_result.candidate.has_value(),
-                  "restart precedence has no candidate");
+    state.require(!precedence_result.evidence.has_value(), "restart precedence has no evidence");
 
     const bool reacquired = acquire_gate(router);
     state.require(reacquired, "latched abort releases Router gate");
-    if (reacquired)
-        router.end_exclusive();
+    if (reacquired) router.end_exclusive();
 }
 
 void test_cancellation_and_restart(TestState &state, Router &router) {
@@ -510,46 +780,48 @@ void test_cancellation_and_restart(TestState &state, Router &router) {
         }
     });
     auto timeout_entered_signal = timeout_gate_entered.get_future();
-    state.require(timeout_entered_signal.wait_for(1s) ==
-                      std::future_status::ready,
+    state.require(timeout_entered_signal.wait_for(1s) == std::future_status::ready,
                   "timeout test owns Router gate");
-    auto timeout_result = timeout_transaction.run(
-        "profile/1", [&](Router &, const ProfilingCancellationCheck &) {
+    auto timeout_result =
+        timeout_transaction.run(context(), [&](Router &, const ProfilingTransactionContext &ctx,
+                                               const ProfilingCancellationCheck &) {
             state.require(false, "timed-out transaction must not capture");
-            return capture(draft());
+            return capture(ctx);
         });
-    state.require(timeout_result.status ==
-                      ProfilingTransactionStatus::GateTimeout,
+    state.require(timeout_result.status == ProfilingTransactionStatus::GateTimeout,
                   "gate acquisition is bounded");
-    state.require(!timeout_result.candidate.has_value(),
-                  "gate timeout has no candidate");
+    state.require(!timeout_result.evidence.has_value(), "gate timeout has no evidence");
+    {
+        auto still_held = router.request_exclusive();
+        state.require(!still_held.pending() &&
+                          still_held.result() == Router::ExclusiveAcquireResult::Retry,
+                      "profiling timeout does not release another owner's gate");
+    }
     timeout_gate_release.set_value();
     timeout_holder.get();
 
     ProfilingTransaction transaction(router, options());
     const bool gate_acquired = acquire_gate(router);
     state.require(gate_acquired, "test owns Router gate");
-    if (!gate_acquired)
-        return;
+    if (!gate_acquired) return;
 
     std::atomic<bool> cancelled{false};
     auto waiting = std::async(std::launch::async, [&] {
         return transaction.run(
-            "profile/1",
-            [&](Router &, const ProfilingCancellationCheck &) {
+            context(),
+            [&](Router &, const ProfilingTransactionContext &ctx,
+                const ProfilingCancellationCheck &) {
                 state.require(false, "cancelled transaction must not capture");
-                return capture(draft());
+                return capture(ctx);
             },
             &cancelled);
     });
     std::this_thread::sleep_for(50ms);
     cancelled.store(true);
     auto cancelled_result = waiting.get();
-    state.require(cancelled_result.status ==
-                      ProfilingTransactionStatus::Cancelled,
+    state.require(cancelled_result.status == ProfilingTransactionStatus::Cancelled,
                   "cancellation aborts a transaction waiting for the gate");
-    state.require(!cancelled_result.candidate.has_value(),
-                  "gate cancellation has no candidate");
+    state.require(!cancelled_result.evidence.has_value(), "gate cancellation has no evidence");
     router.end_exclusive();
 
     std::promise<void> entered;
@@ -559,27 +831,26 @@ void test_cancellation_and_restart(TestState &state, Router &router) {
     auto entered_signal = entered.get_future();
     auto active_cancel = std::async(std::launch::async, [&] {
         return transaction.run(
-            "profile/1",
-            [&](Router &, const ProfilingCancellationCheck &should_abort) {
+            context(),
+            [&](Router &, const ProfilingTransactionContext &ctx,
+                const ProfilingCancellationCheck &should_abort) {
                 entered.set_value();
                 while (!should_abort() && !capture_cancelled.load())
                     std::this_thread::sleep_for(1ms);
                 release_signal.wait();
-                return capture(draft());
+                return capture(ctx);
             },
             &capture_cancelled);
     });
-    const bool entered_ready =
-        entered_signal.wait_for(1s) == std::future_status::ready;
+    const bool entered_ready = entered_signal.wait_for(1s) == std::future_status::ready;
     state.require(entered_ready, "active cancellation capture starts");
     capture_cancelled.store(true);
     release.set_value();
     auto active_cancel_result = active_cancel.get();
-    state.require(active_cancel_result.status ==
-                      ProfilingTransactionStatus::Cancelled,
+    state.require(active_cancel_result.status == ProfilingTransactionStatus::Cancelled,
                   "cancellation during capture releases Router gate");
-    state.require(!active_cancel_result.candidate.has_value(),
-                  "capture cancellation has no candidate");
+    state.require(!active_cancel_result.evidence.has_value(),
+                  "capture cancellation has no evidence");
 
     std::promise<void> restart_entered;
     std::promise<void> restart_release;
@@ -589,13 +860,14 @@ void test_cancellation_and_restart(TestState &state, Router &router) {
     auto restart_entered_signal = restart_entered.get_future();
     auto active_restart = std::async(std::launch::async, [&] {
         return transaction.run(
-            "profile/1",
-            [&](Router &, const ProfilingCancellationCheck &should_abort) {
+            context(),
+            [&](Router &, const ProfilingTransactionContext &ctx,
+                const ProfilingCancellationCheck &should_abort) {
                 restart_entered.set_value();
                 while (!should_abort() && !stop_restart_capture.load())
                     std::this_thread::sleep_for(1ms);
                 restart_signal.wait();
-                return capture(draft());
+                return capture(ctx);
             },
             nullptr, [&] { return restarting.load(); });
     });
@@ -603,43 +875,187 @@ void test_cancellation_and_restart(TestState &state, Router &router) {
         restart_entered_signal.wait_for(1s) == std::future_status::ready;
     state.require(restart_entered_ready, "active restart capture starts");
     restarting.store(true);
-    if (!restart_entered_ready)
-        stop_restart_capture.store(true);
+    if (!restart_entered_ready) stop_restart_capture.store(true);
     restart_release.set_value();
     auto active_restart_result = active_restart.get();
-    state.require(active_restart_result.status ==
-                      ProfilingTransactionStatus::Restarted,
+    state.require(active_restart_result.status == ProfilingTransactionStatus::Restarted,
                   "restart during capture releases Router gate");
-    state.require(!active_restart_result.candidate.has_value(),
-                  "capture restart has no candidate");
+    state.require(!active_restart_result.evidence.has_value(), "capture restart has no evidence");
 
     auto restarted = transaction.run(
-        "profile/1",
-        [&](Router &, const ProfilingCancellationCheck &) {
+        context(),
+        [&](Router &, const ProfilingTransactionContext &ctx, const ProfilingCancellationCheck &) {
             state.require(false, "restart abort must not capture");
-            return capture(draft());
+            return capture(ctx);
         },
         nullptr, [] { return true; });
     state.require(restarted.status == ProfilingTransactionStatus::Restarted,
                   "restart aborts a transaction before gate acquisition");
 }
 
+void test_gate_timeout_bounds_router_lock(TestState &state, Router &router) {
+    auto timeout_options = options();
+    timeout_options.gate_timeout = 100ms;
+    timeout_options.retry_interval = 1ms;
+    ProfilingTransaction transaction(router, timeout_options);
+    auto lock = lemon::ProfilingTransactionTestHook::lock_load_state(router);
+    std::promise<void> started;
+    auto started_signal = started.get_future();
+    auto run = std::async(std::launch::async, [&] {
+        started.set_value();
+        return transaction.run(context("profile/lock-timeout"),
+                               [](Router &, const ProfilingTransactionContext &ctx,
+                                  const ProfilingCancellationCheck &) { return capture(ctx); });
+    });
+    state.require(started_signal.wait_for(1s) == std::future_status::ready,
+                  "Router lock timeout worker did not start");
+    const bool timed_out_while_locked = run.wait_for(1s) == std::future_status::ready;
+    state.require(timed_out_while_locked, "Router lock contention exceeded the gate deadline");
+    if (timed_out_while_locked) {
+        lock.unlock();
+        const auto result = run.get();
+        state.require(result.status == ProfilingTransactionStatus::GateTimeout,
+                      "Router lock contention did not return GateTimeout");
+        state.require(!result.evidence.has_value(), "Router lock timeout returned evidence");
+    } else {
+        transaction.request_abort(ProfilingAbortReason::Cancelled);
+        lock.unlock();
+        const auto result = run.get();
+        (void)result;
+    }
+}
+
+void test_gate_timeout_clears_pending_intent(TestState &state, Router &router) {
+    auto existing_preparation =
+        router.prepare_model_load("profile.deadline-existing", LoadPurpose::UserInference);
+
+    auto timeout_options = options();
+    timeout_options.gate_timeout = 2s;
+    timeout_options.retry_interval = 1ms;
+    ProfilingTransaction transaction(router, timeout_options);
+    std::promise<void> started;
+    auto started_signal = started.get_future();
+    auto run = std::async(std::launch::async, [&] {
+        started.set_value();
+        return transaction.run(context("profile/pending-timeout"),
+                               [](Router &, const ProfilingTransactionContext &ctx,
+                                  const ProfilingCancellationCheck &) { return capture(ctx); });
+    });
+    state.require(started_signal.wait_for(1s) == std::future_status::ready,
+                  "pending timeout worker did not start");
+
+    const auto pending_deadline = std::chrono::steady_clock::now() + 1s;
+    while (!lemon::ProfilingTransactionTestHook::exclusive_pending(router) &&
+           std::chrono::steady_clock::now() < pending_deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    const bool pending = lemon::ProfilingTransactionTestHook::exclusive_pending(router);
+    state.require(pending, "profiling request did not publish writer intent");
+    if (!pending) {
+        transaction.request_abort(ProfilingAbortReason::Cancelled);
+        const auto result = run.get();
+        (void)result;
+        router.abandon_prepared_model_load(std::move(existing_preparation));
+        return;
+    }
+
+    auto lock = lemon::ProfilingTransactionTestHook::lock_load_state(router);
+    const bool pending_while_locked =
+        lemon::ProfilingTransactionTestHook::exclusive_pending(router);
+    state.require(pending_while_locked, "profiling writer intent cleared before lock-contention "
+                                        "proof");
+    if (!pending_while_locked) {
+        transaction.request_abort(ProfilingAbortReason::Cancelled);
+        lock.unlock();
+        const auto result = run.get();
+        (void)result;
+        router.abandon_prepared_model_load(std::move(existing_preparation));
+        return;
+    }
+    state.require(run.wait_for(0ms) == std::future_status::timeout,
+                  "profiling transaction finished before its deadline");
+
+    std::promise<void> queued_started;
+    auto queued_started_signal = queued_started.get_future();
+    auto queued_preparation = std::async(std::launch::async, [&] {
+        queued_started.set_value();
+        return router.prepare_model_load("profile.deadline-queued", LoadPurpose::UserInference);
+    });
+    state.require(queued_started_signal.wait_for(1s) == std::future_status::ready,
+                  "queued model preparation did not start");
+    const bool timed_out_while_locked = run.wait_for(3s) == std::future_status::ready;
+    state.require(timed_out_while_locked,
+                  "pending profiling timeout waited for Router lock cleanup");
+    state.require(!lemon::ProfilingTransactionTestHook::exclusive_pending(router),
+                  "timed-out profiling request retained writer intent");
+    if (timed_out_while_locked) {
+        lock.unlock();
+        const auto result = run.get();
+        state.require(result.status == ProfilingTransactionStatus::GateTimeout,
+                      "pending writer intent did not return GateTimeout");
+        state.require(!result.evidence.has_value(), "pending writer timeout returned evidence");
+    } else {
+        transaction.request_abort(ProfilingAbortReason::Cancelled);
+        lock.unlock();
+        const auto result = run.get();
+        (void)result;
+    }
+
+    state.require(queued_preparation.wait_for(1s) == std::future_status::ready,
+                  "timed-out writer intent stranded queued model work");
+    if (queued_preparation.wait_for(0ms) == std::future_status::ready) {
+        auto queued = queued_preparation.get();
+        router.abandon_prepared_model_load(std::move(queued));
+    }
+    router.abandon_prepared_model_load(std::move(existing_preparation));
+}
+
+void test_cross_router_request_ownership(TestState &state, Router &router, RuntimeConfig &config) {
+    Router other_router(&config, nullptr, nullptr);
+    const auto deadline = std::chrono::steady_clock::now() + 250ms;
+    auto first_request = router.request_exclusive_until(deadline);
+    auto second_request = other_router.request_exclusive();
+    const auto first_generation =
+        lemon::ProfilingTransactionTestHook::exclusive_pending_generation(router);
+    const auto second_generation =
+        lemon::ProfilingTransactionTestHook::exclusive_pending_generation(other_router);
+    state.require(first_request.pending() && second_request.pending(),
+                  "both Routers publish independent writer generations");
+    state.require(first_generation == second_generation,
+                  "both Routers reproduce the same pending generation");
+    std::this_thread::sleep_until(deadline + 20ms);
+
+    const auto wrong_router_result = other_router.try_begin_exclusive(first_request);
+    state.require(wrong_router_result == Router::ExclusiveAcquireResult::Retry,
+                  "a foreign Router request is rejected without mutation");
+    state.require(first_request.pending(), "foreign Router did not consume the original request");
+
+    const auto second_result = other_router.try_begin_exclusive(second_request);
+    state.require(second_result == Router::ExclusiveAcquireResult::Acquired,
+                  "foreign expiry did not clear the other Router generation");
+    if (second_result == Router::ExclusiveAcquireResult::Acquired) other_router.end_exclusive();
+
+    const auto first_result = router.try_begin_exclusive(first_request);
+    state.require(first_result == Router::ExclusiveAcquireResult::DeadlineExceeded,
+                  "the original Router expires its own request");
+    lemon::ProfilingTransactionTestHook::cancel_pending(router, first_generation);
+    lemon::ProfilingTransactionTestHook::cancel_pending(other_router, second_generation);
+}
+
 void test_exception_releases_gate(TestState &state, Router &router) {
     ProfilingTransaction transaction(router, options());
-    auto result = transaction.run(
-        "profile/1",
-        [&](Router &,
-            const ProfilingCancellationCheck &) -> ProfilingTransactionCapture {
-            throw std::runtime_error("capture failed");
-        });
+    auto result =
+        transaction.run(context(),
+                        [&](Router &, const ProfilingTransactionContext &,
+                            const ProfilingCancellationCheck &) -> ProfilingTransactionCapture {
+                            throw std::runtime_error("capture failed");
+                        });
     state.require(result.status == ProfilingTransactionStatus::Failed,
                   "capture exception returns failed result");
-    state.require(!result.candidate.has_value(),
-                  "capture exception has no candidate");
+    state.require(!result.evidence.has_value(), "capture exception has no evidence");
     const bool reacquired = acquire_gate(router);
     state.require(reacquired, "capture exception releases Router gate");
-    if (reacquired)
-        router.end_exclusive();
+    if (reacquired) router.end_exclusive();
 }
 
 } // namespace
@@ -650,12 +1066,15 @@ int main() {
     RuntimeConfig::set_global(&config);
     {
         Router router(&config, nullptr, nullptr);
+        test_cross_router_request_ownership(state, router, config);
         test_accepts_and_releases_gate(state, router);
         test_rejects_incomplete_capture(state, router);
         test_rejects_unsafe_evidence(state, router);
         test_rejects_concurrent_run(state, router);
         test_latched_abort_pulses(state, router);
         test_cancellation_and_restart(state, router);
+        test_gate_timeout_bounds_router_lock(state, router);
+        test_gate_timeout_clears_pending_intent(state, router);
         test_exception_releases_gate(state, router);
     }
     RuntimeConfig::set_global(nullptr);

--- a/test/cpp/test_router_model_lifecycle.cpp
+++ b/test/cpp/test_router_model_lifecycle.cpp
@@ -105,7 +105,7 @@ struct RouterModelLifecycleTestHook {
 
     static bool exclusive_request_pending(Router& router) {
         std::lock_guard<std::mutex> lock(router.load_mutex_);
-        return router.exclusive_pending_;
+        return router.exclusive_pending();
     }
 
     static void seed_watchdog_state(

--- a/test/residency/contract/generated/catalog.json
+++ b/test/residency/contract/generated/catalog.json
@@ -4982,6 +4982,163 @@
           "minor": 0
         }
       },
+      "profiling_phase_attestation": {
+        "conditionals": [
+          {
+            "assert": {
+              "field": "observed_at",
+              "less_than_path": "fresh_until"
+            }
+          },
+          {
+            "assert": {
+              "field": "source_skew_milliseconds",
+              "less_than_or_equal_path": "max_source_skew_milliseconds"
+            }
+          },
+          {
+            "if": {
+              "equals": "baseline",
+              "field": "phase"
+            },
+            "require_values": {
+              "lifecycle_state": "baseline_quiescent"
+            }
+          },
+          {
+            "if": {
+              "equals": "workload",
+              "field": "phase"
+            },
+            "require_values": {
+              "lifecycle_state": "workload_complete"
+            }
+          },
+          {
+            "if": {
+              "equals": "release",
+              "field": "phase"
+            },
+            "require_values": {
+              "lifecycle_state": "release_verified"
+            }
+          }
+        ],
+        "fields": {
+          "attributed_claims": {
+            "required": true,
+            "type": "local_overlay_claim_closure"
+          },
+          "checksum_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "deployment_id": {
+            "required": true,
+            "type": "local_overlay_deployment_identity"
+          },
+          "external_change_claims": {
+            "required": true,
+            "type": "local_overlay_zero_claim_closure"
+          },
+          "fresh_until": {
+            "required": true,
+            "type": "local_overlay_expiry"
+          },
+          "generations": {
+            "required": true,
+            "type": "local_overlay_source_generations"
+          },
+          "health": {
+            "required": true,
+            "type": "local_overlay_profiling_health"
+          },
+          "lifecycle_state": {
+            "required": true,
+            "type": "local_overlay_profiling_lifecycle_state"
+          },
+          "max_source_skew_milliseconds": {
+            "required": true,
+            "type": "local_overlay_positive_uint64"
+          },
+          "observation_contract_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "observation_generation": {
+            "required": true,
+            "type": "local_overlay_positive_uint64"
+          },
+          "observed_at": {
+            "required": true,
+            "type": "local_overlay_timestamp"
+          },
+          "observed_claims": {
+            "required": true,
+            "type": "local_overlay_claim_closure"
+          },
+          "owner_coverage": {
+            "required": true,
+            "type": "local_overlay_profiling_owner_coverage"
+          },
+          "phase": {
+            "required": true,
+            "type": "local_overlay_profiling_phase"
+          },
+          "predictor_contract_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "profiling_transaction_id": {
+            "max_bytes": 128,
+            "required": true,
+            "type": "opaque"
+          },
+          "provenance_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "provider_id": {
+            "max_bytes": 128,
+            "required": true,
+            "type": "opaque"
+          },
+          "provider_revision_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "safety_margin_claims": {
+            "required": true,
+            "type": "local_overlay_safety_margin_claim_closure"
+          },
+          "schema": {
+            "required": true,
+            "type": "local_overlay_schema_version"
+          },
+          "selector_sha256": {
+            "required": true,
+            "type": "sha256"
+          },
+          "source_skew_milliseconds": {
+            "required": true,
+            "type": "local_overlay_nonnegative_uint64"
+          },
+          "unattributed_claims": {
+            "required": true,
+            "type": "local_overlay_zero_claim_closure"
+          },
+          "uncertainty_claims": {
+            "required": true,
+            "type": "local_overlay_claim_closure"
+          }
+        },
+        "output": "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
+        "schema_type": "residency.profiling_phase_attestation/1.0",
+        "version": {
+          "major": 1,
+          "minor": 0
+        }
+      },
       "reason": {
         "conditionals": [
           {
@@ -7267,6 +7424,6 @@
     }
   ],
   "schema": "residency.profiles/1.0",
-  "selection_registry_sha256": "bd040081cc1286047433bfe14ac6556636620176fd02c2a2c934561ac7e9ed28",
+  "selection_registry_sha256": "9dbdfad20160c82f3905493d2d5c4bdcf40f2249b25ad919c57fd4462a51b4b7",
   "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
 }

--- a/test/residency/contract/generated/schema_examples.json
+++ b/test/residency/contract/generated/schema_examples.json
@@ -347,6 +347,195 @@
       "sequence": 1,
       "workload_observation_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
     },
+    "profiling_phase_attestation": {
+      "attributed_claims": [
+        {
+          "completeness": "bounded",
+          "entries": [
+            {
+              "amount": 4096,
+              "constraint_id": "gpu/gtt",
+              "unit": "bytes"
+            }
+          ],
+          "family": "consumable_capacity"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "safety_floor"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "cardinality_pool"
+        },
+        {
+          "completeness": "not_applicable",
+          "entries": [],
+          "family": "compatibility_exclusivity"
+        }
+      ],
+      "checksum_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "deployment_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "external_change_claims": [
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "consumable_capacity"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "safety_floor"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "cardinality_pool"
+        },
+        {
+          "completeness": "not_applicable",
+          "entries": [],
+          "family": "compatibility_exclusivity"
+        }
+      ],
+      "fresh_until": "2026-09-23T10:01:00Z",
+      "generations": {
+        "backend": 2,
+        "configuration": 6,
+        "device": 3,
+        "driver": 5,
+        "model": 1,
+        "topology": 4,
+        "workload": 7
+      },
+      "health": "valid",
+      "lifecycle_state": "baseline_quiescent",
+      "max_source_skew_milliseconds": 1,
+      "observation_contract_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "observation_generation": 1,
+      "observed_at": "2026-01-01T00:00:00Z",
+      "observed_claims": [
+        {
+          "completeness": "bounded",
+          "entries": [
+            {
+              "amount": 4096,
+              "constraint_id": "gpu/gtt",
+              "unit": "bytes"
+            }
+          ],
+          "family": "consumable_capacity"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "safety_floor"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "cardinality_pool"
+        },
+        {
+          "completeness": "not_applicable",
+          "entries": [],
+          "family": "compatibility_exclusivity"
+        }
+      ],
+      "owner_coverage": "complete",
+      "phase": "baseline",
+      "predictor_contract_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "profiling_transaction_id": "profiling_transaction_id-1",
+      "provenance_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "provider_id": "provider_id-1",
+      "provider_revision_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "safety_margin_claims": [
+        {
+          "completeness": "bounded",
+          "entries": [
+            {
+              "amount": 4096,
+              "constraint_id": "gpu/gtt",
+              "unit": "bytes"
+            }
+          ],
+          "family": "consumable_capacity"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "safety_floor"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "cardinality_pool"
+        },
+        {
+          "completeness": "not_applicable",
+          "entries": [],
+          "family": "compatibility_exclusivity"
+        }
+      ],
+      "schema": {
+        "major": 1,
+        "minor": 0
+      },
+      "selector_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "source_skew_milliseconds": 0,
+      "unattributed_claims": [
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "consumable_capacity"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "safety_floor"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "cardinality_pool"
+        },
+        {
+          "completeness": "not_applicable",
+          "entries": [],
+          "family": "compatibility_exclusivity"
+        }
+      ],
+      "uncertainty_claims": [
+        {
+          "completeness": "bounded",
+          "entries": [
+            {
+              "amount": 4096,
+              "constraint_id": "gpu/gtt",
+              "unit": "bytes"
+            }
+          ],
+          "family": "consumable_capacity"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "safety_floor"
+        },
+        {
+          "completeness": "known_zero",
+          "entries": [],
+          "family": "cardinality_pool"
+        },
+        {
+          "completeness": "not_applicable",
+          "entries": [],
+          "family": "compatibility_exclusivity"
+        }
+      ]
+    },
     "reason": {
       "code": "residency_operation_succeeded",
       "presentation": {
@@ -5357,6 +5546,163 @@
               "minor": 0
             }
           },
+          "profiling_phase_attestation": {
+            "conditionals": [
+              {
+                "assert": {
+                  "field": "observed_at",
+                  "less_than_path": "fresh_until"
+                }
+              },
+              {
+                "assert": {
+                  "field": "source_skew_milliseconds",
+                  "less_than_or_equal_path": "max_source_skew_milliseconds"
+                }
+              },
+              {
+                "if": {
+                  "equals": "baseline",
+                  "field": "phase"
+                },
+                "require_values": {
+                  "lifecycle_state": "baseline_quiescent"
+                }
+              },
+              {
+                "if": {
+                  "equals": "workload",
+                  "field": "phase"
+                },
+                "require_values": {
+                  "lifecycle_state": "workload_complete"
+                }
+              },
+              {
+                "if": {
+                  "equals": "release",
+                  "field": "phase"
+                },
+                "require_values": {
+                  "lifecycle_state": "release_verified"
+                }
+              }
+            ],
+            "fields": {
+              "attributed_claims": {
+                "required": true,
+                "type": "local_overlay_claim_closure"
+              },
+              "checksum_sha256": {
+                "required": true,
+                "type": "sha256"
+              },
+              "deployment_id": {
+                "required": true,
+                "type": "local_overlay_deployment_identity"
+              },
+              "external_change_claims": {
+                "required": true,
+                "type": "local_overlay_zero_claim_closure"
+              },
+              "fresh_until": {
+                "required": true,
+                "type": "local_overlay_expiry"
+              },
+              "generations": {
+                "required": true,
+                "type": "local_overlay_source_generations"
+              },
+              "health": {
+                "required": true,
+                "type": "local_overlay_profiling_health"
+              },
+              "lifecycle_state": {
+                "required": true,
+                "type": "local_overlay_profiling_lifecycle_state"
+              },
+              "max_source_skew_milliseconds": {
+                "required": true,
+                "type": "local_overlay_positive_uint64"
+              },
+              "observation_contract_sha256": {
+                "required": true,
+                "type": "sha256"
+              },
+              "observation_generation": {
+                "required": true,
+                "type": "local_overlay_positive_uint64"
+              },
+              "observed_at": {
+                "required": true,
+                "type": "local_overlay_timestamp"
+              },
+              "observed_claims": {
+                "required": true,
+                "type": "local_overlay_claim_closure"
+              },
+              "owner_coverage": {
+                "required": true,
+                "type": "local_overlay_profiling_owner_coverage"
+              },
+              "phase": {
+                "required": true,
+                "type": "local_overlay_profiling_phase"
+              },
+              "predictor_contract_sha256": {
+                "required": true,
+                "type": "sha256"
+              },
+              "profiling_transaction_id": {
+                "max_bytes": 128,
+                "required": true,
+                "type": "opaque"
+              },
+              "provenance_sha256": {
+                "required": true,
+                "type": "sha256"
+              },
+              "provider_id": {
+                "max_bytes": 128,
+                "required": true,
+                "type": "opaque"
+              },
+              "provider_revision_sha256": {
+                "required": true,
+                "type": "sha256"
+              },
+              "safety_margin_claims": {
+                "required": true,
+                "type": "local_overlay_safety_margin_claim_closure"
+              },
+              "schema": {
+                "required": true,
+                "type": "local_overlay_schema_version"
+              },
+              "selector_sha256": {
+                "required": true,
+                "type": "sha256"
+              },
+              "source_skew_milliseconds": {
+                "required": true,
+                "type": "local_overlay_nonnegative_uint64"
+              },
+              "unattributed_claims": {
+                "required": true,
+                "type": "local_overlay_zero_claim_closure"
+              },
+              "uncertainty_claims": {
+                "required": true,
+                "type": "local_overlay_claim_closure"
+              }
+            },
+            "output": "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
+            "schema_type": "residency.profiling_phase_attestation/1.0",
+            "version": {
+              "major": 1,
+              "minor": 0
+            }
+          },
           "reason": {
             "conditionals": [
               {
@@ -7642,7 +7988,7 @@
         }
       ],
       "schema": "residency.profiles/1.0",
-      "selection_registry_sha256": "bd040081cc1286047433bfe14ac6556636620176fd02c2a2c934561ac7e9ed28",
+      "selection_registry_sha256": "9dbdfad20160c82f3905493d2d5c4bdcf40f2249b25ad919c57fd4462a51b4b7",
       "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
     },
     "resource_diagnostic": {

--- a/test/residency/contract/test_cross_component_matrix_public_seam.py
+++ b/test/residency/contract/test_cross_component_matrix_public_seam.py
@@ -15,7 +15,7 @@ from typing import Any
 repo_root = Path(__file__).resolve().parents[3]
 failure = "TASK-013 residency cross-component matrix is unavailable\n"
 expected_catalog_sha256 = (
-    "de567a516d6dc5b731d5acf0f66fe84ab7cae1d1329d6f6bd9735510a5684d65"
+    "c3b8fcd06079c8733515b04a8082c164562636681c197e7ee686406a95f2bd55"
 )
 generated_paths = (
     "docs/api/schemas/residency/artifact_quarantine_record.schema.json",
@@ -27,6 +27,7 @@ generated_paths = (
     "docs/api/schemas/residency/operation_revision.schema.json",
     "docs/api/schemas/residency/overlay_activation_root.schema.json",
     "docs/api/schemas/residency/profiling_input_envelope.schema.json",
+    "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
     "docs/api/schemas/residency/reason.schema.json",
     "docs/api/schemas/residency/request_error.schema.json",
     "docs/api/schemas/residency/residency_profiles.schema.json",
@@ -51,6 +52,7 @@ expected_schema_ids = (
     "residency.operation_revision/1.0",
     "residency.overlay_activation_root/1.0",
     "residency.profiling_input_envelope/1.0",
+    "residency.profiling_phase_attestation/1.0",
     "residency.reason/1.0",
     "residency.request_error/1.0",
     "residency.profiles/1.0",

--- a/test/residency/contract/test_generated_contract.py
+++ b/test/residency/contract/test_generated_contract.py
@@ -28,6 +28,7 @@ GENERATED_PATHS = {
     "docs/api/schemas/residency/operation_revision.schema.json",
     "docs/api/schemas/residency/overlay_activation_root.schema.json",
     "docs/api/schemas/residency/profiling_input_envelope.schema.json",
+    "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
     "docs/api/schemas/residency/reason.schema.json",
     "docs/api/schemas/residency/request_error.schema.json",
     "docs/api/schemas/residency/residency_profiles.schema.json",
@@ -139,7 +140,7 @@ def require_catalog_contract(files: dict[str, bytes]) -> None:
         "reason_envelope_registry": 8,
         "reason_registry": 87,
         "request_context_registry": 37,
-        "schema_registry": 15,
+        "schema_registry": 16,
     }
     for key, expected in expected_counts.items():
         require(len(registry[key]) == expected, f"{key} count drifted")
@@ -690,6 +691,7 @@ def require_cpp_codec_schema_seam(
         "deployment_local_overlay_object",
         "overlay_activation_root",
         "profiling_input_envelope",
+        "profiling_phase_attestation",
     }
     require(
         set(documents) == expected_documents,
@@ -1006,6 +1008,7 @@ def require_local_overlay_schemas(
 ) -> None:
     names = {
         "profiling_input_envelope",
+        "profiling_phase_attestation",
         "deployment_local_overlay_object",
         "overlay_activation_root",
     }
@@ -1024,14 +1027,81 @@ def require_local_overlay_schemas(
     profiling = contract_validator(
         schemas["profiling_input_envelope"], registry=resources
     )
+    phase = contract_validator(
+        schemas["profiling_phase_attestation"], registry=resources
+    )
     overlay = contract_validator(
         schemas["deployment_local_overlay_object"], registry=resources
     )
     root = contract_validator(schemas["overlay_activation_root"], registry=resources)
 
+    profiling_input_fields = {
+        "schema",
+        "deployment_id",
+        "sequence",
+        "profiling_transaction_id",
+        "selector",
+        "generations",
+        "attributed_claims",
+        "baseline_observation_sha256",
+        "workload_observation_sha256",
+        "release_observation_sha256",
+        "observation_contract_sha256",
+        "predictor_contract_sha256",
+        "observed_at",
+        "fresh_until",
+        "max_clock_skew_milliseconds",
+        "attribution_complete",
+        "external_demand_absent",
+        "lifecycle_release_verified",
+        "checksum_sha256",
+    }
+    require(
+        set(schemas["profiling_input_envelope"]["properties"])
+        == profiling_input_fields,
+        "profiling-input envelope field roster drifted",
+    )
+    profiling_phase_fields = {
+        "schema",
+        "phase",
+        "deployment_id",
+        "profiling_transaction_id",
+        "selector_sha256",
+        "provider_id",
+        "provider_revision_sha256",
+        "provenance_sha256",
+        "observation_contract_sha256",
+        "predictor_contract_sha256",
+        "generations",
+        "observation_generation",
+        "observed_at",
+        "fresh_until",
+        "source_skew_milliseconds",
+        "max_source_skew_milliseconds",
+        "health",
+        "owner_coverage",
+        "observed_claims",
+        "attributed_claims",
+        "external_change_claims",
+        "unattributed_claims",
+        "uncertainty_claims",
+        "safety_margin_claims",
+        "lifecycle_state",
+        "checksum_sha256",
+    }
+    require(
+        set(schemas["profiling_phase_attestation"]["properties"])
+        == profiling_phase_fields,
+        "profiling phase-attestation field roster drifted",
+    )
+
     timestamp_validators = {
         "profiling_input_envelope": (
             profiling,
+            ("observed_at", "fresh_until"),
+        ),
+        "profiling_phase_attestation": (
+            phase,
             ("observed_at", "fresh_until"),
         ),
         "deployment_local_overlay_object": (
@@ -1148,6 +1218,67 @@ def require_local_overlay_schemas(
     require(
         not profiling.is_valid(unknown_claim),
         "profiling schema accepted an incomplete claim closure",
+    )
+
+    unhealthy_phase = copy.deepcopy(examples["profiling_phase_attestation"])
+    unhealthy_phase["health"] = "stale"
+    require(
+        not phase.is_valid(unhealthy_phase),
+        "phase attestation accepted non-valid observation health",
+    )
+    incomplete_owner_coverage = copy.deepcopy(examples["profiling_phase_attestation"])
+    incomplete_owner_coverage["owner_coverage"] = "incomplete"
+    require(
+        not phase.is_valid(incomplete_owner_coverage),
+        "phase attestation accepted incomplete owner coverage",
+    )
+    lifecycle_by_phase = {
+        "baseline": "baseline_quiescent",
+        "workload": "workload_complete",
+        "release": "release_verified",
+    }
+    for phase_name, expected_lifecycle in lifecycle_by_phase.items():
+        for lifecycle in lifecycle_by_phase.values():
+            candidate = copy.deepcopy(examples["profiling_phase_attestation"])
+            candidate["phase"] = phase_name
+            candidate["lifecycle_state"] = lifecycle
+            require(
+                phase.is_valid(candidate) == (lifecycle == expected_lifecycle),
+                "phase attestation phase/lifecycle mapping drifted",
+            )
+    skew_at_limit = copy.deepcopy(examples["profiling_phase_attestation"])
+    skew_at_limit["source_skew_milliseconds"] = 1000
+    skew_at_limit["max_source_skew_milliseconds"] = 1000
+    require(
+        phase.is_valid(skew_at_limit),
+        "phase attestation rejected source skew at the accepted limit",
+    )
+    skew_over_limit = copy.deepcopy(skew_at_limit)
+    skew_over_limit["source_skew_milliseconds"] = 1001
+    require(
+        not phase.is_valid(skew_over_limit),
+        "phase attestation accepted source skew above the limit",
+    )
+    zero_maximum_skew = copy.deepcopy(examples["profiling_phase_attestation"])
+    zero_maximum_skew["max_source_skew_milliseconds"] = 0
+    require(
+        not phase.is_valid(zero_maximum_skew),
+        "phase attestation accepted a zero maximum source skew",
+    )
+    for claim_field in ("external_change_claims", "unattributed_claims"):
+        contaminated = copy.deepcopy(examples["profiling_phase_attestation"])
+        contaminated[claim_field][0] = copy.deepcopy(contaminated["observed_claims"][0])
+        require(
+            not phase.is_valid(contaminated),
+            f"phase attestation accepted bounded {claim_field}",
+        )
+    zero_phase_safety_margin = copy.deepcopy(examples["profiling_phase_attestation"])
+    for family in zero_phase_safety_margin["safety_margin_claims"]:
+        family["completeness"] = "known_zero"
+        family["entries"] = []
+    require(
+        not phase.is_valid(zero_phase_safety_margin),
+        "phase attestation accepted a zero safety margin",
     )
 
     wrong_status = copy.deepcopy(examples["deployment_local_overlay_object"])

--- a/test/test_residency_capability_inventory_contract_registry.py
+++ b/test/test_residency_capability_inventory_contract_registry.py
@@ -24,7 +24,7 @@ class ResidencyCapabilityInventoryContractRegistryTest(
         self.assertEqual(len(registry["reason_registry"]), 87)
         self.assertEqual(len(registry["presentation_registry"]), 27)
         self.assertEqual(len(registry["detail_schema_registry"]), 15)
-        self.assertEqual(len(registry["schema_registry"]), 15)
+        self.assertEqual(len(registry["schema_registry"]), 16)
         catalog_fields = registry["schema_registry"]["residency_profiles"]["fields"]
         self.assertEqual(
             catalog_fields["source_support_baseline"],

--- a/tools/residency_contract/generator.py
+++ b/tools/residency_contract/generator.py
@@ -23,6 +23,7 @@ OUTPUT_PATHS = (
     "docs/api/schemas/residency/operation_revision.schema.json",
     "docs/api/schemas/residency/overlay_activation_root.schema.json",
     "docs/api/schemas/residency/profiling_input_envelope.schema.json",
+    "docs/api/schemas/residency/profiling_phase_attestation.schema.json",
     "docs/api/schemas/residency/reason.schema.json",
     "docs/api/schemas/residency/request_error.schema.json",
     "docs/api/schemas/residency/residency_profiles.schema.json",
@@ -315,7 +316,7 @@ def _schema_rows(registry: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
     rows = _registry_mapping(registry, "schema_registry")
     if set(rows) != set(SCHEMA_KEYS):
         raise ContractGenerationError(
-            "schema_registry must contain the exact 15 generated schema keys"
+            f"schema_registry must contain the exact {len(SCHEMA_KEYS)} generated schema keys"
         )
     return {
         key: copy.deepcopy(_mapping(rows[key], f"schema_registry.{key}"))

--- a/tools/residency_contract/schemas.py
+++ b/tools/residency_contract/schemas.py
@@ -448,10 +448,8 @@ def _local_overlay_field_schema(
     if spec["type"] == "local_overlay_required_true":
         return {"const": True}
     if spec["type"] == "local_overlay_profiling_phase":
-        return _string_schema(
-            values=("baseline", "workload", "release"),
-            max_length=len("baseline"),
-        )
+        values = ("baseline", "workload", "release")
+        return _string_schema(values=values, max_length=max(map(len, values)))
     if spec["type"] == "local_overlay_profiling_health":
         return {"const": "valid"}
     if spec["type"] == "local_overlay_profiling_owner_coverage":

--- a/tools/residency_contract/schemas.py
+++ b/tools/residency_contract/schemas.py
@@ -23,6 +23,7 @@ SCHEMA_KEYS = (
     "operation_revision",
     "overlay_activation_root",
     "profiling_input_envelope",
+    "profiling_phase_attestation",
     "reason",
     "request_error",
     "residency_profiles",
@@ -35,6 +36,7 @@ LOCAL_OVERLAY_SCHEMA_KEYS = frozenset(
         "deployment_local_overlay_object",
         "overlay_activation_root",
         "profiling_input_envelope",
+        "profiling_phase_attestation",
     }
 )
 LOCAL_OVERLAY_TEMPLATE_OPERATIONS = {
@@ -439,10 +441,39 @@ def _local_overlay_field_schema(
     del name, registry, catalog
     if spec["type"] == "local_overlay_positive_uint64":
         return {"type": "integer", "minimum": 1, "maximum": UINT64_MAX}
+    if spec["type"] == "local_overlay_nonnegative_uint64":
+        return {"type": "integer", "minimum": 0, "maximum": UINT64_MAX}
     if spec["type"] == "local_overlay_confidence_basis_points":
         return {"type": "integer", "minimum": 1, "maximum": 10000}
     if spec["type"] == "local_overlay_required_true":
         return {"const": True}
+    if spec["type"] == "local_overlay_profiling_phase":
+        return _string_schema(
+            values=("baseline", "workload", "release"),
+            max_length=len("baseline"),
+        )
+    if spec["type"] == "local_overlay_profiling_health":
+        return {"const": "valid"}
+    if spec["type"] == "local_overlay_profiling_owner_coverage":
+        return {"const": "complete"}
+    if spec["type"] == "local_overlay_profiling_lifecycle_state":
+        values = ("baseline_quiescent", "workload_complete", "release_verified")
+        return _string_schema(values=values, max_length=max(map(len, values)))
+    if spec["type"] == "local_overlay_zero_claim_closure":
+        return {
+            "allOf": [
+                {"$ref": "#/$defs/claim_closure"},
+                {
+                    "not": {
+                        "contains": {
+                            "type": "object",
+                            "properties": {"completeness": {"const": "bounded"}},
+                            "required": ["completeness"],
+                        }
+                    }
+                },
+            ]
+        }
     definitions = {
         "local_overlay_authority_status": "authority_status",
         "local_overlay_claim_closure": "claim_closure",
@@ -1408,6 +1439,8 @@ def _local_overlay_field_example(
     field_type = spec["type"]
     if field_type == "local_overlay_positive_uint64":
         return True, 1
+    if field_type == "local_overlay_nonnegative_uint64":
+        return True, 0
     if field_type == "local_overlay_confidence_basis_points":
         return True, 9900
     if field_type == "local_overlay_required_true":
@@ -1429,6 +1462,10 @@ def _local_overlay_field_example(
         "local_overlay_object_status": "qualified",
         "local_overlay_previous_root_reference": None,
         "local_overlay_root_transition": "qualification",
+        "local_overlay_profiling_health": "valid",
+        "local_overlay_profiling_lifecycle_state": "baseline_quiescent",
+        "local_overlay_profiling_owner_coverage": "complete",
+        "local_overlay_profiling_phase": "baseline",
         "local_overlay_safety_margin_claim_closure": _local_overlay_claim_example(),
         "local_overlay_schema_version": {"major": 1, "minor": 0},
         "local_overlay_selector_identity": _local_overlay_selector_example(),
@@ -1442,6 +1479,28 @@ def _local_overlay_field_example(
             "workload": 7,
         },
         "local_overlay_timestamp": "2026-01-01T00:00:00Z",
+        "local_overlay_zero_claim_closure": [
+            {
+                "completeness": "known_zero",
+                "entries": [],
+                "family": "consumable_capacity",
+            },
+            {
+                "completeness": "known_zero",
+                "entries": [],
+                "family": "safety_floor",
+            },
+            {
+                "completeness": "known_zero",
+                "entries": [],
+                "family": "cardinality_pool",
+            },
+            {
+                "completeness": "not_applicable",
+                "entries": [],
+                "family": "compatibility_exclusivity",
+            },
+        ],
     }
     if field_type not in examples:
         return False, None

--- a/tools/residency_inventory/contract_registry.py
+++ b/tools/residency_inventory/contract_registry.py
@@ -21,7 +21,7 @@ from .contract import (
 from .path import _path_tokens
 
 EXPECTED_REGISTRY_DIGEST = (
-    "cb0fcefcd8fa46b4c600e19ae13144ff7192d43aedcb8cca0901eafd28f8d832"
+    "76dfa0d84a4367e242b536bc5edbaa12cb117280320674d7d5ac92f8ded1d481"
 )
 EXPECTED_REGISTRY_KEYS = [
     "schema",
@@ -71,6 +71,7 @@ EXPECTED_SCHEMA_KEYS = [
     "operation_revision",
     "overlay_activation_root",
     "profiling_input_envelope",
+    "profiling_phase_attestation",
     "reason",
     "request_error",
     "residency_profiles",
@@ -339,9 +340,14 @@ SCHEMA_FIELD_TYPES = {
     "local_overlay_deployment_identity",
     "local_overlay_expiry",
     "local_overlay_method_identity",
+    "local_overlay_nonnegative_uint64",
     "local_overlay_object_status",
     "local_overlay_previous_root_reference",
     "local_overlay_positive_uint64",
+    "local_overlay_profiling_health",
+    "local_overlay_profiling_lifecycle_state",
+    "local_overlay_profiling_owner_coverage",
+    "local_overlay_profiling_phase",
     "local_overlay_required_true",
     "local_overlay_root_transition",
     "local_overlay_safety_margin_claim_closure",
@@ -349,6 +355,7 @@ SCHEMA_FIELD_TYPES = {
     "local_overlay_selector_identity",
     "local_overlay_source_generations",
     "local_overlay_timestamp",
+    "local_overlay_zero_claim_closure",
     "nullable_enum_ref",
     "nullable_opaque",
     "nullable_reason_code",


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 1371 additions, 215 deletions" src="https://img.shields.io/badge/IMPL-%2B1371%20%E2%88%92215-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 964 additions, 245 deletions" src="https://img.shields.io/badge/TEST-%2B964%20%E2%88%92245-6F5F9A?style=flat" height="16"></picture> <picture><img alt="GEN: 2231 additions, 5 deletions" src="https://img.shields.io/badge/GEN-%2B2231%20%E2%88%925-76652F?style=flat" height="16"></picture> <picture><img alt="FILES: 26 touched" src="https://img.shields.io/badge/FILES-26-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 1371 additions, 215 deletions" src="https://img.shields.io/badge/IMPL-%2B1371%20%E2%88%92215-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 12 implementation files" src="https://img.shields.io/badge/FILES-12-5F6B78?style=flat" height="16"></picture>
  - [`src/cpp/include/lemon/residency/local_overlay.h`](https://github.com/nisavid/lemonade/pull/130/files#diff-c95d846f38642d59209c1433eb16d6ae83abdaec32a20f05c426de1ec0e0c04c) <picture><img alt="130 additions, 0 deletions" title="130 additions, 0 deletions" src="https://img.shields.io/badge/%2B130-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/profiling_transaction.h`](https://github.com/nisavid/lemonade/pull/130/files#diff-c9cf2ca0c9baf8c161c1fc26386953492f8c626f60c96e56f7d2ddd8d0b109db) <picture><img alt="53 additions, 23 deletions" title="53 additions, 23 deletions" src="https://img.shields.io/badge/%2B53-%E2%88%9223-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/router.h`](https://github.com/nisavid/lemonade/pull/130/files#diff-fccdb79fd24929a165563974da076cf0d05d4e705cc565149e638144514076be) <picture><img alt="46 additions, 8 deletions" title="46 additions, 8 deletions" src="https://img.shields.io/badge/%2B46-%E2%88%928-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/server.h`](https://github.com/nisavid/lemonade/pull/130/files#diff-422e93385c59a644069286b4b8fcf44e3e1a168ed89ab0099c342dacd8cf7973) <picture><img alt="1 addition, 1 deletion" title="1 addition, 1 deletion" src="https://img.shields.io/badge/%2B1-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/eviction_engine.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-43e7074fdda43b4e606a84ce936e92bd9e30ce617d4bce9478a45db70117c732) <picture><img alt="2 additions, 2 deletions" title="2 additions, 2 deletions" src="https://img.shields.io/badge/%2B2-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/local_overlay.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-68ad1eed125cb7d2b6ccafbb17b09939654a829e96526fb5a6570313c2d304c1) <picture><img alt="564 additions, 0 deletions" title="564 additions, 0 deletions" src="https://img.shields.io/badge/%2B564-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-ea5131019f6fd33b90980405887b634fb161b5fd8367c8acf451c849fa3f24a5) <picture><img alt="406 additions, 138 deletions" title="406 additions, 138 deletions" src="https://img.shields.io/badge/%2B406-%E2%88%92138-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/router.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-bd6e46c28596fe62518f52a0deb83609aad20f892c9e8f4bc7f02ec8056b2739) <picture><img alt="94 additions, 35 deletions" title="94 additions, 35 deletions" src="https://img.shields.io/badge/%2B94-%E2%88%9235-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/server.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-69b799dde63dbc74c434ff8c0d4df45824f2f134a059eb42f9cb6b994486d673) <picture><img alt="6 additions, 6 deletions" title="6 additions, 6 deletions" src="https://img.shields.io/badge/%2B6-%E2%88%926-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`tools/residency_contract/generator.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-da8fca90ee64f0070882a03d34dbf5417f78610fd42b1501d447dc722c583046) <picture><img alt="2 additions, 1 deletion" title="2 additions, 1 deletion" src="https://img.shields.io/badge/%2B2-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`tools/residency_contract/schemas.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-f8e2c0f047d170bca5f07f75f5140367425af02ed9d0ff233ba76bd905c5caac) <picture><img alt="59 additions, 0 deletions" title="59 additions, 0 deletions" src="https://img.shields.io/badge/%2B59-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`tools/residency_inventory/contract_registry.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-98f30e48f6e77995346fdffc84ba7596cac803c0c2d472e84a9534b7a5d84219) <picture><img alt="8 additions, 1 deletion" title="8 additions, 1 deletion" src="https://img.shields.io/badge/%2B8-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 964 additions, 245 deletions" src="https://img.shields.io/badge/TEST-%2B964%20%E2%88%92245-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 7 test files" src="https://img.shields.io/badge/FILES-7-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_contract_matrix.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-e2a51963f7e9ffcf30591f6ac8c00c7711a5d2b395af058170adbd0e111fa8bc) <picture><img alt="2 additions, 2 deletions" title="2 additions, 2 deletions" src="https://img.shields.io/badge/%2B2-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_residency_local_overlay.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-8330e2dd29f45944fb75e4d564ee4bf90752ab8cbd20d17f4b6bda120ebd1e79) <picture><img alt="167 additions, 0 deletions" title="167 additions, 0 deletions" src="https://img.shields.io/badge/%2B167-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_residency_profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-6eccc8288ec167c7e83b3691fca7a50b36c196c464b41e557e3303ecbd1c2004) <picture><img alt="658 additions, 239 deletions" title="658 additions, 239 deletions" src="https://img.shields.io/badge/%2B658-%E2%88%92239-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_router_model_lifecycle.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-101578dbcf4388e1cb78cda0ecd89d693060e88110e4fa3231be8aa97f11c47c) <picture><img alt="1 addition, 1 deletion" title="1 addition, 1 deletion" src="https://img.shields.io/badge/%2B1-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/contract/test_cross_component_matrix_public_seam.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-4764eeeecdfee8c47df66b0cc59e9f314eae6691d2bdad8d19a9521147f18ec7) <picture><img alt="3 additions, 1 deletion" title="3 additions, 1 deletion" src="https://img.shields.io/badge/%2B3-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/contract/test_generated_contract.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-f4aedde496144cbb063c64279fd6016397108c648fff8983acff25d27d2545c7) <picture><img alt="132 additions, 1 deletion" title="132 additions, 1 deletion" src="https://img.shields.io/badge/%2B132-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/test_residency_capability_inventory_contract_registry.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-2cad42eb89687c81ea3f972b678e8243794a7b28347eea77bd364cfd868f8fe7) <picture><img alt="1 addition, 1 deletion" title="1 addition, 1 deletion" src="https://img.shields.io/badge/%2B1-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="GEN: 2231 additions, 5 deletions" src="https://img.shields.io/badge/GEN-%2B2231%20%E2%88%925-76652F?style=flat" height="16"></picture> <picture><img alt="FILES: 7 generated files" src="https://img.shields.io/badge/FILES-7-5F6B78?style=flat" height="16"></picture>
  - [`docs/api/schemas/residency/profiling_phase_attestation.schema.json`](https://github.com/nisavid/lemonade/pull/130/files#diff-41c59bf0e3fd5f5b1a7acbd8f83d15beb3883816e1301302770d984a78a98154) <picture><img alt="1408 additions, 0 deletions" title="1408 additions, 0 deletions" src="https://img.shields.io/badge/%2B1408-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`docs/research/portable-residency-capability-inventory.json`](https://github.com/nisavid/lemonade/pull/130/files#diff-459591f1b678f4cdd379888968734f1f9feb9281d0db3afc5e2203e79bf96e8c) <picture><img alt="157 additions, 0 deletions" title="157 additions, 0 deletions" src="https://img.shields.io/badge/%2B157-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/generated_contract.h`](https://github.com/nisavid/lemonade/pull/130/files#diff-663e52ce3bc96f80c1f3a2be5f9af88a6e19374d461a63e079801b439ebec739) <picture><img alt="1 addition, 1 deletion" title="1 addition, 1 deletion" src="https://img.shields.io/badge/%2B1-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/resources/residency_profiles.json`](https://github.com/nisavid/lemonade/pull/130/files#diff-38879bab320889a09189954a4d6db209b582def1d6ac9b5a16195c0afb338d16) <picture><img alt="158 additions, 1 deletion" title="158 additions, 1 deletion" src="https://img.shields.io/badge/%2B158-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/generated_contract.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-03758824282c86057da168fc5c2b5d8331fdc1124d28646ff1567c058728b559) <picture><img alt="2 additions, 1 deletion" title="2 additions, 1 deletion" src="https://img.shields.io/badge/%2B2-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/contract/generated/catalog.json`](https://github.com/nisavid/lemonade/pull/130/files#diff-803469b7b24f4cd1d6947447da79a8555c3bb267ef6880193e18c501335ed234) <picture><img alt="158 additions, 1 deletion" title="158 additions, 1 deletion" src="https://img.shields.io/badge/%2B158-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/contract/generated/schema_examples.json`](https://github.com/nisavid/lemonade/pull/130/files#diff-90e86011b821f201b6f7b7820626a928198092371fd4a21fe6d1be035207cde1) <picture><img alt="347 additions, 1 deletion" title="347 additions, 1 deletion" src="https://img.shields.io/badge/%2B347-%E2%88%921-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Serialize baseline, workload, and release profiling attestations and bind their exact canonical bytes into one immutable accepted-evidence bundle. Router exclusive admission now observes a steady-clock deadline even when its mutation lock is contended, while lifecycle restart and cancellation remain fail-closed.

Refs #120

## Review path

1. Start with the authored phase contract in [`tools/residency_contract/schemas.py`](https://github.com/nisavid/lemonade/pull/130/files#diff-f8e2c0f047d170bca5f07f75f5140367425af02ed9d0ff233ba76bd905c5caac) and its canonical C++ codec in [`local_overlay.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-68ad1eed125cb7d2b6ccafbb17b09939654a829e96526fb5a6570313c2d304c1).
2. Review the bounded writer-intent and promotion protocol in [`router.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-bd6e46c28596fe62518f52a0deb83609aad20f892c9e8f4bc7f02ec8056b2739), then the transaction-owned cross-phase validation and envelope construction in [`profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/130/files#diff-ea5131019f6fd33b90980405887b634fb161b5fd8367c8acf451c849fa3f24a5).
3. Use the focused transaction test for deadline contention, pending-intent cleanup, cancellation/restart precedence, exact digest binding, freshness, attribution, and release failure cases. The schema, catalog, inventory, and example JSON files are generated from the authored registry and pass generator drift checks.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

- Adds the closed `residency.profiling_phase_attestation/1.0` contract and derives envelope truth from three validated phase documents instead of provider-supplied booleans.
- Makes pending-to-active Router gate admission deadline-bounded without force-releasing an existing owner.
- Returns exact accepted evidence as an immutable bundle and clears the whole bundle when the Server lifecycle invalidates it.
- Does not add the live Server-owned observation provider, activation/publication handoff, or signing. #120 remains open for those follow-ups.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build "$LEMONADE_ISSUE120_BUILD" --target cpp-ci-tests -j2` — passed.
- `ctest --test-dir "$LEMONADE_ISSUE120_BUILD" -L cpp-ci --output-on-failure` — 64/64 passed.
- `python tools/generate_residency_contract.py --check` and the generated-contract, cross-component matrix, and capability-inventory Python suites — passed.
- An AddressSanitizer-enabled `test_residency_profiling_transaction` run passed; GCC and Clang contract-codec builds passed with `-Werror -pedantic`. MSVC and AppleClang were not available locally and remain covered by hosted CI.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profiling-phase attestations for baseline, workload, and release evidence.
  * Added validation for identity, timestamps, provenance, lifecycle, health, ownership, claims, safety margins, and checksums.
  * Added accepted evidence handling for profiling transactions.
  * Added deadline-aware exclusive resource acquisition.

* **Bug Fixes**
  * Improved coordination to prevent eviction and downsizing while exclusive requests are active or pending.

* **Tests**
  * Expanded coverage for attestation validation, evidence handling, timing, cancellation, concurrency, and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->