### PR TITLE
feat(residency/profiling): derive contract-bound raw observations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,6 +977,7 @@ set(SOURCES_CORE
     src/cpp/server/residency/explanations.cpp
     src/cpp/server/residency/generated_contract.cpp
     src/cpp/server/residency/local_overlay.cpp
+    src/cpp/server/residency/profiling_provider.cpp
     src/cpp/server/residency/profiling_transaction.cpp
     src/cpp/server/wrapped_server.cpp
     src/cpp/server/streaming_proxy.cpp
@@ -3486,6 +3487,25 @@ if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_TRANSACTION_TEST_SRC}")
         COMMAND test_residency_profiling_transaction
     )
     set_tests_properties(ResidencyProfilingTransaction PROPERTIES TIMEOUT 30)
+endif()
+
+set(_RESIDENCY_PROFILING_PROVIDER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_residency_profiling_provider.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_PROVIDER_TEST_SRC}")
+    add_executable(
+        test_residency_profiling_provider
+        test/cpp/test_residency_profiling_provider.cpp
+    )
+    target_link_libraries(test_residency_profiling_provider PRIVATE
+        lemonade-server-core
+    )
+    add_cpp_ci_test(
+        ResidencyProfilingProvider
+        CI ON
+        COMMAND test_residency_profiling_provider
+    )
+    set_tests_properties(ResidencyProfilingProvider PROPERTIES TIMEOUT 30)
 endif()
 
 # Routing-helper reconciliation: durable needed-set + non-blocking prune that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -291,6 +291,18 @@ _Avoid_: Confusing it with the conservative claim overlay, generalizing an exact
 An exclusive, server-owned qualification of one exact operation and identity whose workload, baseline, and lifecycle are completely isolated and attributed. Unattributed external demand prevents it from establishing a local overlay.
 _Avoid_: Treating an ordinary concurrent benchmark, global memory sample, or partially attributed run as qualification evidence.
 
+**Profiling source sample**:
+A phase-neutral low-level reading containing an opaque sensor ID, an optional server-issued owner-scope ID, one unsigned scalar value, and the source's native generation. It carries no claim family, unit, timestamp, health, completeness, lifecycle, attribution, uncertainty, safety, or attestation authority.
+_Avoid_: Accepting provider-supplied truth decisions or treating a successful read as profiling evidence.
+
+**Profiling derivation contract**:
+The transaction-specific, server-owned policy binding one provider revision, the exact required capacity sensors and owner scopes, their mappings to consumable-capacity byte claims, freshness and skew bounds, and per-sensor uncertainty bounds and safety ceilings. Its canonical digest is order-insensitive for sensor and owner sets. The collector accepts only an exact coherent raw closure and derives a phase-neutral observation with positive safety slack; a later transaction authority proves phase and lifecycle before sealing an attestation.
+_Avoid_: Applying capacity slack arithmetic to discrete claims, letting an observation source select semantics or close ownership, or letting a caller assign phase or lifecycle from one snapshot.
+
+**Profiling derived observation**:
+A phase-neutral Server result from one contract-matched raw closure, carrying Server-derived provider identity, raw provenance, generation, acquisition and freshness bounds, health, complete current owner coverage, observed and owner-attributed capacity closure, uncertainty, and positive safety slack. It carries no interval-change claim, is not a phase attestation, and has no lifecycle or publication authority.
+_Avoid_: Inferring external or unattributed interval change from one snapshot, or treating one accepted collection as baseline, workload, release, or completed qualification evidence.
+
 **Deployment-qualified residency method**:
 A local-only method result established for one exact operation and closed residency deployment identity by a complete profiling transaction. It does not change the shared capability level or footprint confidence class and does not apply to another model, device, backend, configuration, workload, or operation family.
 _Avoid_: Treating local qualification as shared release authority or allowing it to bypass protection, ownership, recovery, claim-completeness, or safety constraints.

--- a/src/cpp/include/lemon/residency/profiling_provider.h
+++ b/src/cpp/include/lemon/residency/profiling_provider.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include "lemon/residency/profiling_transaction.h"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lemon::residency {
+
+enum class ProfilingSourceError {
+    None,
+    Unavailable,
+    Cancelled,
+    Failed,
+};
+
+struct ProfilingRawSample {
+    std::string sensor_id;
+    // Absence identifies the all-owner sensor total. Present identities must
+    // come from the Server-issued scope set in the read request.
+    std::optional<std::string> owner_scope_id;
+    std::uint64_t value = 0;
+    std::uint64_t source_generation = 0;
+};
+
+struct ProfilingRawReadRequest {
+    std::vector<std::string> sensor_ids;
+    std::vector<std::string> owner_scope_ids;
+};
+
+struct ProfilingRawReadResult {
+    ProfilingSourceError error = ProfilingSourceError::Unavailable;
+    std::vector<ProfilingRawSample> samples;
+    std::string diagnostic;
+};
+
+class ProfilingObservationSource {
+public:
+    virtual ~ProfilingObservationSource() = default;
+
+    // Reads are synchronous: implementations must not retain either reference.
+    virtual ProfilingRawReadResult
+    read(const ProfilingRawReadRequest &request,
+         const ProfilingCancellationCheck &should_abort) = 0;
+};
+
+class UnavailableProfilingObservationSource final
+    : public ProfilingObservationSource {
+public:
+    ProfilingRawReadResult
+    read(const ProfilingRawReadRequest &request,
+         const ProfilingCancellationCheck &should_abort) override;
+};
+
+struct ProfilingSensorContract {
+    std::string sensor_id;
+    std::string constraint_id;
+    ClaimFamily claim_family = ClaimFamily::ConsumableCapacity;
+    std::uint64_t uncertainty_bound = 0;
+    std::uint64_t safety_ceiling = 0;
+};
+
+struct ProfilingDerivationContract {
+    std::string provider_id;
+    std::string provider_revision_sha256;
+    std::vector<ProfilingSensorContract> sensors;
+    std::vector<std::string> owner_scope_ids;
+    std::chrono::seconds freshness_window{0};
+    std::chrono::milliseconds max_source_skew{0};
+};
+
+std::optional<std::string> profiling_derivation_contract_sha256(
+    const ProfilingDerivationContract &contract);
+
+struct ProfilingCollectionClock {
+    std::function<std::chrono::steady_clock::time_point()> monotonic_now;
+    std::function<std::chrono::system_clock::time_point()> utc_now;
+};
+
+enum class ProfilingCollectionStatus {
+    Accepted,
+    Cancelled,
+    EvidenceUnavailable,
+    InvalidContract,
+    InvalidObservation,
+    DigestUnavailable,
+};
+
+struct ProfilingDerivedObservation {
+    std::string provider_id;
+    std::string provider_revision_sha256;
+    std::string raw_provenance_sha256;
+    std::string observation_contract_sha256;
+    std::uint64_t observation_generation = 0;
+    std::string observed_at;
+    std::string fresh_until;
+    std::uint64_t source_skew_milliseconds = 0;
+    std::uint64_t max_source_skew_milliseconds = 0;
+    ProfilingObservationHealth health = ProfilingObservationHealth::Missing;
+    ProfilingOwnerCoverage owner_coverage = ProfilingOwnerCoverage::Incomplete;
+    std::vector<ClaimFamilyClosure> observed_claims;
+    std::vector<ClaimFamilyClosure> attributed_claims;
+    std::vector<ClaimFamilyClosure> uncertainty_claims;
+    std::vector<ClaimFamilyClosure> safety_margin_claims;
+};
+
+struct ProfilingObservationCollectionResult {
+    ProfilingCollectionStatus status =
+        ProfilingCollectionStatus::EvidenceUnavailable;
+    std::string diagnostic;
+    std::optional<ProfilingDerivedObservation> observation;
+
+    bool accepted() const noexcept;
+};
+
+class ProfilingObservationCollector {
+public:
+    explicit ProfilingObservationCollector(ProfilingDerivationContract contract,
+                                           ProfilingCollectionClock clock = {});
+    // The injected source must outlive this collector.
+    ProfilingObservationCollector(ProfilingDerivationContract contract,
+                                  ProfilingObservationSource &source,
+                                  ProfilingCollectionClock clock = {});
+
+    ProfilingObservationCollector(const ProfilingObservationCollector &) =
+        delete;
+    ProfilingObservationCollector &
+    operator=(const ProfilingObservationCollector &) = delete;
+    ProfilingObservationCollector(ProfilingObservationCollector &&) = delete;
+    ProfilingObservationCollector &
+    operator=(ProfilingObservationCollector &&) = delete;
+
+    ProfilingObservationCollectionResult
+    collect(const ProfilingTransactionContext &context,
+            const ProfilingCancellationCheck &should_abort);
+
+private:
+    ProfilingDerivationContract contract_;
+    UnavailableProfilingObservationSource unavailable_source_;
+    ProfilingObservationSource *source_ = nullptr;
+    ProfilingCollectionClock clock_;
+};
+
+} // namespace lemon::residency

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -1,0 +1,750 @@
+#include "lemon/residency/profiling_provider.h"
+
+#include <mbedtls/md.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <ctime>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <optional>
+#include <ratio>
+#include <set>
+#include <sstream>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace lemon::residency {
+namespace {
+
+using SteadyClock = std::chrono::steady_clock;
+using SystemClock = std::chrono::system_clock;
+
+struct SensorValues {
+    std::optional<std::uint64_t> total;
+    std::map<std::string, std::uint64_t> owners;
+    std::uint64_t attributed_total = 0;
+};
+
+std::string bounded_diagnostic(std::string value) {
+    if (value.size() <= max_local_overlay_diagnostic_bytes) return value;
+    std::size_t boundary = max_local_overlay_diagnostic_bytes;
+    while (boundary > 0 &&
+           (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u) {
+        --boundary;
+    }
+    value.resize(boundary);
+    return value;
+}
+
+ProfilingObservationCollectionResult
+result_for(ProfilingCollectionStatus status, std::string diagnostic = {}) {
+    return ProfilingObservationCollectionResult{
+        status,
+        bounded_diagnostic(std::move(diagnostic)),
+        std::nullopt,
+    };
+}
+
+bool cancelled(const ProfilingCancellationCheck &should_abort) noexcept {
+    if (!should_abort) return false;
+    try {
+        return should_abort();
+    } catch (...) {
+        return true;
+    }
+}
+
+std::optional<std::size_t> family_index(ClaimFamily family) noexcept {
+    switch (family) {
+    case ClaimFamily::ConsumableCapacity:
+        return 0;
+    case ClaimFamily::SafetyFloor:
+        return 1;
+    case ClaimFamily::CardinalityPool:
+        return 2;
+    case ClaimFamily::CompatibilityExclusivity:
+        return 3;
+    }
+    return std::nullopt;
+}
+
+ClaimFamily family_at(std::size_t index) noexcept {
+    static constexpr std::array<ClaimFamily, claim_family_count> families{
+        ClaimFamily::ConsumableCapacity,
+        ClaimFamily::SafetyFloor,
+        ClaimFamily::CardinalityPool,
+        ClaimFamily::CompatibilityExclusivity,
+    };
+    return families[index];
+}
+
+std::optional<ClaimUnit> expected_unit(ClaimFamily family) noexcept {
+    switch (family) {
+    case ClaimFamily::ConsumableCapacity:
+    case ClaimFamily::SafetyFloor:
+        return ClaimUnit::Bytes;
+    case ClaimFamily::CardinalityPool:
+    case ClaimFamily::CompatibilityExclusivity:
+        return ClaimUnit::Count;
+    }
+    return std::nullopt;
+}
+
+std::string_view claim_family_wire(ClaimFamily family) noexcept {
+    switch (family) {
+    case ClaimFamily::ConsumableCapacity:
+        return "consumable_capacity";
+    case ClaimFamily::SafetyFloor:
+        return "safety_floor";
+    case ClaimFamily::CardinalityPool:
+        return "cardinality_pool";
+    case ClaimFamily::CompatibilityExclusivity:
+        return "compatibility_exclusivity";
+    }
+    return {};
+}
+
+std::string_view claim_unit_wire(ClaimUnit unit) noexcept {
+    switch (unit) {
+    case ClaimUnit::Bytes:
+        return "bytes";
+    case ClaimUnit::Count:
+        return "count";
+    }
+    return {};
+}
+
+bool identifier_is_valid(std::string_view value) noexcept {
+    return !value.empty() &&
+           value.size() <= max_local_overlay_identifier_bytes &&
+           std::all_of(value.begin(), value.end(), [](unsigned char character) {
+               return character >= 0x21 && character <= 0x7e;
+           });
+}
+
+bool digest_is_valid(std::string_view value) noexcept {
+    return value.size() == 64 &&
+           std::all_of(value.begin(), value.end(), [](char character) {
+               return (character >= '0' && character <= '9') ||
+                      (character >= 'a' && character <= 'f');
+           });
+}
+
+bool contract_is_valid(const ProfilingDerivationContract &contract) {
+    if (!identifier_is_valid(contract.provider_id) ||
+        !digest_is_valid(contract.provider_revision_sha256) ||
+        contract.sensors.empty() ||
+        contract.sensors.size() > max_journal_array_entries ||
+        contract.owner_scope_ids.empty() ||
+        contract.owner_scope_ids.size() > max_journal_array_entries ||
+        contract.freshness_window <= std::chrono::seconds::zero() ||
+        contract.max_source_skew <= std::chrono::milliseconds::zero() ||
+        contract.max_source_skew.count() / 1000 >=
+            contract.freshness_window.count()) {
+        return false;
+    }
+
+    std::set<std::string> sensor_ids;
+    std::set<std::string> constraint_ids;
+    for (const auto &sensor : contract.sensors) {
+        if (!identifier_is_valid(sensor.sensor_id) ||
+            !identifier_is_valid(sensor.constraint_id) ||
+            sensor.claim_family != ClaimFamily::ConsumableCapacity ||
+            sensor.safety_ceiling <= sensor.uncertainty_bound ||
+            !sensor_ids.insert(sensor.sensor_id).second ||
+            !constraint_ids.insert(sensor.constraint_id).second) {
+            return false;
+        }
+    }
+
+    std::set<std::string> owner_scope_ids;
+    for (const auto &owner_scope_id : contract.owner_scope_ids) {
+        if (!identifier_is_valid(owner_scope_id) ||
+            !owner_scope_ids.insert(owner_scope_id).second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename Rep>
+std::optional<std::int64_t> count_as_i64(Rep value) noexcept {
+    static_assert(std::is_integral_v<Rep>);
+    if constexpr (std::is_signed_v<Rep>) {
+        if constexpr (std::numeric_limits<Rep>::digits >
+                      std::numeric_limits<std::int64_t>::digits) {
+            if (value < static_cast<Rep>(
+                            std::numeric_limits<std::int64_t>::min()) ||
+                value > static_cast<Rep>(
+                            std::numeric_limits<std::int64_t>::max())) {
+                return std::nullopt;
+            }
+        }
+    } else if constexpr (std::numeric_limits<Rep>::digits >=
+                         std::numeric_limits<std::int64_t>::digits) {
+        if (value >
+            static_cast<Rep>(std::numeric_limits<std::int64_t>::max())) {
+            return std::nullopt;
+        }
+    }
+    return static_cast<std::int64_t>(value);
+}
+
+std::optional<std::int64_t>
+system_clock_seconds(SystemClock::time_point value) noexcept {
+    using Scale = std::ratio_divide<SystemClock::duration::period,
+                                    std::chrono::seconds::period>;
+    const auto ticks = count_as_i64(value.time_since_epoch().count());
+    if (!ticks) return std::nullopt;
+
+    static_assert(Scale::num > 0 && Scale::den > 0);
+    const auto numerator = static_cast<std::int64_t>(Scale::num);
+    const auto floor_divide = [](std::int64_t dividend) noexcept {
+        constexpr auto denominator = static_cast<std::int64_t>(Scale::den);
+        auto quotient = dividend / denominator;
+        if (dividend % denominator < 0) --quotient;
+        return quotient;
+    };
+    if (numerator == 1) return floor_divide(*ticks);
+    if ((*ticks > 0 &&
+         *ticks > std::numeric_limits<std::int64_t>::max() / numerator) ||
+        (*ticks < 0 &&
+         *ticks < std::numeric_limits<std::int64_t>::min() / numerator)) {
+        return std::nullopt;
+    }
+    return floor_divide(*ticks * numerator);
+}
+
+bool system_clock_contains_seconds(std::int64_t value) noexcept {
+    const auto minimum = system_clock_seconds(SystemClock::time_point::min());
+    const auto maximum = system_clock_seconds(SystemClock::time_point::max());
+    return minimum && maximum && value >= *minimum && value <= *maximum;
+}
+
+std::optional<std::int64_t> checked_add(std::int64_t left,
+                                        std::int64_t right) noexcept {
+    if ((right > 0 &&
+         left > std::numeric_limits<std::int64_t>::max() - right) ||
+        (right < 0 &&
+         left < std::numeric_limits<std::int64_t>::min() - right)) {
+        return std::nullopt;
+    }
+    return left + right;
+}
+
+std::string format_utc(std::int64_t seconds) {
+    std::time_t time{};
+    if constexpr (std::is_signed_v<std::time_t>) {
+        if constexpr (std::numeric_limits<std::time_t>::digits <
+                      std::numeric_limits<std::int64_t>::digits) {
+            if (seconds < static_cast<std::int64_t>(
+                              std::numeric_limits<std::time_t>::min()) ||
+                seconds > static_cast<std::int64_t>(
+                              std::numeric_limits<std::time_t>::max())) {
+                return {};
+            }
+        }
+        time = static_cast<std::time_t>(seconds);
+    } else {
+        if (seconds < 0 || static_cast<std::uint64_t>(seconds) >
+                               std::numeric_limits<std::time_t>::max()) {
+            return {};
+        }
+        time = static_cast<std::time_t>(seconds);
+    }
+    std::tm utc{};
+#ifdef _WIN32
+    if (gmtime_s(&utc, &time) != 0) return {};
+#else
+    if (gmtime_r(&time, &utc) == nullptr) return {};
+#endif
+    std::ostringstream output;
+    output << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+    auto result = output ? output.str() : std::string{};
+    return result.size() == 20 ? result : std::string{};
+}
+
+void append_u64(std::string &bytes, std::uint64_t value) {
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        bytes.push_back(static_cast<char>((value >> shift) & 0xffu));
+    }
+}
+
+void append_string(std::string &bytes, std::string_view value) {
+    append_u64(bytes, static_cast<std::uint64_t>(value.size()));
+    bytes.append(value.data(), value.size());
+}
+
+std::optional<std::string> sha256_hex(std::string_view bytes) {
+    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    if (info == nullptr) return std::nullopt;
+
+    mbedtls_md_context_t context;
+    mbedtls_md_init(&context);
+    std::array<unsigned char, 32> digest{};
+    const bool failed =
+        mbedtls_md_setup(&context, info, 0) != 0 ||
+        mbedtls_md_starts(&context) != 0 ||
+        mbedtls_md_update(&context,
+                          reinterpret_cast<const unsigned char *>(bytes.data()),
+                          bytes.size()) != 0 ||
+        mbedtls_md_finish(&context, digest.data()) != 0;
+    mbedtls_md_free(&context);
+    if (failed) return std::nullopt;
+
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(64);
+    for (const auto byte : digest) {
+        result.push_back(hex[(byte >> 4) & 0x0f]);
+        result.push_back(hex[byte & 0x0f]);
+    }
+    return result;
+}
+
+std::optional<std::string>
+derivation_contract_digest(const ProfilingDerivationContract &contract) {
+    if (!contract_is_valid(contract)) return std::nullopt;
+
+    auto sensors = contract.sensors;
+    std::sort(sensors.begin(), sensors.end(),
+              [](const ProfilingSensorContract &left,
+                 const ProfilingSensorContract &right) {
+                  return std::tie(left.sensor_id, left.constraint_id,
+                                  left.claim_family, left.uncertainty_bound,
+                                  left.safety_ceiling) <
+                         std::tie(right.sensor_id, right.constraint_id,
+                                  right.claim_family, right.uncertainty_bound,
+                                  right.safety_ceiling);
+              });
+    auto owner_scope_ids = contract.owner_scope_ids;
+    std::sort(owner_scope_ids.begin(), owner_scope_ids.end());
+
+    std::string bytes = "lemonade/profiling-derivation-contract/v1";
+    append_string(bytes, contract.provider_id);
+    append_string(bytes, contract.provider_revision_sha256);
+    append_u64(bytes, static_cast<std::uint64_t>(sensors.size()));
+    for (const auto &sensor : sensors) {
+        const auto unit = expected_unit(sensor.claim_family);
+        if (!unit) return std::nullopt;
+        append_string(bytes, sensor.sensor_id);
+        append_string(bytes, sensor.constraint_id);
+        append_string(bytes, claim_family_wire(sensor.claim_family));
+        append_string(bytes, claim_unit_wire(*unit));
+        append_u64(bytes, sensor.uncertainty_bound);
+        append_u64(bytes, sensor.safety_ceiling);
+    }
+    append_u64(bytes, static_cast<std::uint64_t>(owner_scope_ids.size()));
+    for (const auto &owner_scope_id : owner_scope_ids) {
+        append_string(bytes, owner_scope_id);
+    }
+    append_u64(bytes,
+               static_cast<std::uint64_t>(contract.freshness_window.count()));
+    append_u64(bytes,
+               static_cast<std::uint64_t>(contract.max_source_skew.count()));
+    return sha256_hex(bytes);
+}
+
+std::optional<std::string>
+raw_provenance_digest(const ProfilingTransactionContext &context,
+                      const std::vector<ProfilingRawSample> &input_samples,
+                      std::string_view observed_at) {
+    auto samples = input_samples;
+    std::sort(
+        samples.begin(), samples.end(),
+        [](const ProfilingRawSample &left, const ProfilingRawSample &right) {
+            return std::tie(left.sensor_id, left.owner_scope_id, left.value,
+                            left.source_generation) <
+                   std::tie(right.sensor_id, right.owner_scope_id, right.value,
+                            right.source_generation);
+        });
+
+    std::string bytes = "lemonade/profiling-raw-observation/v1";
+    append_string(bytes, context.deployment_id);
+    append_string(bytes, context.profiling_transaction_id);
+    append_string(bytes, context.selector_sha256);
+    append_string(bytes, context.observation_contract_sha256);
+    append_string(bytes, observed_at);
+    append_u64(bytes, static_cast<std::uint64_t>(samples.size()));
+    for (const auto &sample : samples) {
+        append_string(bytes, sample.sensor_id);
+        bytes.push_back(sample.owner_scope_id.has_value() ? '\1' : '\0');
+        if (sample.owner_scope_id) append_string(bytes, *sample.owner_scope_id);
+        append_u64(bytes, sample.value);
+        append_u64(bytes, sample.source_generation);
+    }
+    return sha256_hex(bytes);
+}
+
+using ClaimEntries = std::array<std::vector<ClaimAmount>, claim_family_count>;
+
+std::vector<ClaimFamilyClosure>
+claim_closure(const ProfilingDerivationContract &contract,
+              const std::vector<std::uint64_t> &amounts) {
+    ClaimEntries entries;
+    std::array<bool, claim_family_count> represented{};
+    for (std::size_t index = 0; index < contract.sensors.size(); ++index) {
+        const auto &sensor = contract.sensors[index];
+        const auto family = family_index(sensor.claim_family);
+        if (!family) return {};
+        represented[*family] = true;
+        if (amounts[index] > 0) {
+            const auto unit = expected_unit(sensor.claim_family);
+            if (!unit) return {};
+            entries[*family].push_back(
+                ClaimAmount{sensor.constraint_id, *unit, amounts[index]});
+        }
+    }
+
+    std::vector<ClaimFamilyClosure> result;
+    result.reserve(claim_family_count);
+    for (std::size_t index = 0; index < claim_family_count; ++index) {
+        auto completeness = ClaimCompleteness::NotApplicable;
+        if (represented[index]) {
+            completeness = entries[index].empty() ? ClaimCompleteness::KnownZero
+                                                  : ClaimCompleteness::Bounded;
+        }
+        result.push_back(ClaimFamilyClosure{family_at(index), completeness,
+                                            std::move(entries[index])});
+    }
+    return result;
+}
+
+std::optional<std::uint64_t>
+source_generation(const std::vector<ProfilingRawSample> &samples) noexcept {
+    if (samples.empty() || samples.front().source_generation == 0) {
+        return std::nullopt;
+    }
+    const auto generation = samples.front().source_generation;
+    for (const auto &sample : samples) {
+        if (sample.source_generation != generation) return std::nullopt;
+    }
+    return generation;
+}
+
+std::optional<std::vector<SensorValues>>
+reconcile_samples(const ProfilingDerivationContract &contract,
+                  const std::vector<ProfilingRawSample> &samples) {
+    if (contract.sensors.size() > std::numeric_limits<std::size_t>::max() /
+                                      (contract.owner_scope_ids.size() + 1)) {
+        return std::nullopt;
+    }
+    const auto expected_count =
+        contract.sensors.size() * (contract.owner_scope_ids.size() + 1);
+    if (samples.size() != expected_count) return std::nullopt;
+
+    std::map<std::string, std::size_t> sensor_indices;
+    for (std::size_t index = 0; index < contract.sensors.size(); ++index) {
+        sensor_indices.emplace(contract.sensors[index].sensor_id, index);
+    }
+    const std::set<std::string> owner_scope_ids(
+        contract.owner_scope_ids.begin(), contract.owner_scope_ids.end());
+
+    std::vector<SensorValues> values(contract.sensors.size());
+    for (const auto &sample : samples) {
+        const auto sensor = sensor_indices.find(sample.sensor_id);
+        if (sensor == sensor_indices.end()) return std::nullopt;
+        auto &sensor_values = values[sensor->second];
+        if (!sample.owner_scope_id) {
+            if (sensor_values.total.has_value()) return std::nullopt;
+            sensor_values.total = sample.value;
+            continue;
+        }
+        if (owner_scope_ids.count(*sample.owner_scope_id) == 0 ||
+            !sensor_values.owners.emplace(*sample.owner_scope_id, sample.value)
+                 .second) {
+            return std::nullopt;
+        }
+    }
+
+    for (auto &sensor_values : values) {
+        if (!sensor_values.total ||
+            sensor_values.owners.size() != contract.owner_scope_ids.size()) {
+            return std::nullopt;
+        }
+        for (const auto &owner_scope_id : contract.owner_scope_ids) {
+            const auto owner = sensor_values.owners.find(owner_scope_id);
+            if (owner == sensor_values.owners.end() ||
+                owner->second > std::numeric_limits<std::uint64_t>::max() -
+                                    sensor_values.attributed_total) {
+                return std::nullopt;
+            }
+            sensor_values.attributed_total += owner->second;
+        }
+        if (sensor_values.attributed_total != *sensor_values.total) {
+            return std::nullopt;
+        }
+    }
+    return values;
+}
+
+std::optional<SteadyClock::duration>
+elapsed_between(SteadyClock::time_point started,
+                SteadyClock::time_point finished) noexcept {
+    using Rep = SteadyClock::duration::rep;
+    static_assert(std::is_integral_v<Rep>);
+
+    const auto start = count_as_i64(started.time_since_epoch().count());
+    const auto finish = count_as_i64(finished.time_since_epoch().count());
+    if (!start || !finish || *finish < *start) return std::nullopt;
+
+    std::uint64_t ticks = 0;
+    if (*start < 0 && *finish >= 0) {
+        const auto magnitude =
+            static_cast<std::uint64_t>(-(*start + 1)) + 1;
+        ticks = magnitude + static_cast<std::uint64_t>(*finish);
+    } else {
+        ticks = static_cast<std::uint64_t>(*finish - *start);
+    }
+    if constexpr (std::is_signed_v<Rep>) {
+        if (ticks > static_cast<std::uint64_t>(
+                        std::numeric_limits<Rep>::max())) {
+            return std::nullopt;
+        }
+    } else if constexpr (std::numeric_limits<Rep>::digits <
+                         std::numeric_limits<std::uint64_t>::digits) {
+        if (ticks > static_cast<std::uint64_t>(
+                        std::numeric_limits<Rep>::max())) {
+            return std::nullopt;
+        }
+    }
+    return SteadyClock::duration(static_cast<Rep>(ticks));
+}
+
+std::optional<std::uint64_t>
+rounded_up_milliseconds(SteadyClock::duration elapsed) noexcept {
+    using Scale = std::ratio_divide<SteadyClock::duration::period,
+                                    std::chrono::milliseconds::period>;
+    const auto ticks = count_as_i64(elapsed.count());
+    if (!ticks || *ticks < 0) return std::nullopt;
+
+    static_assert(Scale::num > 0 && Scale::den > 0);
+    const auto numerator = static_cast<std::uint64_t>(Scale::num);
+    const auto denominator = static_cast<std::uint64_t>(Scale::den);
+    const auto unsigned_ticks = static_cast<std::uint64_t>(*ticks);
+    if (unsigned_ticks >
+        std::numeric_limits<std::uint64_t>::max() / numerator) {
+        return std::nullopt;
+    }
+    const auto scaled = unsigned_ticks * numerator;
+    auto milliseconds = scaled / denominator;
+    if (scaled % denominator != 0) {
+        if (milliseconds == std::numeric_limits<std::uint64_t>::max()) {
+            return std::nullopt;
+        }
+        ++milliseconds;
+    }
+    return milliseconds;
+}
+
+} // namespace
+
+std::optional<std::string> profiling_derivation_contract_sha256(
+    const ProfilingDerivationContract &contract) {
+    return derivation_contract_digest(contract);
+}
+
+ProfilingRawReadResult UnavailableProfilingObservationSource::read(
+    const ProfilingRawReadRequest &, const ProfilingCancellationCheck &) {
+    return ProfilingRawReadResult{
+        ProfilingSourceError::Unavailable,
+        {},
+        "profiling observation source is unavailable",
+    };
+}
+
+bool ProfilingObservationCollectionResult::accepted() const noexcept {
+    return status == ProfilingCollectionStatus::Accepted &&
+           observation.has_value();
+}
+
+ProfilingObservationCollector::ProfilingObservationCollector(
+    ProfilingDerivationContract contract, ProfilingCollectionClock clock)
+    : contract_(std::move(contract)), source_(&unavailable_source_),
+      clock_(std::move(clock)) {
+    if (!clock_.monotonic_now) {
+        clock_.monotonic_now = [] { return SteadyClock::now(); };
+    }
+    if (!clock_.utc_now) clock_.utc_now = [] { return SystemClock::now(); };
+}
+
+ProfilingObservationCollector::ProfilingObservationCollector(
+    ProfilingDerivationContract contract, ProfilingObservationSource &source,
+    ProfilingCollectionClock clock)
+    : contract_(std::move(contract)), source_(&source),
+      clock_(std::move(clock)) {
+    if (!clock_.monotonic_now) {
+        clock_.monotonic_now = [] { return SteadyClock::now(); };
+    }
+    if (!clock_.utc_now) clock_.utc_now = [] { return SystemClock::now(); };
+}
+
+ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
+    const ProfilingTransactionContext &context,
+    const ProfilingCancellationCheck &should_abort) {
+    try {
+        if (!contract_is_valid(contract_)) {
+            return result_for(ProfilingCollectionStatus::InvalidContract,
+                              "profiling derivation contract is invalid");
+        }
+        const auto contract_sha256 = derivation_contract_digest(contract_);
+        if (!contract_sha256) {
+            return result_for(
+                ProfilingCollectionStatus::DigestUnavailable,
+                "profiling derivation contract digest is unavailable");
+        }
+        if (context.observation_contract_sha256 != *contract_sha256) {
+            return result_for(ProfilingCollectionStatus::InvalidContract,
+                              "profiling derivation contract identity does not "
+                              "match context");
+        }
+        if (cancelled(should_abort)) {
+            return result_for(ProfilingCollectionStatus::Cancelled,
+                              "profiling observation collection cancelled");
+        }
+
+        const auto started = clock_.monotonic_now();
+        const auto observed_time = clock_.utc_now();
+        const auto observed_seconds =
+            observed_time >= SystemClock::time_point{}
+                ? system_clock_seconds(observed_time)
+                : std::nullopt;
+        const auto freshness_seconds =
+            count_as_i64(contract_.freshness_window.count());
+        const auto fresh_seconds =
+            observed_seconds && freshness_seconds
+                ? checked_add(*observed_seconds, *freshness_seconds)
+                : std::nullopt;
+        const auto observed_at =
+            observed_seconds ? format_utc(*observed_seconds) : std::string{};
+        const auto fresh_until =
+            fresh_seconds && system_clock_contains_seconds(*fresh_seconds)
+                ? format_utc(*fresh_seconds)
+                : std::string{};
+        if (observed_at.empty() || fresh_until.empty()) {
+            return result_for(ProfilingCollectionStatus::InvalidObservation,
+                              "profiling collection clock is unavailable");
+        }
+
+        ProfilingRawReadRequest request;
+        request.sensor_ids.reserve(contract_.sensors.size());
+        for (const auto &sensor : contract_.sensors) {
+            request.sensor_ids.push_back(sensor.sensor_id);
+        }
+        request.owner_scope_ids = contract_.owner_scope_ids;
+
+        ProfilingRawReadResult raw;
+        try {
+            raw = source_->read(request, should_abort);
+        } catch (...) {
+            return result_for(ProfilingCollectionStatus::EvidenceUnavailable,
+                              "profiling observation source failed");
+        }
+        const auto finished = clock_.monotonic_now();
+
+        if (cancelled(should_abort) ||
+            raw.error == ProfilingSourceError::Cancelled) {
+            return result_for(ProfilingCollectionStatus::Cancelled,
+                              raw.diagnostic.empty()
+                                  ? "profiling observation collection cancelled"
+                                  : std::move(raw.diagnostic));
+        }
+        if (raw.error != ProfilingSourceError::None) {
+            return result_for(
+                ProfilingCollectionStatus::EvidenceUnavailable,
+                raw.diagnostic.empty()
+                    ? "profiling observation source is unavailable"
+                    : std::move(raw.diagnostic));
+        }
+        const auto elapsed = elapsed_between(started, finished);
+        const auto skew = elapsed ? rounded_up_milliseconds(*elapsed)
+                                  : std::nullopt;
+        if (!raw.diagnostic.empty() || !skew) {
+            return result_for(ProfilingCollectionStatus::InvalidObservation,
+                              "profiling raw observation is incoherent");
+        }
+
+        if (*skew >
+            static_cast<std::uint64_t>(contract_.max_source_skew.count())) {
+            return result_for(ProfilingCollectionStatus::InvalidObservation,
+                              "profiling source skew exceeds the contract");
+        }
+        const auto generation = source_generation(raw.samples);
+        const auto values = reconcile_samples(contract_, raw.samples);
+        if (!generation || !values) {
+            return result_for(ProfilingCollectionStatus::InvalidObservation,
+                              "profiling raw observation does not close");
+        }
+
+        std::vector<std::uint64_t> observed;
+        std::vector<std::uint64_t> attributed;
+        std::vector<std::uint64_t> uncertainty;
+        std::vector<std::uint64_t> safety_margin;
+        observed.reserve(values->size());
+        attributed.reserve(values->size());
+        uncertainty.reserve(values->size());
+        safety_margin.reserve(values->size());
+        for (std::size_t index = 0; index < values->size(); ++index) {
+            const auto amount = *(*values)[index].total;
+            const auto &sensor = contract_.sensors[index];
+            if (amount >= sensor.safety_ceiling) {
+                return result_for(ProfilingCollectionStatus::InvalidObservation,
+                                  "profiling observation meets or exceeds its "
+                                  "safety ceiling");
+            }
+            const auto remaining = sensor.safety_ceiling - amount;
+            if (sensor.uncertainty_bound >= remaining) {
+                return result_for(ProfilingCollectionStatus::InvalidObservation,
+                                  "profiling safety margin is not positive");
+            }
+            observed.push_back(amount);
+            attributed.push_back((*values)[index].attributed_total);
+            uncertainty.push_back(sensor.uncertainty_bound);
+            safety_margin.push_back(remaining - sensor.uncertainty_bound);
+        }
+
+        const auto provenance =
+            raw_provenance_digest(context, raw.samples, observed_at);
+        if (!provenance) {
+            return result_for(ProfilingCollectionStatus::DigestUnavailable,
+                              "profiling provenance digest is unavailable");
+        }
+
+        ProfilingDerivedObservation observation;
+        observation.provider_id = contract_.provider_id;
+        observation.provider_revision_sha256 =
+            contract_.provider_revision_sha256;
+        observation.raw_provenance_sha256 = *provenance;
+        observation.observation_contract_sha256 = *contract_sha256;
+        observation.observation_generation = *generation;
+        observation.observed_at = observed_at;
+        observation.fresh_until = fresh_until;
+        observation.source_skew_milliseconds = *skew;
+        observation.max_source_skew_milliseconds =
+            static_cast<std::uint64_t>(contract_.max_source_skew.count());
+        observation.health = ProfilingObservationHealth::Valid;
+        observation.owner_coverage = ProfilingOwnerCoverage::Complete;
+        observation.observed_claims = claim_closure(contract_, observed);
+        observation.attributed_claims = claim_closure(contract_, attributed);
+        observation.uncertainty_claims = claim_closure(contract_, uncertainty);
+        observation.safety_margin_claims =
+            claim_closure(contract_, safety_margin);
+
+        return ProfilingObservationCollectionResult{
+            ProfilingCollectionStatus::Accepted,
+            {},
+            std::move(observation),
+        };
+    } catch (...) {
+        return result_for(ProfilingCollectionStatus::InvalidObservation,
+                          "profiling observation collection failed");
+    }
+}
+
+} // namespace lemon::residency

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -1,6 +1,10 @@
 #include "lemon/residency/profiling_provider.h"
 
 #include <mbedtls/md.h>
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR >= 4
+#include <psa/crypto.h>
+#endif
 
 #include <algorithm>
 #include <array>
@@ -10,6 +14,7 @@
 #include <iomanip>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <ratio>
 #include <set>
@@ -282,6 +287,14 @@ void append_string(std::string &bytes, std::string_view value) {
 }
 
 std::optional<std::string> sha256_hex(std::string_view bytes) {
+#if MBEDTLS_VERSION_MAJOR >= 4
+    static std::once_flag initialized;
+    static psa_status_t initialization_status = PSA_ERROR_BAD_STATE;
+    std::call_once(initialized,
+                   [] { initialization_status = psa_crypto_init(); });
+    if (initialization_status != PSA_SUCCESS) return std::nullopt;
+#endif
+
     const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     if (info == nullptr) return std::nullopt;
 

--- a/test/cpp/test_residency_profiling_provider.cpp
+++ b/test/cpp/test_residency_profiling_provider.cpp
@@ -1,0 +1,777 @@
+#include "lemon/residency/profiling_provider.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+using namespace lemon::residency;
+
+template <typename T, typename = void>
+struct HasClaimFamily : std::false_type {};
+template <typename T>
+struct HasClaimFamily<T, std::void_t<decltype(std::declval<T>().claim_family)>>
+    : std::true_type {};
+
+template <typename T, typename = void> struct HasUnit : std::false_type {};
+template <typename T>
+struct HasUnit<T, std::void_t<decltype(std::declval<T>().unit)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasObservedAt : std::false_type {};
+template <typename T>
+struct HasObservedAt<T, std::void_t<decltype(std::declval<T>().observed_at)>>
+    : std::true_type {};
+
+template <typename T, typename = void> struct HasHealth : std::false_type {};
+template <typename T>
+struct HasHealth<T, std::void_t<decltype(std::declval<T>().health)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasCompleteness : std::false_type {};
+template <typename T>
+struct HasCompleteness<T, std::void_t<decltype(std::declval<T>().completeness)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasSafetyMargin : std::false_type {};
+template <typename T>
+struct HasSafetyMargin<T,
+                       std::void_t<decltype(std::declval<T>().safety_margin)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasFreshUntil : std::false_type {};
+template <typename T>
+struct HasFreshUntil<T, std::void_t<decltype(std::declval<T>().fresh_until)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasOwnerCoverage : std::false_type {};
+template <typename T>
+struct HasOwnerCoverage<T,
+                        std::void_t<decltype(std::declval<T>().owner_coverage)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasLifecycleState : std::false_type {};
+template <typename T>
+struct HasLifecycleState<
+    T, std::void_t<decltype(std::declval<T>().lifecycle_state)>>
+    : std::true_type {};
+
+template <typename T, typename = void> struct HasPhase : std::false_type {};
+template <typename T>
+struct HasPhase<T, std::void_t<decltype(std::declval<T>().phase)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasUncertaintyClaims : std::false_type {};
+template <typename T>
+struct HasUncertaintyClaims<
+    T, std::void_t<decltype(std::declval<T>().uncertainty_claims)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasSafetyMarginClaims : std::false_type {};
+template <typename T>
+struct HasSafetyMarginClaims<
+    T, std::void_t<decltype(std::declval<T>().safety_margin_claims)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasExternalChangeClaims : std::false_type {};
+template <typename T>
+struct HasExternalChangeClaims<
+    T, std::void_t<decltype(std::declval<T>().external_change_claims)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasUnattributedClaims : std::false_type {};
+template <typename T>
+struct HasUnattributedClaims<
+    T, std::void_t<decltype(std::declval<T>().unattributed_claims)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasAttestation : std::false_type {};
+template <typename T>
+struct HasAttestation<T, std::void_t<decltype(std::declval<T>().attestation)>>
+    : std::true_type {};
+
+static_assert(
+    std::is_same_v<decltype(ProfilingRawSample::sensor_id), std::string>);
+static_assert(std::is_same_v<decltype(ProfilingRawSample::owner_scope_id),
+                             std::optional<std::string>>);
+static_assert(
+    std::is_same_v<decltype(ProfilingRawSample::value), std::uint64_t>);
+static_assert(std::is_same_v<decltype(ProfilingRawSample::source_generation),
+                             std::uint64_t>);
+static_assert(!HasClaimFamily<ProfilingRawSample>::value);
+static_assert(!HasUnit<ProfilingRawSample>::value);
+static_assert(!HasObservedAt<ProfilingRawSample>::value);
+static_assert(!HasHealth<ProfilingRawSample>::value);
+static_assert(!HasCompleteness<ProfilingRawSample>::value);
+static_assert(!HasSafetyMargin<ProfilingRawSample>::value);
+static_assert(!HasFreshUntil<ProfilingRawSample>::value);
+static_assert(!HasOwnerCoverage<ProfilingRawSample>::value);
+static_assert(!HasLifecycleState<ProfilingRawSample>::value);
+static_assert(!HasUncertaintyClaims<ProfilingRawSample>::value);
+static_assert(!HasAttestation<ProfilingRawSample>::value);
+static_assert(!HasHealth<ProfilingRawReadResult>::value);
+static_assert(!HasFreshUntil<ProfilingRawReadResult>::value);
+static_assert(!HasOwnerCoverage<ProfilingRawReadResult>::value);
+static_assert(!HasLifecycleState<ProfilingRawReadResult>::value);
+static_assert(!HasUncertaintyClaims<ProfilingRawReadResult>::value);
+static_assert(!HasAttestation<ProfilingRawReadResult>::value);
+static_assert(!HasUncertaintyClaims<ProfilingDerivationContract>::value);
+static_assert(!HasSafetyMarginClaims<ProfilingDerivationContract>::value);
+static_assert(!HasPhase<ProfilingDerivedObservation>::value);
+static_assert(!HasLifecycleState<ProfilingDerivedObservation>::value);
+static_assert(!HasAttestation<ProfilingDerivedObservation>::value);
+static_assert(!HasExternalChangeClaims<ProfilingDerivedObservation>::value);
+static_assert(!HasUnattributedClaims<ProfilingDerivedObservation>::value);
+static_assert(!HasPhase<ProfilingObservationCollectionResult>::value);
+static_assert(!HasLifecycleState<ProfilingObservationCollectionResult>::value);
+static_assert(!HasAttestation<ProfilingObservationCollectionResult>::value);
+static_assert(
+    std::is_same_v<decltype(ProfilingSensorContract::uncertainty_bound),
+                   std::uint64_t>);
+static_assert(std::is_same_v<decltype(ProfilingSensorContract::safety_ceiling),
+                             std::uint64_t>);
+static_assert(!noexcept(std::declval<ProfilingObservationCollector &>().collect(
+    std::declval<const ProfilingTransactionContext &>(),
+    std::declval<const ProfilingCancellationCheck &>())));
+
+struct TestState {
+    std::atomic<bool> ok{true};
+
+    void require(bool condition, const char *message) {
+        if (condition) return;
+        ok.store(false);
+        std::cerr << "FAIL: " << message << '\n';
+    }
+};
+
+void test_default_source_is_unavailable(TestState &state) {
+    UnavailableProfilingObservationSource source;
+    ProfilingRawReadRequest request{{"sensor/gtt-used"}, {"owner/model-alpha"}};
+
+    const auto result = source.read(request, [] { return false; });
+
+    state.require(result.error == ProfilingSourceError::Unavailable,
+                  "the production source defaults to unavailable");
+    state.require(result.samples.empty(),
+                  "the unavailable source cannot return partial samples");
+    state.require(result.diagnostic ==
+                      "profiling observation source is unavailable",
+                  "the unavailable source reports a stable diagnostic");
+}
+
+std::string digest(char value) { return std::string(64, value); }
+
+constexpr char known_contract_sha256[] =
+    "a1abcdbffca73bbd6f0238f9ff647c417aa46734a364ad78c709f53fe0a963d1";
+
+ProfilingDerivationContract contract() {
+    ProfilingDerivationContract value;
+    value.provider_id = "provider/scripted-raw";
+    value.provider_revision_sha256 = digest('e');
+    value.sensors = {
+        ProfilingSensorContract{"sensor/gtt-used", "gpu/gtt",
+                                ClaimFamily::ConsumableCapacity, 512, 4864},
+    };
+    value.owner_scope_ids = {"owner/model-alpha"};
+    value.freshness_window = std::chrono::seconds(60);
+    value.max_source_skew = std::chrono::milliseconds(20);
+    return value;
+}
+
+ProfilingTransactionContext
+context(const ProfilingDerivationContract &derivation_contract = contract()) {
+    const auto contract_sha256 =
+        profiling_derivation_contract_sha256(derivation_contract);
+    if (!contract_sha256) {
+        throw std::runtime_error("test derivation contract is invalid");
+    }
+
+    ProfilingTransactionContext value;
+    value.deployment_id = digest('a');
+    value.sequence = 1;
+    value.profiling_transaction_id = "profile/raw-provider";
+    value.selector_sha256 = digest('b');
+    value.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    value.observation_contract_sha256 = *contract_sha256;
+    value.predictor_contract_sha256 = digest('d');
+    return value;
+}
+
+ProfilingCollectionClock clock(
+    std::chrono::milliseconds elapsed = std::chrono::milliseconds(10),
+    std::chrono::system_clock::time_point utc =
+        std::chrono::system_clock::time_point{} + std::chrono::seconds(1000)) {
+    auto times =
+        std::make_shared<std::deque<std::chrono::steady_clock::time_point>>();
+    times->push_back(std::chrono::steady_clock::time_point{});
+    times->push_back(std::chrono::steady_clock::time_point{} + elapsed);
+    ProfilingCollectionClock value;
+    value.monotonic_now = [times] {
+        const auto result = times->front();
+        times->pop_front();
+        return result;
+    };
+    value.utc_now = [utc] { return utc; };
+    return value;
+}
+
+ProfilingRawReadResult successful_read(std::uint64_t total = 4096,
+                                       std::uint64_t owner = 4096,
+                                       std::uint64_t generation = 7) {
+    return ProfilingRawReadResult{
+        ProfilingSourceError::None,
+        {
+            ProfilingRawSample{"sensor/gtt-used", std::nullopt, total,
+                               generation},
+            ProfilingRawSample{"sensor/gtt-used", "owner/model-alpha", owner,
+                               generation},
+        },
+        {},
+    };
+}
+
+class ScriptedProfilingObservationSource final
+    : public ProfilingObservationSource {
+public:
+    explicit ScriptedProfilingObservationSource(
+        std::deque<ProfilingRawReadResult> script,
+        std::function<void()> on_read = {})
+        : script_(std::move(script)), on_read_(std::move(on_read)) {}
+
+    ProfilingRawReadResult
+    read(const ProfilingRawReadRequest &request,
+         const ProfilingCancellationCheck &should_abort) override {
+        requests.push_back(request);
+        if (on_read_) on_read_();
+        if (should_abort && should_abort()) {
+            return ProfilingRawReadResult{
+                ProfilingSourceError::Cancelled, {}, "scripted read cancelled"};
+        }
+        if (script_.empty()) {
+            return ProfilingRawReadResult{
+                ProfilingSourceError::Unavailable, {}, "script exhausted"};
+        }
+        auto result = std::move(script_.front());
+        script_.pop_front();
+        return result;
+    }
+
+    std::vector<ProfilingRawReadRequest> requests;
+
+private:
+    std::deque<ProfilingRawReadResult> script_;
+    std::function<void()> on_read_;
+};
+
+class ThrowingProfilingObservationSource final
+    : public ProfilingObservationSource {
+public:
+    ProfilingRawReadResult read(const ProfilingRawReadRequest &,
+                                const ProfilingCancellationCheck &) override {
+        throw std::runtime_error("adapter failure");
+    }
+};
+
+const ClaimFamilyClosure *family(const std::vector<ClaimFamilyClosure> &claims,
+                                 ClaimFamily wanted) {
+    for (const auto &candidate : claims) {
+        if (candidate.family == wanted) return &candidate;
+    }
+    return nullptr;
+}
+
+void require_capacity(TestState &state,
+                      const std::vector<ClaimFamilyClosure> &claims,
+                      std::uint64_t expected, const char *message) {
+    const auto *capacity = family(claims, ClaimFamily::ConsumableCapacity);
+    const bool matches = capacity != nullptr &&
+                         capacity->completeness == ClaimCompleteness::Bounded &&
+                         capacity->entries.size() == 1 &&
+                         capacity->entries.front().constraint_id == "gpu/gtt" &&
+                         capacity->entries.front().unit == ClaimUnit::Bytes &&
+                         capacity->entries.front().amount == expected;
+    state.require(matches, message);
+}
+
+void test_derivation_contract_identity(TestState &state) {
+    const auto derivation_contract = contract();
+    const auto identity =
+        profiling_derivation_contract_sha256(derivation_contract);
+    state.require(identity.has_value(),
+                  "a valid derivation contract has an identity");
+    if (identity) {
+        state.require(
+            *identity == known_contract_sha256,
+            "the derivation contract identity uses the canonical encoding");
+    }
+
+    auto reordered = derivation_contract;
+    reordered.sensors.push_back(ProfilingSensorContract{
+        "sensor/vram-used", "gpu/vram", ClaimFamily::ConsumableCapacity, 1, 5});
+    reordered.owner_scope_ids.push_back("owner/model-beta");
+    auto canonical = reordered;
+    std::reverse(reordered.sensors.begin(), reordered.sensors.end());
+    std::reverse(reordered.owner_scope_ids.begin(),
+                 reordered.owner_scope_ids.end());
+    const auto canonical_identity =
+        profiling_derivation_contract_sha256(canonical);
+    const auto reordered_identity =
+        profiling_derivation_contract_sha256(reordered);
+    state.require(
+        canonical_identity.has_value() && reordered_identity.has_value() &&
+            canonical_identity == reordered_identity,
+        "sensor and owner ordering does not change contract identity");
+
+    auto invalid = derivation_contract;
+    invalid.sensors.front().safety_ceiling =
+        invalid.sensors.front().uncertainty_bound;
+    state.require(!profiling_derivation_contract_sha256(invalid).has_value(),
+                  "an invalid derivation contract has no identity");
+}
+
+void test_stale_contract_identity_fails_before_source_access(TestState &state) {
+    struct Mutation {
+        const char *message;
+        std::function<void(ProfilingDerivationContract &)> apply;
+    };
+    const std::vector<Mutation> mutations{
+        {"provider identity is bound",
+         [](auto &value) { value.provider_id = "provider/scripted-raw-v2"; }},
+        {"provider revision is bound",
+         [](auto &value) { value.provider_revision_sha256 = digest('f'); }},
+        {"sensor identity is bound",
+         [](auto &value) {
+             value.sensors.front().sensor_id = "sensor/gtt-used-v2";
+         }},
+        {"constraint mapping is bound",
+         [](auto &value) {
+             value.sensors.front().constraint_id = "gpu/gtt-v2";
+         }},
+        {"uncertainty policy is bound",
+         [](auto &value) { value.sensors.front().uncertainty_bound = 513; }},
+        {"safety policy is bound",
+         [](auto &value) { value.sensors.front().safety_ceiling = 4865; }},
+        {"owner scopes are bound",
+         [](auto &value) {
+             value.owner_scope_ids.front() = "owner/model-beta";
+         }},
+        {"freshness policy is bound",
+         [](auto &value) { value.freshness_window = 61s; }},
+        {"source skew policy is bound",
+         [](auto &value) { value.max_source_skew = 21ms; }},
+    };
+
+    const auto stale_context = context();
+    for (const auto &mutation : mutations) {
+        auto changed_contract = contract();
+        mutation.apply(changed_contract);
+        const auto changed_identity =
+            profiling_derivation_contract_sha256(changed_contract);
+        state.require(changed_identity.has_value() &&
+                          *changed_identity !=
+                              stale_context.observation_contract_sha256,
+                      "a stale-identity fixture remains a valid changed contract");
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(std::move(changed_contract),
+                                                source, clock());
+
+        const auto result =
+            collector.collect(stale_context, [] { return false; });
+
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidContract &&
+                          !result.observation.has_value(),
+                      mutation.message);
+        state.require(source.requests.empty(),
+                      "a stale contract identity cannot enter the source");
+    }
+}
+
+void test_collector_derives_observation_from_raw_samples(TestState &state) {
+    const auto derivation_contract = contract();
+    auto transaction_context = context(derivation_contract);
+    transaction_context.observation_contract_sha256 = known_contract_sha256;
+    ScriptedProfilingObservationSource source({successful_read()});
+    ProfilingObservationCollector collector(derivation_contract, source,
+                                            clock());
+
+    const auto result =
+        collector.collect(transaction_context, [] { return false; });
+
+    state.require(result.accepted(), "a closed raw batch is accepted");
+    state.require(result.observation.has_value(),
+                  "an accepted batch yields a derived observation");
+    if (!result.observation) return;
+
+    const auto &observation = *result.observation;
+    state.require(observation.provider_id == "provider/scripted-raw",
+                  "the Server assigns provider identity from its contract");
+    state.require(
+        observation.observation_contract_sha256 ==
+            transaction_context.observation_contract_sha256,
+        "the derived observation carries the matched contract identity");
+    state.require(observation.observation_generation == 7,
+                  "the Server derives the coherent native generation");
+    state.require(observation.observed_at == "1970-01-01T00:16:40Z",
+                  "the Server assigns observation time");
+    state.require(observation.fresh_until == "1970-01-01T00:17:40Z",
+                  "the Server derives freshness");
+    state.require(observation.source_skew_milliseconds == 10,
+                  "the Server derives source skew");
+    state.require(observation.health == ProfilingObservationHealth::Valid,
+                  "the Server derives valid health only after closure");
+    state.require(observation.owner_coverage ==
+                      ProfilingOwnerCoverage::Complete,
+                  "the Server derives complete owner coverage");
+    require_capacity(state, observation.observed_claims, 4096,
+                     "the Server derives observed claims");
+    require_capacity(state, observation.attributed_claims, 4096,
+                     "the Server derives attributed claims");
+    require_capacity(state, observation.uncertainty_claims, 512,
+                     "the Server derives uncertainty from policy");
+    require_capacity(state, observation.safety_margin_claims, 256,
+                     "the Server derives safety margin from policy");
+
+    state.require(source.requests.size() == 1,
+                  "the collector performs one deterministic read");
+    if (!source.requests.empty()) {
+        state.require(source.requests.front().sensor_ids ==
+                          std::vector<std::string>{"sensor/gtt-used"},
+                      "the Server selects source sensors");
+        state.require(source.requests.front().owner_scope_ids ==
+                          std::vector<std::string>{"owner/model-alpha"},
+                      "the Server supplies owner scopes");
+    }
+}
+
+void test_freshness_is_anchored_before_read(TestState &state) {
+    auto utc = std::make_shared<std::chrono::system_clock::time_point>(
+        std::chrono::system_clock::time_point{} + 1000s);
+    auto collection_clock = clock();
+    collection_clock.utc_now = [utc] { return *utc; };
+    ScriptedProfilingObservationSource source({successful_read()}, [utc] {
+        *utc = std::chrono::system_clock::time_point{} + 2000s;
+    });
+    ProfilingObservationCollector collector(contract(), source,
+                                            std::move(collection_clock));
+
+    const auto result = collector.collect(context(), [] { return false; });
+
+    state.require(result.accepted() && result.observation.has_value(),
+                  "a coherent observation remains accepted");
+    if (!result.observation) return;
+    state.require(result.observation->observed_at == "1970-01-01T00:16:40Z",
+                  "observation time is captured before source access");
+    state.require(result.observation->fresh_until == "1970-01-01T00:17:40Z",
+                  "freshness starts at the oldest possible acquisition time");
+}
+
+void test_collector_fails_closed(TestState &state) {
+    {
+        auto invalid_contract = contract();
+        invalid_contract.sensors.front().safety_ceiling =
+            invalid_contract.sensors.front().uncertainty_bound;
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(std::move(invalid_contract),
+                                                source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidContract &&
+                          !result.observation.has_value(),
+                      "invalid Server policy fails before source access");
+        state.require(source.requests.empty(),
+                      "invalid safety policy cannot enter the source");
+    }
+
+    {
+        auto discrete_contract = contract();
+        discrete_contract.sensors.front().claim_family =
+            ClaimFamily::CompatibilityExclusivity;
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(std::move(discrete_contract),
+                                                source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(
+            result.status == ProfilingCollectionStatus::InvalidContract &&
+                !result.observation.has_value(),
+            "discrete claim families are outside the capacity policy");
+        state.require(source.requests.empty(),
+                      "unsupported claim semantics cannot enter the source");
+    }
+
+    {
+        auto invalid_freshness_contract = contract();
+        invalid_freshness_contract.freshness_window = 1s;
+        invalid_freshness_contract.max_source_skew = 1000ms;
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            std::move(invalid_freshness_contract), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidContract &&
+                          !result.observation.has_value(),
+                      "freshness must strictly exceed maximum source skew");
+        state.require(source.requests.empty(),
+                      "an incoherent freshness policy cannot enter the source");
+    }
+
+    {
+        auto extreme_window_contract = contract();
+        extreme_window_contract.freshness_window = std::chrono::seconds::max();
+        const auto transaction_context = context(extreme_window_contract);
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            std::move(extreme_window_contract), source, clock());
+        const auto result =
+            collector.collect(transaction_context, [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "an overflowing freshness window fails closed");
+        state.require(
+            source.requests.empty(),
+            "an overflowing freshness deadline cannot enter the source");
+    }
+
+    {
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            contract(), source,
+            clock(10ms, std::chrono::system_clock::time_point::max()));
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "an extreme collection clock fails closed");
+        state.require(source.requests.empty(),
+                      "an invalid freshness deadline cannot enter the source");
+    }
+
+    {
+        auto times = std::make_shared<
+            std::deque<std::chrono::steady_clock::time_point>>();
+        times->push_back(std::chrono::steady_clock::time_point::min());
+        times->push_back(std::chrono::steady_clock::time_point::max());
+        ProfilingCollectionClock extreme_monotonic_clock;
+        extreme_monotonic_clock.monotonic_now = [times] {
+            const auto result = times->front();
+            times->pop_front();
+            return result;
+        };
+        extreme_monotonic_clock.utc_now = [] {
+            return std::chrono::system_clock::time_point{} + 1000s;
+        };
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            contract(), source, std::move(extreme_monotonic_clock));
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "an unrepresentable monotonic interval fails closed");
+    }
+
+    {
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            contract(), source,
+            clock(10ms, std::chrono::system_clock::time_point{} - 500ms));
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "a pre-epoch fractional collection clock fails closed");
+        state.require(source.requests.empty(),
+                      "an invalid pre-epoch clock cannot enter the source");
+    }
+
+    {
+        ProfilingObservationCollector collector(contract(), clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::EvidenceUnavailable &&
+                          !result.observation.has_value(),
+                      "the production collector defaults to unavailable");
+    }
+
+    {
+        auto read = successful_read();
+        read.error = ProfilingSourceError::Failed;
+        read.diagnostic = std::string(300, 'x');
+        ScriptedProfilingObservationSource source({std::move(read)});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::EvidenceUnavailable &&
+                          !result.observation.has_value(),
+                      "source errors discard partial samples");
+        state.require(result.diagnostic.size() ==
+                          max_local_overlay_diagnostic_bytes,
+                      "source diagnostics remain bounded");
+    }
+
+    {
+        ThrowingProfilingObservationSource source;
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::EvidenceUnavailable &&
+                          !result.observation.has_value(),
+                      "adapter exceptions fail closed at the Server boundary");
+    }
+
+    {
+        auto read = successful_read();
+        read.samples.pop_back();
+        ScriptedProfilingObservationSource source({std::move(read)});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "missing owner samples fail closed");
+    }
+
+    {
+        auto read = successful_read();
+        read.samples.back().owner_scope_id = "owner/external";
+        ScriptedProfilingObservationSource source({std::move(read)});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "unknown owner scopes fail closed");
+    }
+
+    {
+        ScriptedProfilingObservationSource source(
+            {successful_read(4096, 2048)});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "unattributed totals fail closed");
+    }
+
+    {
+        auto zero_margin_contract = contract();
+        zero_margin_contract.sensors.front().safety_ceiling = 4608;
+        const auto transaction_context = context(zero_margin_contract);
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(std::move(zero_margin_contract),
+                                                source, clock());
+        const auto result =
+            collector.collect(transaction_context, [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "zero safety margin fails closed");
+    }
+
+    {
+        auto over_ceiling_contract = contract();
+        over_ceiling_contract.sensors.front().safety_ceiling = 4095;
+        const auto transaction_context = context(over_ceiling_contract);
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            std::move(over_ceiling_contract), source, clock());
+        const auto result =
+            collector.collect(transaction_context, [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "observations above the safety ceiling fail closed");
+    }
+
+    {
+        auto overflow_contract = contract();
+        overflow_contract.sensors.front().uncertainty_bound = 1;
+        overflow_contract.sensors.front().safety_ceiling =
+            std::numeric_limits<std::uint64_t>::max();
+        const auto transaction_context = context(overflow_contract);
+        ScriptedProfilingObservationSource source(
+            {successful_read(std::numeric_limits<std::uint64_t>::max(),
+                             std::numeric_limits<std::uint64_t>::max())});
+        ProfilingObservationCollector collector(std::move(overflow_contract),
+                                                source, clock());
+        const auto result =
+            collector.collect(transaction_context, [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "overflow-prone safety arithmetic fails closed");
+    }
+
+    {
+        auto read = successful_read();
+        read.samples.back().source_generation = 8;
+        ScriptedProfilingObservationSource source({std::move(read)});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "mixed native generations fail closed");
+    }
+
+    {
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(contract(), source,
+                                                clock(21ms));
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "excess source skew fails closed");
+    }
+
+    {
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return true; });
+        state.require(result.status == ProfilingCollectionStatus::Cancelled &&
+                          !result.observation.has_value(),
+                      "cancellation cannot produce evidence");
+        state.require(source.requests.empty(),
+                      "pre-read cancellation does not enter the source");
+    }
+}
+
+} // namespace
+
+int main() {
+    TestState state;
+    test_default_source_is_unavailable(state);
+    test_derivation_contract_identity(state);
+    test_stale_contract_identity_fails_before_source_access(state);
+    test_collector_derives_observation_from_raw_samples(state);
+    test_freshness_is_anchored_before_read(state);
+    test_collector_fails_closed(state);
+    return state.ok.load() ? 0 : 1;
+}

--- a/test/cpp/test_residency_profiling_provider.cpp
+++ b/test/cpp/test_residency_profiling_provider.cpp
@@ -231,6 +231,9 @@ ProfilingCollectionClock clock(
     times->push_back(std::chrono::steady_clock::time_point{} + elapsed);
     ProfilingCollectionClock value;
     value.monotonic_now = [times] {
+        if (times->empty()) {
+            throw std::runtime_error("scripted monotonic clock exhausted");
+        }
         const auto result = times->front();
         times->pop_front();
         return result;


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 918 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B918%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 777 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B777%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="DOC: 12 additions, 0 deletions" src="https://img.shields.io/badge/DOC-%2B12%20%E2%88%920-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 5 touched" src="https://img.shields.io/badge/FILES-5-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 918 additions, 0 deletions" src="https://img.shields.io/badge/IMPL-%2B918%20%E2%88%920-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 3 implementation files" src="https://img.shields.io/badge/FILES-3-5F6B78?style=flat" height="16"></picture>
  - [`CMakeLists.txt`](https://github.com/nisavid/lemonade/pull/132/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) <picture><img alt="20 additions, 0 deletions" title="20 additions, 0 deletions" src="https://img.shields.io/badge/%2B20-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/profiling_provider.h`](https://github.com/nisavid/lemonade/pull/132/files#diff-29107e48e5034466d25c7ad4f67dfdaa4f3d58571ddb4523129ec48b43b80a2c) <picture><img alt="148 additions, 0 deletions" title="148 additions, 0 deletions" src="https://img.shields.io/badge/%2B148-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_provider.cpp`](https://github.com/nisavid/lemonade/pull/132/files#diff-5212fed0ccb231b81eceebeb55bdd403330258d266ced17520b5b58cd6758614) <picture><img alt="750 additions, 0 deletions" title="750 additions, 0 deletions" src="https://img.shields.io/badge/%2B750-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 777 additions, 0 deletions" src="https://img.shields.io/badge/TEST-%2B777%20%E2%88%920-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 1 test file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_profiling_provider.cpp`](https://github.com/nisavid/lemonade/pull/132/files#diff-71a96f8621cd1ed5320380d5f561f9454e172ce0f8f9eedcc02c4e737d0ff422) <picture><img alt="777 additions, 0 deletions" title="777 additions, 0 deletions" src="https://img.shields.io/badge/%2B777-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="DOC: 12 additions, 0 deletions" src="https://img.shields.io/badge/DOC-%2B12%20%E2%88%920-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 1 documentation file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`CONTEXT.md`](https://github.com/nisavid/lemonade/pull/132/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14) <picture><img alt="12 additions, 0 deletions" title="12 additions, 0 deletions" src="https://img.shields.io/badge/%2B12-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Adds a fail-closed raw observation source and Server-owned derivation contract for residency profiling. The collector binds semantic-free sensor readings to an exact contract, derives only phase-neutral current-owner closure, uncertainty, freshness, skew, and positive safety slack, and leaves the default production source unavailable.

Refs #120

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

### Contracts

- Observation adapters return only opaque sensor and owner-scope identities, unsigned values, native generations, and failure state; they cannot assign claim semantics, health, lifecycle, or attestation truth.
- The canonical derivation-contract digest binds provider revision, exact sensors and owner scopes, claim mappings, uncertainty and safety policy, freshness, and skew before the source is read.
- Collection fails closed on incomplete ownership, mixed generations, stale contract identity, clock overflow, unsafe arithmetic, cancellation, adapter failure, unsupported discrete claims, or non-positive safety slack.

### Boundary

This slice does not add a live platform source, Server profiling-session driver, lifecycle or interval-continuity authority, attestation sealing, overlay activation, shared publication, or signing. A single snapshot cannot claim that external demand was absent across the gated interval, so #120 remains open for that Server-owned orchestration and live evidence path.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build . --target cpp-ci-tests -j2` from the fresh configured build directory — the aggregate built successfully.
- `ctest -L cpp-ci --output-on-failure` from that build directory — 65/65 tests passed in 72.44 seconds.
- `ctest -R '^(ResidencyProfilingTransaction|ResidencyProfilingProvider)$' --repeat until-fail:3 --output-on-failure` — both focused tests passed three consecutive runs.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added residency profiling to collect raw sensor observations and produce validated derived results.
  - Added contract and provenance tracking, freshness checks, safety limits, cancellation handling, and source error classification.
  - Added support for unavailable or failing observation sources with clear collection status reporting.

- **Tests**
  - Added comprehensive coverage for profiling contracts, sample validation, ownership, cancellation, safety limits, overflow, and source timing.
  - Enabled the profiling provider test in CI with a 30-second timeout.

- **Documentation**
  - Added glossary definitions for profiling samples, derivation contracts, and derived observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->