### PR TITLE
test(residency/profiling): fence Server evidence handoff

### DIFF
--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -44,6 +44,8 @@ namespace jobs {
 class JobManager;
 }
 
+struct ServerProfilingTestHook;
+
 struct RouterDispatchResult {
     std::string requested_model;
     std::string selected_model;
@@ -76,6 +78,14 @@ public:
     bool startup_failed() const;
 
 private:
+    friend struct ServerProfilingTestHook;
+
+    struct ProfilingTestTag {};
+
+    Server(ProfilingTestTag,
+           std::shared_ptr<RuntimeConfig> config,
+           residency::ProfilingTransactionOptions options);
+
     void begin_residency_lifecycle_change();
 
     // This trusted internal seam does not publish. Its caller must be a
@@ -85,6 +95,12 @@ private:
         residency::ProfilingTransactionContext context,
         residency::ProfilingTransaction::Capture capture,
         std::atomic<bool> *cancel = nullptr);
+
+    residency::ProfilingTransactionResult run_residency_profiling_transaction(
+        residency::ProfilingTransactionContext context,
+        residency::ProfilingTransaction::Capture capture,
+        std::atomic<bool> *cancel,
+        std::function<void(const residency::ProfilingTransactionResult &)> before_handoff);
 
     std::string resolve_host_to_ip(int ai_family, const std::string& host);
     void setup_routes(httplib::Server &web_server);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -438,6 +438,18 @@ static const json MIME_TYPES = {
     {"pcm",  "audio/l16;rate=24000;endianness=little-endian"}
 };
 
+Server::Server(ProfilingTestTag,
+               std::shared_ptr<RuntimeConfig> config,
+               residency::ProfilingTransactionOptions options)
+    : config_(config),
+      cache_dir_(),
+      port_(config->port()), running_(false), udp_beacon_() {
+    router_ = std::make_unique<Router>(config_.get(), nullptr, nullptr);
+    profiling_transaction_ =
+        std::make_unique<residency::ProfilingTransaction>(*router_, std::move(options));
+    profiling_accepting_.store(true);
+}
+
 Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_dir)
     : config_(config),
       cache_dir_(cache_dir),
@@ -2566,6 +2578,16 @@ Server::run_residency_profiling_transaction(
     residency::ProfilingTransactionContext context,
     residency::ProfilingTransaction::Capture capture,
     std::atomic<bool> *cancel) {
+    return run_residency_profiling_transaction(
+        std::move(context), std::move(capture), cancel, {});
+}
+
+residency::ProfilingTransactionResult
+Server::run_residency_profiling_transaction(
+    residency::ProfilingTransactionContext context,
+    residency::ProfilingTransaction::Capture capture,
+    std::atomic<bool> *cancel,
+    std::function<void(const residency::ProfilingTransactionResult &)> before_handoff) {
     uint64_t lifecycle_epoch = 0;
     residency::ProfilingTransaction *transaction = nullptr;
     {
@@ -2623,6 +2645,7 @@ Server::run_residency_profiling_transaction(
                        shutdown_requested_.load() || rebind_requested_.load() ||
                        profiling_lifecycle_epoch_.load() != lifecycle_epoch;
             });
+        if (before_handoff) before_handoff(result);
     } catch (...) {
         residency::ProfilingTransactionResult failed;
         failed.status = residency::ProfilingTransactionStatus::Failed;

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -1,6 +1,7 @@
 #include "lemon/config_file.h"
 #include "lemon/residency/profiling_transaction.h"
 #include "lemon/router.h"
+#include "lemon/server.h"
 
 #include <mbedtls/md.h>
 #include <nlohmann/json.hpp>
@@ -37,6 +38,29 @@ struct ProfilingTransactionTestHook {
 
     static void cancel_pending(Router &router, std::uint64_t generation) {
         router.cancel_exclusive_request(generation);
+    }
+};
+
+struct ServerProfilingTestHook {
+    static std::unique_ptr<Server> create(
+        std::shared_ptr<RuntimeConfig> config,
+        residency::ProfilingTransactionOptions options) {
+        return std::unique_ptr<Server>(new Server(
+            Server::ProfilingTestTag{}, std::move(config), std::move(options)));
+    }
+
+    static residency::ProfilingTransactionResult run(
+        Server &server,
+        residency::ProfilingTransactionContext context,
+        residency::ProfilingTransaction::Capture capture,
+        std::function<void(const residency::ProfilingTransactionResult &)> before_handoff) {
+        return server.run_residency_profiling_transaction(
+            std::move(context), std::move(capture), nullptr, std::move(before_handoff));
+    }
+
+    static void advance_lifecycle_epoch(Server &server) {
+        std::lock_guard<std::mutex> lock(server.lifecycle_mutex_);
+        server.profiling_lifecycle_epoch_.fetch_add(1);
     }
 };
 
@@ -1053,12 +1077,53 @@ void test_exception_releases_gate(TestState &state, Router &router) {
     if (reacquired) router.end_exclusive();
 }
 
+void test_server_rejects_evidence_after_lifecycle_handoff(
+    TestState &state, const std::shared_ptr<RuntimeConfig> &config) {
+    auto server = lemon::ServerProfilingTestHook::create(config, options());
+    std::promise<void> handoff_entered;
+    auto handoff_entered_signal = handoff_entered.get_future();
+    std::promise<void> release_handoff;
+    auto release_handoff_signal = release_handoff.get_future().share();
+
+    auto run = std::async(std::launch::async, [&] {
+        return lemon::ServerProfilingTestHook::run(
+            *server, context("profile/server-lifecycle-handoff"),
+            [](Router &, const ProfilingTransactionContext &transaction_context,
+               const ProfilingCancellationCheck &) { return capture(transaction_context); },
+            [&](const ProfilingTransactionResult &result) {
+                state.require(result.status == ProfilingTransactionStatus::Accepted,
+                              "Server handoff probe observes accepted transaction");
+                state.require(result.evidence.has_value(),
+                              "Server handoff probe observes accepted evidence");
+                handoff_entered.set_value();
+                release_handoff_signal.wait();
+            });
+    });
+
+    const bool entered =
+        handoff_entered_signal.wait_for(1s) == std::future_status::ready;
+    state.require(entered, "Server transaction reaches the lifecycle handoff");
+    if (entered) lemon::ServerProfilingTestHook::advance_lifecycle_epoch(*server);
+    release_handoff.set_value();
+
+    const auto result = run.get();
+    state.require(result.status == ProfilingTransactionStatus::Restarted,
+                  "Server rejects evidence after a lifecycle-epoch handoff");
+    state.require(!result.evidence.has_value(),
+                  "Server clears evidence after a lifecycle-epoch handoff");
+    state.require(result.diagnostic ==
+                      "profiling lifecycle changed before publication",
+                  "Server reports the lifecycle handoff diagnostic");
+}
+
 } // namespace
 
 int main() {
     TestState state;
     RuntimeConfig config = make_config();
     RuntimeConfig::set_global(&config);
+    auto config_handle =
+        std::shared_ptr<RuntimeConfig>(&config, [](RuntimeConfig *) {});
     {
         Router router(&config, nullptr, nullptr);
         test_cross_router_request_ownership(state, router, config);
@@ -1071,6 +1136,7 @@ int main() {
         test_gate_timeout_bounds_router_lock(state, router);
         test_gate_timeout_clears_pending_intent(state, router);
         test_exception_releases_gate(state, router);
+        test_server_rejects_evidence_after_lifecycle_handoff(state, config_handle);
     }
     RuntimeConfig::set_global(nullptr);
     return state.ok.load() ? 0 : 1;

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -1100,10 +1100,8 @@ void test_server_rejects_evidence_after_lifecycle_handoff(
             });
     });
 
-    const bool entered =
-        handoff_entered_signal.wait_for(1s) == std::future_status::ready;
-    state.require(entered, "Server transaction reaches the lifecycle handoff");
-    if (entered) lemon::ServerProfilingTestHook::advance_lifecycle_epoch(*server);
+    handoff_entered_signal.wait();
+    lemon::ServerProfilingTestHook::advance_lifecycle_epoch(*server);
     release_handoff.set_value();
 
     const auto result = run.get();

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <future>
 #include <iostream>
@@ -1080,27 +1081,61 @@ void test_exception_releases_gate(TestState &state, Router &router) {
 void test_server_rejects_evidence_after_lifecycle_handoff(
     TestState &state, const std::shared_ptr<RuntimeConfig> &config) {
     auto server = lemon::ServerProfilingTestHook::create(config, options());
-    std::promise<void> handoff_entered;
-    auto handoff_entered_signal = handoff_entered.get_future();
+    std::mutex handoff_mutex;
+    std::condition_variable handoff_changed;
+    bool handoff_entered = false;
+    bool run_completed = false;
     std::promise<void> release_handoff;
     auto release_handoff_signal = release_handoff.get_future().share();
 
     auto run = std::async(std::launch::async, [&] {
-        return lemon::ServerProfilingTestHook::run(
-            *server, context("profile/server-lifecycle-handoff"),
-            [](Router &, const ProfilingTransactionContext &transaction_context,
-               const ProfilingCancellationCheck &) { return capture(transaction_context); },
-            [&](const ProfilingTransactionResult &result) {
-                state.require(result.status == ProfilingTransactionStatus::Accepted,
-                              "Server handoff probe observes accepted transaction");
-                state.require(result.evidence.has_value(),
-                              "Server handoff probe observes accepted evidence");
-                handoff_entered.set_value();
-                release_handoff_signal.wait();
-            });
+        const auto mark_run_completed = [&] {
+            {
+                std::lock_guard<std::mutex> lock(handoff_mutex);
+                run_completed = true;
+            }
+            handoff_changed.notify_one();
+        };
+        try {
+            auto result = lemon::ServerProfilingTestHook::run(
+                *server, context("profile/server-lifecycle-handoff"),
+                [](Router &, const ProfilingTransactionContext &transaction_context,
+                   const ProfilingCancellationCheck &) {
+                    return capture(transaction_context);
+                },
+                [&](const ProfilingTransactionResult &result) {
+                    state.require(
+                        result.status == ProfilingTransactionStatus::Accepted,
+                        "Server handoff probe observes accepted transaction");
+                    state.require(result.evidence.has_value(),
+                                  "Server handoff probe observes accepted evidence");
+                    {
+                        std::lock_guard<std::mutex> lock(handoff_mutex);
+                        handoff_entered = true;
+                    }
+                    handoff_changed.notify_one();
+                    release_handoff_signal.wait();
+                });
+            mark_run_completed();
+            return result;
+        } catch (...) {
+            mark_run_completed();
+            throw;
+        }
     });
 
-    handoff_entered_signal.wait();
+    {
+        std::unique_lock<std::mutex> lock(handoff_mutex);
+        handoff_changed.wait(lock, [&] { return handoff_entered || run_completed; });
+        if (run_completed) {
+            lock.unlock();
+            const auto early_result = run.get();
+            state.require(false, "Server transaction reaches the lifecycle handoff");
+            state.require(early_result.status != ProfilingTransactionStatus::Accepted,
+                          "Server cannot accept evidence without invoking the handoff");
+            return;
+        }
+    }
     lemon::ServerProfilingTestHook::advance_lifecycle_epoch(*server);
     release_handoff.set_value();
 


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 39 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B39%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 99 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B99%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 3 touched" src="https://img.shields.io/badge/FILES-3-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 39 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B39%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 2 implementation files" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture>
  - [`src/cpp/include/lemon/server.h`](https://github.com/nisavid/lemonade/pull/131/files#diff-422e93385c59a644069286b4b8fcf44e3e1a168ed89ab0099c342dacd8cf7973) <picture><img alt="16 additions, 0 deletions" title="16 additions, 0 deletions" src="https://img.shields.io/badge/%2B16-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/server.cpp`](https://github.com/nisavid/lemonade/pull/131/files#diff-69b799dde63dbc74c434ff8c0d4df45824f2f134a059eb42f9cb6b994486d673) <picture><img alt="23 additions, 0 deletions" title="23 additions, 0 deletions" src="https://img.shields.io/badge/%2B23-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 99 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B99%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 1 test file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/131/files#diff-6eccc8288ec167c7e83b3691fca7a50b36c196c464b41e557e3303ecbd1c2004) <picture><img alt="99 additions, 0 deletions" title="99 additions, 0 deletions" src="https://img.shields.io/badge/%2B99-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Adds a deterministic Server-boundary handoff test that pauses after profiling evidence is accepted, advances the lifecycle epoch, and proves the Server returns `Restarted` without releasing stale evidence. The production profiling call path remains unchanged.

Refs #120

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build <build-dir> --target cpp-ci-tests -j2` — passed.
- `ctest --test-dir <build-dir> -L cpp-ci --output-on-failure` — 64/64 passed.
- `ctest --test-dir <build-dir> -R '^ResidencyProfilingTransaction$' --output-on-failure` — passed; the focused executable also passed three consecutive direct runs.
- `git diff --check origin/main...HEAD` — clean.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved residency profiling reliability when the server lifecycle changes during transaction handoff.
  * Profiling evidence is now correctly rejected and marked for restart when it becomes stale, preventing outdated results from being published.

* **Tests**
  * Added coverage for profiling transaction execution, lifecycle changes, handoff validation, and restart handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
