### PR TITLE
feat(residency/profiling): record complete observation intervals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3508,6 +3508,25 @@ if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_PROVIDER_TEST_SRC}")
     set_tests_properties(ResidencyProfilingProvider PROPERTIES TIMEOUT 30)
 endif()
 
+set(_RESIDENCY_PROFILING_INTERVAL_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_residency_profiling_interval.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_INTERVAL_TEST_SRC}")
+    add_executable(
+        test_residency_profiling_interval
+        test/cpp/test_residency_profiling_interval.cpp
+    )
+    target_link_libraries(test_residency_profiling_interval PRIVATE
+        lemonade-server-core
+    )
+    add_cpp_ci_test(
+        ResidencyProfilingInterval
+        CI ON
+        COMMAND test_residency_profiling_interval
+    )
+    set_tests_properties(ResidencyProfilingInterval PROPERTIES TIMEOUT 30)
+endif()
+
 # Routing-helper reconciliation: durable needed-set + non-blocking prune that
 # skips busy/pinned helpers, plus a policy-update-vs-busy concurrency race.
 set(_ROUTING_HELPER_RECONCILE_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_helper_reconcile.cpp")

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -300,7 +300,7 @@ The transaction-specific, server-owned policy binding one provider revision, exa
 _Avoid_: Applying capacity slack arithmetic to discrete claims, letting an observation source select semantics or close ownership, or letting a caller assign phase or lifecycle from one snapshot.
 
 **Profiling derived observation**:
-A phase-neutral Server result from one contract-matched raw closure, carrying Server-derived provider identity, raw provenance, generation, acquisition and freshness bounds, health, complete current owner coverage, observed and owner-attributed capacity closure, uncertainty, and positive safety slack. It carries no interval-change claim, is not a phase attestation, and has no lifecycle or publication authority.
+A phase-neutral Server result from one contract-matched raw closure, carrying Server-derived provider identity, raw provenance, source generation, acquisition and freshness bounds, health, complete current owner coverage, observed and owner-attributed capacity closure, uncertainty, and positive safety slack. It carries no interval-change claim, is not a phase attestation, and has no lifecycle or publication authority.
 _Avoid_: Inferring external or unattributed interval change from one snapshot, or treating one accepted collection as baseline, workload, release, or completed qualification evidence.
 
 **Profiling observation interval**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -296,12 +296,20 @@ A phase-neutral low-level reading containing an opaque sensor ID, an optional se
 _Avoid_: Accepting provider-supplied truth decisions or treating a successful read as profiling evidence.
 
 **Profiling derivation contract**:
-The transaction-specific, server-owned policy binding one provider revision, the exact required capacity sensors and owner scopes, their mappings to consumable-capacity byte claims, freshness and skew bounds, and per-sensor uncertainty bounds and safety ceilings. Its canonical digest is order-insensitive for sensor and owner sets. The collector accepts only an exact coherent raw closure and derives a phase-neutral observation with positive safety slack; a later transaction authority proves phase and lifecycle before sealing an attestation.
+The transaction-specific, server-owned policy binding one provider revision, exact required capacity sensors, owner-containment identities, claim mappings, freshness and skew bounds, uncertainty and safety policy, event semantics, observation cadence, stability windows, and interval retention. Its canonical digest is order-insensitive for sensor and owner sets. The collector accepts only an exact coherent raw closure and derives a phase-neutral observation with positive safety slack; a later transaction authority proves interval continuity, phase, and lifecycle before sealing an attestation.
 _Avoid_: Applying capacity slack arithmetic to discrete claims, letting an observation source select semantics or close ownership, or letting a caller assign phase or lifecycle from one snapshot.
 
 **Profiling derived observation**:
 A phase-neutral Server result from one contract-matched raw closure, carrying Server-derived provider identity, raw provenance, generation, acquisition and freshness bounds, health, complete current owner coverage, observed and owner-attributed capacity closure, uncertainty, and positive safety slack. It carries no interval-change claim, is not a phase attestation, and has no lifecycle or publication authority.
 _Avoid_: Inferring external or unattributed interval change from one snapshot, or treating one accepted collection as baseline, workload, release, or completed qualification evidence.
+
+**Profiling observation interval**:
+A Server-owned whole-transaction record that begins with an atomic subscription and snapshot after exclusive admission and ends with an atomic drain and unsubscription after the target becomes terminal. It is complete only when one bound source epoch and owner-scope set exposes every relevant resource mutation without lost history; the Server, not the adapter, derives interval attribution.
+_Avoid_: Inferring isolation from point samples, accepting a provider-supplied clean-interval decision, or ending observation before target release.
+
+**Profiling event watermark**:
+The source-native progress cursor for relevant resource mutations within one profiling observation interval. It may remain unchanged at a checkpoint; a gap, wrap, epoch change, owner-scope replacement, or lost history makes the interval incomplete.
+_Avoid_: Treating it as phase order, a Server capture generation, or evidence by itself.
 
 **Deployment-qualified residency method**:
 A local-only method result established for one exact operation and closed residency deployment identity by a complete profiling transaction. It does not change the shared capability level or footprint confidence class and does not apply to another model, device, backend, configuration, workload, or operation family.

--- a/src/cpp/include/lemon/residency/profiling_provider.h
+++ b/src/cpp/include/lemon/residency/profiling_provider.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -136,7 +137,7 @@ public:
     // caller cancellation to skip source cleanup.
     virtual ProfilingRawIntervalBatch
     finish(ProfilingRawIntervalToken token,
-           ProfilingEventWatermark after_event_watermark) = 0;
+           ProfilingEventWatermark after_event_watermark) noexcept = 0;
 };
 
 class UnavailableProfilingIntervalObservationSource final
@@ -151,7 +152,7 @@ public:
                const ProfilingCancellationCheck &should_abort) override;
     ProfilingRawIntervalBatch
     finish(ProfilingRawIntervalToken token,
-           ProfilingEventWatermark after_event_watermark) override;
+           ProfilingEventWatermark after_event_watermark) noexcept override;
 };
 
 struct ProfilingSensorContract {
@@ -209,7 +210,7 @@ struct ProfilingDerivedObservation {
     std::string provider_revision_sha256;
     std::string raw_provenance_sha256;
     std::string observation_contract_sha256;
-    std::uint64_t observation_generation = 0;
+    std::uint64_t source_generation = 0;
     std::string observed_at;
     std::string fresh_until;
     std::uint64_t source_skew_milliseconds = 0;
@@ -257,6 +258,83 @@ private:
     UnavailableProfilingObservationSource unavailable_source_;
     ProfilingObservationSource *source_ = nullptr;
     ProfilingCollectionClock clock_;
+};
+
+enum class ProfilingIntervalRecorderStatus {
+    Ok,
+    Cancelled,
+    EvidenceUnavailable,
+    InvalidContract,
+    InvalidObservation,
+    DigestUnavailable,
+    InvalidState,
+};
+
+struct ProfilingRecordedCheckpoint {
+    std::uint64_t capture_generation = 0;
+    ProfilingEventWatermark event_watermark;
+    ProfilingDerivedObservation observation;
+};
+
+struct ProfilingIntervalSegment {
+    std::string source_epoch_sha256;
+    std::string owner_scope_set_sha256;
+    std::string event_semantics_revision_sha256;
+    ProfilingEventWatermark after_event_watermark;
+    ProfilingEventWatermark through_event_watermark;
+    std::uint64_t first_capture_generation = 0;
+    std::uint64_t last_capture_generation = 0;
+    std::uint64_t frame_count = 0;
+    std::string provenance_sha256;
+    ProfilingRecordedCheckpoint checkpoint;
+    std::vector<ClaimFamilyClosure> peak_observed_claims;
+    std::vector<ClaimFamilyClosure> peak_attributed_claims;
+    std::vector<ClaimFamilyClosure> external_change_claims;
+    std::vector<ClaimFamilyClosure> unattributed_claims;
+    std::vector<ClaimFamilyClosure> uncertainty_claims;
+    std::vector<ClaimFamilyClosure> safety_margin_claims;
+};
+
+struct ProfilingIntervalRecorderResult {
+    ProfilingIntervalRecorderStatus status =
+        ProfilingIntervalRecorderStatus::EvidenceUnavailable;
+    std::string diagnostic;
+    std::optional<ProfilingIntervalSegment> segment;
+
+    bool ok() const noexcept;
+};
+
+class ProfilingIntervalRecorder {
+public:
+    // One Server owner serializes the recorder lifecycle and all source calls.
+    ProfilingIntervalRecorder(ProfilingDerivationContract contract,
+                              ProfilingCollectionClock clock = {});
+    // The injected source must outlive this recorder.
+    ProfilingIntervalRecorder(ProfilingDerivationContract contract,
+                              ProfilingIntervalObservationSource &source,
+                              ProfilingCollectionClock clock = {});
+    ~ProfilingIntervalRecorder();
+
+    ProfilingIntervalRecorder(const ProfilingIntervalRecorder &) = delete;
+    ProfilingIntervalRecorder &
+    operator=(const ProfilingIntervalRecorder &) = delete;
+    ProfilingIntervalRecorder(ProfilingIntervalRecorder &&) = delete;
+    ProfilingIntervalRecorder &
+    operator=(ProfilingIntervalRecorder &&) = delete;
+
+    ProfilingIntervalRecorderResult
+    begin(const ProfilingTransactionContext &context,
+          const ProfilingCancellationCheck &should_abort);
+    ProfilingIntervalRecorderResult
+    poll(const ProfilingCancellationCheck &should_abort);
+    ProfilingIntervalRecorderResult
+    checkpoint(const ProfilingCancellationCheck &should_abort);
+    ProfilingIntervalRecorderResult finish();
+    bool active() const noexcept;
+
+private:
+    struct State;
+    std::unique_ptr<State> state_;
 };
 
 } // namespace lemon::residency

--- a/src/cpp/include/lemon/residency/profiling_provider.h
+++ b/src/cpp/include/lemon/residency/profiling_provider.h
@@ -89,6 +89,8 @@ struct ProfilingRawIntervalFrame {
     std::string source_epoch_sha256;
     std::string owner_scope_set_sha256;
     std::string event_semantics_revision_sha256;
+    // All samples share a source generation equal to this watermark. This
+    // source order remains independent from the Server capture generation.
     ProfilingEventWatermark event_watermark;
     std::vector<ProfilingRawSample> samples;
 };

--- a/src/cpp/include/lemon/residency/profiling_provider.h
+++ b/src/cpp/include/lemon/residency/profiling_provider.h
@@ -127,14 +127,16 @@ public:
     virtual ProfilingRawIntervalBeginResult
     begin(const ProfilingRawIntervalReadRequest &request,
           const ProfilingCancellationCheck &should_abort) = 0;
-    // Success returns every retained event after the supplied watermark and
-    // an atomic checkpoint at the returned through-watermark.
+    // Event watermarks are dense: success returns exactly one retained frame
+    // for each watermark after the supplied watermark through the returned
+    // watermark, plus an atomic checkpoint at that watermark.
     virtual ProfilingRawIntervalBatch
     read_since(ProfilingRawIntervalToken token,
                ProfilingEventWatermark after_event_watermark,
                const ProfilingCancellationCheck &should_abort) = 0;
     // Finish must atomically drain and unregister the token without allowing
-    // caller cancellation to skip source cleanup.
+    // caller cancellation to skip source cleanup. Implementations must not
+    // throw.
     virtual ProfilingRawIntervalBatch
     finish(ProfilingRawIntervalToken token,
            ProfilingEventWatermark after_event_watermark) noexcept = 0;

--- a/src/cpp/include/lemon/residency/profiling_provider.h
+++ b/src/cpp/include/lemon/residency/profiling_provider.h
@@ -11,6 +11,8 @@
 
 namespace lemon::residency {
 
+inline constexpr std::uint64_t max_profiling_interval_frames = 4096;
+
 enum class ProfilingSourceError {
     None,
     Unavailable,
@@ -30,11 +32,13 @@ struct ProfilingRawSample {
 struct ProfilingRawReadRequest {
     std::vector<std::string> sensor_ids;
     std::vector<std::string> owner_scope_ids;
+    std::string owner_scope_set_sha256;
 };
 
 struct ProfilingRawReadResult {
     ProfilingSourceError error = ProfilingSourceError::Unavailable;
     std::vector<ProfilingRawSample> samples;
+    std::string owner_scope_set_sha256;
     std::string diagnostic;
 };
 
@@ -56,6 +60,100 @@ public:
          const ProfilingCancellationCheck &should_abort) override;
 };
 
+enum class ProfilingIntervalSourceError {
+    None,
+    Unavailable,
+    Cancelled,
+    HistoryLost,
+    Failed,
+};
+
+struct ProfilingRawIntervalReadRequest {
+    ProfilingRawReadRequest read;
+    std::string event_semantics_revision_sha256;
+};
+
+struct ProfilingEventWatermark {
+    std::uint64_t value = 0;
+
+    bool operator==(const ProfilingEventWatermark &other) const noexcept {
+        return value == other.value;
+    }
+    bool operator!=(const ProfilingEventWatermark &other) const noexcept {
+        return !(*this == other);
+    }
+};
+
+struct ProfilingRawIntervalFrame {
+    std::string source_epoch_sha256;
+    std::string owner_scope_set_sha256;
+    std::string event_semantics_revision_sha256;
+    ProfilingEventWatermark event_watermark;
+    std::vector<ProfilingRawSample> samples;
+};
+
+struct ProfilingRawIntervalToken {
+    std::uint64_t opaque_id = 0;
+};
+
+struct ProfilingRawIntervalBeginResult {
+    ProfilingIntervalSourceError error =
+        ProfilingIntervalSourceError::Unavailable;
+    ProfilingRawIntervalToken token;
+    ProfilingRawIntervalFrame checkpoint;
+    std::string diagnostic;
+};
+
+struct ProfilingRawIntervalBatch {
+    ProfilingIntervalSourceError error =
+        ProfilingIntervalSourceError::Unavailable;
+    ProfilingEventWatermark after_event_watermark;
+    ProfilingEventWatermark through_event_watermark;
+    std::vector<ProfilingRawIntervalFrame> event_frames;
+    ProfilingRawIntervalFrame checkpoint;
+    std::string diagnostic;
+};
+
+class ProfilingIntervalObservationSource {
+public:
+    virtual ~ProfilingIntervalObservationSource() = default;
+
+    // Calls are synchronous. Implementations must not retain request or
+    // cancellation references, and a successful begin owns one token until
+    // finish drains and unregisters it. The Server serializes calls for one
+    // token; implementations must synchronize any concurrently active tokens.
+    // Success atomically registers the interval before taking its checkpoint.
+    virtual ProfilingRawIntervalBeginResult
+    begin(const ProfilingRawIntervalReadRequest &request,
+          const ProfilingCancellationCheck &should_abort) = 0;
+    // Success returns every retained event after the supplied watermark and
+    // an atomic checkpoint at the returned through-watermark.
+    virtual ProfilingRawIntervalBatch
+    read_since(ProfilingRawIntervalToken token,
+               ProfilingEventWatermark after_event_watermark,
+               const ProfilingCancellationCheck &should_abort) = 0;
+    // Finish must atomically drain and unregister the token without allowing
+    // caller cancellation to skip source cleanup.
+    virtual ProfilingRawIntervalBatch
+    finish(ProfilingRawIntervalToken token,
+           ProfilingEventWatermark after_event_watermark) = 0;
+};
+
+class UnavailableProfilingIntervalObservationSource final
+    : public ProfilingIntervalObservationSource {
+public:
+    ProfilingRawIntervalBeginResult
+    begin(const ProfilingRawIntervalReadRequest &request,
+          const ProfilingCancellationCheck &should_abort) override;
+    ProfilingRawIntervalBatch
+    read_since(ProfilingRawIntervalToken token,
+               ProfilingEventWatermark after_event_watermark,
+               const ProfilingCancellationCheck &should_abort) override;
+    ProfilingRawIntervalBatch
+    finish(ProfilingRawIntervalToken token,
+           ProfilingEventWatermark after_event_watermark) override;
+};
+
 struct ProfilingSensorContract {
     std::string sensor_id;
     std::string constraint_id;
@@ -64,17 +162,33 @@ struct ProfilingSensorContract {
     std::uint64_t safety_ceiling = 0;
 };
 
+struct ProfilingOwnerScopeBinding {
+    std::string owner_scope_id;
+    std::string containment_identity_sha256;
+};
+
+struct ProfilingIntervalContract {
+    std::string event_semantics_revision_sha256;
+    std::chrono::milliseconds max_observation_gap{0};
+    std::chrono::milliseconds baseline_stability_window{0};
+    std::chrono::milliseconds release_stability_window{0};
+    std::uint64_t max_interval_frames = 0;
+};
+
 struct ProfilingDerivationContract {
     std::string provider_id;
     std::string provider_revision_sha256;
     std::vector<ProfilingSensorContract> sensors;
-    std::vector<std::string> owner_scope_ids;
+    std::vector<ProfilingOwnerScopeBinding> owner_scopes;
     std::chrono::seconds freshness_window{0};
     std::chrono::milliseconds max_source_skew{0};
+    ProfilingIntervalContract interval;
 };
 
 std::optional<std::string> profiling_derivation_contract_sha256(
     const ProfilingDerivationContract &contract);
+std::optional<std::string> profiling_owner_scope_set_sha256(
+    const std::vector<ProfilingOwnerScopeBinding> &owner_scopes);
 
 struct ProfilingCollectionClock {
     std::function<std::chrono::steady_clock::time_point()> monotonic_now;

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -125,6 +125,53 @@ std::string_view claim_unit_wire(ClaimUnit unit) noexcept {
     return {};
 }
 
+std::string_view
+claim_completeness_wire(ClaimCompleteness completeness) noexcept {
+    switch (completeness) {
+    case ClaimCompleteness::NotApplicable:
+        return "not_applicable";
+    case ClaimCompleteness::KnownZero:
+        return "known_zero";
+    case ClaimCompleteness::Bounded:
+        return "bounded";
+    case ClaimCompleteness::Unknown:
+        return "unknown";
+    }
+    return {};
+}
+
+std::string_view
+profiling_health_wire(ProfilingObservationHealth health) noexcept {
+    switch (health) {
+    case ProfilingObservationHealth::Valid:
+        return "valid";
+    case ProfilingObservationHealth::Missing:
+        return "missing";
+    case ProfilingObservationHealth::Stale:
+        return "stale";
+    case ProfilingObservationHealth::Unhealthy:
+        return "unhealthy";
+    case ProfilingObservationHealth::Incoherent:
+        return "incoherent";
+    case ProfilingObservationHealth::Superseded:
+        return "superseded";
+    }
+    return {};
+}
+
+std::string_view profiling_owner_coverage_wire(
+    ProfilingOwnerCoverage coverage) noexcept {
+    switch (coverage) {
+    case ProfilingOwnerCoverage::Complete:
+        return "complete";
+    case ProfilingOwnerCoverage::Incomplete:
+        return "incomplete";
+    case ProfilingOwnerCoverage::Unknown:
+        return "unknown";
+    }
+    return {};
+}
+
 bool identifier_is_valid(std::string_view value) noexcept {
     return !value.empty() &&
            value.size() <= max_local_overlay_identifier_bytes &&
@@ -320,6 +367,36 @@ void append_string(std::string &bytes, std::string_view value) {
     bytes.append(value.data(), value.size());
 }
 
+void append_claim_closure(std::string &bytes,
+                          std::vector<ClaimFamilyClosure> closure) {
+    std::sort(closure.begin(), closure.end(),
+              [](const ClaimFamilyClosure &left,
+                 const ClaimFamilyClosure &right) {
+                  return claim_family_wire(left.family) <
+                         claim_family_wire(right.family);
+              });
+    append_u64(bytes, static_cast<std::uint64_t>(closure.size()));
+    for (auto &family : closure) {
+        std::sort(family.entries.begin(), family.entries.end(),
+                  [](const ClaimAmount &left, const ClaimAmount &right) {
+                      return std::tie(left.constraint_id, left.unit,
+                                      left.amount) <
+                             std::tie(right.constraint_id, right.unit,
+                                      right.amount);
+                  });
+        append_string(bytes, claim_family_wire(family.family));
+        append_string(bytes,
+                      claim_completeness_wire(family.completeness));
+        append_u64(bytes,
+                   static_cast<std::uint64_t>(family.entries.size()));
+        for (const auto &entry : family.entries) {
+            append_string(bytes, entry.constraint_id);
+            append_string(bytes, claim_unit_wire(entry.unit));
+            append_u64(bytes, entry.amount);
+        }
+    }
+}
+
 std::optional<std::string> sha256_hex(std::string_view bytes) {
 #if MBEDTLS_VERSION_MAJOR >= 4
     static std::once_flag initialized;
@@ -493,8 +570,10 @@ claim_closure(const ProfilingDerivationContract &contract,
 }
 
 std::optional<std::uint64_t>
-source_generation(const std::vector<ProfilingRawSample> &samples) noexcept {
-    if (samples.empty() || samples.front().source_generation == 0) {
+source_generation(const std::vector<ProfilingRawSample> &samples,
+                  bool require_nonzero) noexcept {
+    if (samples.empty() ||
+        (require_nonzero && samples.front().source_generation == 0)) {
         return std::nullopt;
     }
     const auto generation = samples.front().source_generation;
@@ -561,6 +640,43 @@ reconcile_samples(const ProfilingDerivationContract &contract,
     return values;
 }
 
+struct DerivedClaimAmounts {
+    std::uint64_t source_generation = 0;
+    std::vector<std::uint64_t> observed;
+    std::vector<std::uint64_t> attributed;
+    std::vector<std::uint64_t> uncertainty;
+    std::vector<std::uint64_t> safety_margin;
+};
+
+std::optional<DerivedClaimAmounts>
+derive_claim_amounts(const ProfilingDerivationContract &contract,
+                     const std::vector<ProfilingRawSample> &samples,
+                     bool require_nonzero_generation = true) {
+    const auto generation =
+        source_generation(samples, require_nonzero_generation);
+    const auto values = reconcile_samples(contract, samples);
+    if (!generation || !values) return std::nullopt;
+
+    DerivedClaimAmounts result;
+    result.source_generation = *generation;
+    result.observed.reserve(values->size());
+    result.attributed.reserve(values->size());
+    result.uncertainty.reserve(values->size());
+    result.safety_margin.reserve(values->size());
+    for (std::size_t index = 0; index < values->size(); ++index) {
+        const auto amount = *(*values)[index].total;
+        const auto &sensor = contract.sensors[index];
+        if (amount >= sensor.safety_ceiling) return std::nullopt;
+        const auto remaining = sensor.safety_ceiling - amount;
+        if (sensor.uncertainty_bound >= remaining) return std::nullopt;
+        result.observed.push_back(amount);
+        result.attributed.push_back((*values)[index].attributed_total);
+        result.uncertainty.push_back(sensor.uncertainty_bound);
+        result.safety_margin.push_back(remaining - sensor.uncertainty_bound);
+    }
+    return result;
+}
+
 std::optional<SteadyClock::duration>
 elapsed_between(SteadyClock::time_point started,
                 SteadyClock::time_point finished) noexcept {
@@ -620,6 +736,195 @@ rounded_up_milliseconds(SteadyClock::duration elapsed) noexcept {
     return milliseconds;
 }
 
+struct ProfilingAcquisitionTiming {
+    std::string observed_at;
+    std::string fresh_until;
+    std::uint64_t source_skew_milliseconds = 0;
+};
+
+std::optional<ProfilingAcquisitionTiming> acquisition_timing(
+    const ProfilingDerivationContract &contract, SteadyClock::time_point started,
+    SystemClock::time_point observed_time, SteadyClock::time_point finished) {
+    const auto observed_seconds =
+        observed_time >= SystemClock::time_point{}
+            ? system_clock_seconds(observed_time)
+            : std::nullopt;
+    const auto freshness_seconds =
+        count_as_i64(contract.freshness_window.count());
+    const auto fresh_seconds =
+        observed_seconds && freshness_seconds
+            ? checked_add(*observed_seconds, *freshness_seconds)
+            : std::nullopt;
+    const auto observed_at =
+        observed_seconds ? format_utc(*observed_seconds) : std::string{};
+    const auto fresh_until =
+        fresh_seconds && system_clock_contains_seconds(*fresh_seconds)
+            ? format_utc(*fresh_seconds)
+            : std::string{};
+    const auto elapsed = elapsed_between(started, finished);
+    const auto skew = elapsed ? rounded_up_milliseconds(*elapsed)
+                              : std::nullopt;
+    if (observed_at.empty() || fresh_until.empty() || !skew ||
+        *skew >
+            static_cast<std::uint64_t>(contract.max_source_skew.count())) {
+        return std::nullopt;
+    }
+    return ProfilingAcquisitionTiming{observed_at, fresh_until, *skew};
+}
+
+std::optional<ProfilingDerivedObservation> derived_observation(
+    const ProfilingDerivationContract &contract,
+    const ProfilingTransactionContext &context,
+    const std::vector<ProfilingRawSample> &samples,
+    const DerivedClaimAmounts &claims,
+    const ProfilingAcquisitionTiming &timing,
+    std::string_view contract_sha256) {
+    const auto provenance =
+        raw_provenance_digest(context, samples, timing.observed_at);
+    if (!provenance) return std::nullopt;
+
+    ProfilingDerivedObservation observation;
+    observation.provider_id = contract.provider_id;
+    observation.provider_revision_sha256 = contract.provider_revision_sha256;
+    observation.raw_provenance_sha256 = *provenance;
+    observation.observation_contract_sha256 = std::string(contract_sha256);
+    observation.source_generation = claims.source_generation;
+    observation.observed_at = timing.observed_at;
+    observation.fresh_until = timing.fresh_until;
+    observation.source_skew_milliseconds = timing.source_skew_milliseconds;
+    observation.max_source_skew_milliseconds =
+        static_cast<std::uint64_t>(contract.max_source_skew.count());
+    observation.health = ProfilingObservationHealth::Valid;
+    observation.owner_coverage = ProfilingOwnerCoverage::Complete;
+    observation.observed_claims = claim_closure(contract, claims.observed);
+    observation.attributed_claims =
+        claim_closure(contract, claims.attributed);
+    observation.uncertainty_claims =
+        claim_closure(contract, claims.uncertainty);
+    observation.safety_margin_claims =
+        claim_closure(contract, claims.safety_margin);
+    return observation;
+}
+
+std::optional<std::string> interval_frame_provenance_digest(
+    const ProfilingTransactionContext &context,
+    const ProfilingRawIntervalFrame &frame) {
+    auto samples = frame.samples;
+    std::sort(
+        samples.begin(), samples.end(),
+        [](const ProfilingRawSample &left, const ProfilingRawSample &right) {
+            return std::tie(left.sensor_id, left.owner_scope_id, left.value,
+                            left.source_generation) <
+                   std::tie(right.sensor_id, right.owner_scope_id, right.value,
+                            right.source_generation);
+        });
+
+    std::string bytes = "lemonade/profiling-interval-frame/v1";
+    append_string(bytes, context.deployment_id);
+    append_string(bytes, context.profiling_transaction_id);
+    append_string(bytes, context.selector_sha256);
+    append_string(bytes, context.observation_contract_sha256);
+    append_string(bytes, frame.source_epoch_sha256);
+    append_string(bytes, frame.owner_scope_set_sha256);
+    append_string(bytes, frame.event_semantics_revision_sha256);
+    append_u64(bytes, frame.event_watermark.value);
+    append_u64(bytes, static_cast<std::uint64_t>(samples.size()));
+    for (const auto &sample : samples) {
+        append_string(bytes, sample.sensor_id);
+        bytes.push_back(sample.owner_scope_id.has_value() ? '\1' : '\0');
+        if (sample.owner_scope_id) append_string(bytes, *sample.owner_scope_id);
+        append_u64(bytes, sample.value);
+        append_u64(bytes, sample.source_generation);
+    }
+    return sha256_hex(bytes);
+}
+
+std::optional<std::string> segment_provenance_seed(
+    const ProfilingTransactionContext &context, std::string_view source_epoch,
+    std::string_view owner_scope_set, std::string_view event_semantics,
+    ProfilingEventWatermark after_event_watermark) {
+    std::string bytes = "lemonade/profiling-interval-segment/v1";
+    append_string(bytes, context.deployment_id);
+    append_string(bytes, context.profiling_transaction_id);
+    append_string(bytes, context.observation_contract_sha256);
+    append_string(bytes, source_epoch);
+    append_string(bytes, owner_scope_set);
+    append_string(bytes, event_semantics);
+    append_u64(bytes, after_event_watermark.value);
+    return sha256_hex(bytes);
+}
+
+std::optional<std::string> extend_segment_provenance(
+    std::string_view prior, std::uint64_t capture_generation,
+    ProfilingEventWatermark event_watermark,
+    std::string_view frame_provenance_sha256) {
+    std::string bytes = "lemonade/profiling-interval-segment-frame/v1";
+    append_string(bytes, prior);
+    append_u64(bytes, capture_generation);
+    append_u64(bytes, event_watermark.value);
+    append_string(bytes, frame_provenance_sha256);
+    return sha256_hex(bytes);
+}
+
+std::optional<std::string> checkpoint_provenance_digest(
+    const ProfilingRecordedCheckpoint &checkpoint) {
+    const auto &observation = checkpoint.observation;
+    std::string bytes = "lemonade/profiling-interval-checkpoint/v1";
+    append_u64(bytes, checkpoint.capture_generation);
+    append_u64(bytes, checkpoint.event_watermark.value);
+    append_string(bytes, observation.provider_id);
+    append_string(bytes, observation.provider_revision_sha256);
+    append_string(bytes, observation.raw_provenance_sha256);
+    append_string(bytes, observation.observation_contract_sha256);
+    append_u64(bytes, observation.source_generation);
+    append_string(bytes, observation.observed_at);
+    append_string(bytes, observation.fresh_until);
+    append_u64(bytes, observation.source_skew_milliseconds);
+    append_u64(bytes, observation.max_source_skew_milliseconds);
+    append_string(bytes, profiling_health_wire(observation.health));
+    append_string(bytes,
+                  profiling_owner_coverage_wire(observation.owner_coverage));
+    append_claim_closure(bytes, observation.observed_claims);
+    append_claim_closure(bytes, observation.attributed_claims);
+    append_claim_closure(bytes, observation.uncertainty_claims);
+    append_claim_closure(bytes, observation.safety_margin_claims);
+    return sha256_hex(bytes);
+}
+
+std::optional<std::string> extend_checkpoint_provenance(
+    std::string_view prior, std::string_view checkpoint_sha256) {
+    std::string bytes = "lemonade/profiling-interval-segment-checkpoint/v1";
+    append_string(bytes, prior);
+    append_string(bytes, checkpoint_sha256);
+    return sha256_hex(bytes);
+}
+
+bool componentwise_maximum(std::vector<std::uint64_t> &target,
+                           const std::vector<std::uint64_t> &candidate) {
+    if (target.empty()) {
+        target = candidate;
+        return true;
+    }
+    if (target.size() != candidate.size()) return false;
+    for (std::size_t index = 0; index < target.size(); ++index) {
+        target[index] = std::max(target[index], candidate[index]);
+    }
+    return true;
+}
+
+bool componentwise_minimum(std::vector<std::uint64_t> &target,
+                           const std::vector<std::uint64_t> &candidate) {
+    if (target.empty()) {
+        target = candidate;
+        return true;
+    }
+    if (target.size() != candidate.size()) return false;
+    for (std::size_t index = 0; index < target.size(); ++index) {
+        target[index] = std::min(target[index], candidate[index]);
+    }
+    return true;
+}
+
 } // namespace
 
 std::optional<std::string> profiling_derivation_contract_sha256(
@@ -669,7 +974,8 @@ UnavailableProfilingIntervalObservationSource::read_since(
 }
 
 ProfilingRawIntervalBatch UnavailableProfilingIntervalObservationSource::finish(
-    ProfilingRawIntervalToken, ProfilingEventWatermark after_event_watermark) {
+    ProfilingRawIntervalToken,
+    ProfilingEventWatermark after_event_watermark) noexcept {
     return ProfilingRawIntervalBatch{
         ProfilingIntervalSourceError::Unavailable,
         after_event_watermark,
@@ -809,38 +1115,10 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
             return result_for(ProfilingCollectionStatus::InvalidObservation,
                               "profiling source skew exceeds the contract");
         }
-        const auto generation = source_generation(raw.samples);
-        const auto values = reconcile_samples(contract_, raw.samples);
-        if (!generation || !values) {
+        const auto claims = derive_claim_amounts(contract_, raw.samples);
+        if (!claims) {
             return result_for(ProfilingCollectionStatus::InvalidObservation,
                               "profiling raw observation does not close");
-        }
-
-        std::vector<std::uint64_t> observed;
-        std::vector<std::uint64_t> attributed;
-        std::vector<std::uint64_t> uncertainty;
-        std::vector<std::uint64_t> safety_margin;
-        observed.reserve(values->size());
-        attributed.reserve(values->size());
-        uncertainty.reserve(values->size());
-        safety_margin.reserve(values->size());
-        for (std::size_t index = 0; index < values->size(); ++index) {
-            const auto amount = *(*values)[index].total;
-            const auto &sensor = contract_.sensors[index];
-            if (amount >= sensor.safety_ceiling) {
-                return result_for(ProfilingCollectionStatus::InvalidObservation,
-                                  "profiling observation meets or exceeds its "
-                                  "safety ceiling");
-            }
-            const auto remaining = sensor.safety_ceiling - amount;
-            if (sensor.uncertainty_bound >= remaining) {
-                return result_for(ProfilingCollectionStatus::InvalidObservation,
-                                  "profiling safety margin is not positive");
-            }
-            observed.push_back(amount);
-            attributed.push_back((*values)[index].attributed_total);
-            uncertainty.push_back(sensor.uncertainty_bound);
-            safety_margin.push_back(remaining - sensor.uncertainty_bound);
         }
 
         const auto provenance =
@@ -856,7 +1134,7 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
             contract_.provider_revision_sha256;
         observation.raw_provenance_sha256 = *provenance;
         observation.observation_contract_sha256 = *contract_sha256;
-        observation.observation_generation = *generation;
+        observation.source_generation = claims->source_generation;
         observation.observed_at = observed_at;
         observation.fresh_until = fresh_until;
         observation.source_skew_milliseconds = *skew;
@@ -864,11 +1142,14 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
             static_cast<std::uint64_t>(contract_.max_source_skew.count());
         observation.health = ProfilingObservationHealth::Valid;
         observation.owner_coverage = ProfilingOwnerCoverage::Complete;
-        observation.observed_claims = claim_closure(contract_, observed);
-        observation.attributed_claims = claim_closure(contract_, attributed);
-        observation.uncertainty_claims = claim_closure(contract_, uncertainty);
+        observation.observed_claims =
+            claim_closure(contract_, claims->observed);
+        observation.attributed_claims =
+            claim_closure(contract_, claims->attributed);
+        observation.uncertainty_claims =
+            claim_closure(contract_, claims->uncertainty);
         observation.safety_margin_claims =
-            claim_closure(contract_, safety_margin);
+            claim_closure(contract_, claims->safety_margin);
 
         return ProfilingObservationCollectionResult{
             ProfilingCollectionStatus::Accepted,
@@ -879,6 +1160,588 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
         return result_for(ProfilingCollectionStatus::InvalidObservation,
                           "profiling observation collection failed");
     }
+}
+
+namespace {
+
+ProfilingIntervalRecorderResult
+recorder_result(ProfilingIntervalRecorderStatus status,
+                std::string diagnostic = {}) {
+    return ProfilingIntervalRecorderResult{
+        status,
+        bounded_diagnostic(std::move(diagnostic)),
+        std::nullopt,
+    };
+}
+
+struct SegmentAccumulator {
+    ProfilingEventWatermark after_event_watermark;
+    ProfilingEventWatermark through_event_watermark;
+    std::uint64_t first_capture_generation = 0;
+    std::uint64_t last_capture_generation = 0;
+    std::uint64_t frame_count = 0;
+    std::string provenance_sha256;
+    std::vector<std::uint64_t> peak_observed;
+    std::vector<std::uint64_t> peak_attributed;
+    std::vector<std::uint64_t> maximum_uncertainty;
+    std::vector<std::uint64_t> minimum_safety_margin;
+    ProfilingRecordedCheckpoint checkpoint;
+    bool has_checkpoint = false;
+};
+
+} // namespace
+
+struct ProfilingIntervalRecorder::State {
+    ProfilingDerivationContract contract;
+    UnavailableProfilingIntervalObservationSource unavailable_source;
+    ProfilingIntervalObservationSource *source = nullptr;
+    ProfilingCollectionClock clock;
+    ProfilingTransactionContext context;
+    std::string contract_sha256;
+    std::string owner_scope_set_sha256;
+    std::string source_epoch_sha256;
+    ProfilingRawIntervalToken token;
+    ProfilingEventWatermark current_event_watermark;
+    std::optional<SteadyClock::time_point> last_read_started;
+    std::uint64_t next_capture_generation = 1;
+    std::uint64_t total_frame_count = 0;
+    SegmentAccumulator segment;
+    DerivedClaimAmounts last_claims;
+    std::string last_raw_frame_provenance_sha256;
+    std::string last_checkpoint_provenance_sha256;
+    ProfilingRecordedCheckpoint last_checkpoint;
+    bool is_active = false;
+
+    State(ProfilingDerivationContract input_contract,
+          ProfilingCollectionClock input_clock)
+        : contract(std::move(input_contract)), source(&unavailable_source),
+          clock(std::move(input_clock)) {
+        initialize_clock();
+    }
+
+    State(ProfilingDerivationContract input_contract,
+          ProfilingIntervalObservationSource &input_source,
+          ProfilingCollectionClock input_clock)
+        : contract(std::move(input_contract)), source(&input_source),
+          clock(std::move(input_clock)) {
+        initialize_clock();
+    }
+
+    void initialize_clock() {
+        if (!clock.monotonic_now) {
+            clock.monotonic_now = [] { return SteadyClock::now(); };
+        }
+        if (!clock.utc_now) clock.utc_now = [] { return SystemClock::now(); };
+    }
+
+    void cleanup() noexcept {
+        if (!is_active) return;
+        const auto owned_token = token;
+        is_active = false;
+        token = {};
+        source->finish(owned_token, current_event_watermark);
+    }
+
+    ProfilingIntervalRecorderResult fail_active(
+        ProfilingIntervalRecorderStatus status, std::string diagnostic) {
+        cleanup();
+        return recorder_result(status, std::move(diagnostic));
+    }
+
+    bool frame_matches_stream(const ProfilingRawIntervalFrame &frame) const {
+        return digest_is_valid(frame.source_epoch_sha256) &&
+               frame.source_epoch_sha256 == source_epoch_sha256 &&
+               frame.owner_scope_set_sha256 == owner_scope_set_sha256 &&
+               frame.event_semantics_revision_sha256 ==
+                   contract.interval.event_semantics_revision_sha256;
+    }
+
+    bool initialize_segment(ProfilingEventWatermark after) {
+        segment = {};
+        segment.after_event_watermark = after;
+        segment.through_event_watermark = after;
+        const auto seed = segment_provenance_seed(
+            context, source_epoch_sha256, owner_scope_set_sha256,
+            contract.interval.event_semantics_revision_sha256, after);
+        if (!seed) return false;
+        segment.provenance_sha256 = *seed;
+        return true;
+    }
+
+    bool fold_claims(const DerivedClaimAmounts &claims) {
+        return componentwise_maximum(segment.peak_observed,
+                                     claims.observed) &&
+               componentwise_maximum(segment.peak_attributed,
+                                     claims.attributed) &&
+               componentwise_maximum(segment.maximum_uncertainty,
+                                     claims.uncertainty) &&
+               componentwise_minimum(segment.minimum_safety_margin,
+                                     claims.safety_margin);
+    }
+
+    bool record_frame(const ProfilingRawIntervalFrame &frame,
+                      const std::optional<ProfilingAcquisitionTiming> &timing,
+                      bool counts_toward_limit) {
+        if (!frame_matches_stream(frame)) return false;
+        const auto claims = derive_claim_amounts(contract, frame.samples, false);
+        if (!claims ||
+            claims->source_generation != frame.event_watermark.value) {
+            return false;
+        }
+        if (counts_toward_limit) {
+            if (total_frame_count >= contract.interval.max_interval_frames ||
+                next_capture_generation == 0) {
+                return false;
+            }
+            ++total_frame_count;
+        }
+        const auto capture_generation = next_capture_generation;
+        if (counts_toward_limit) {
+            if (next_capture_generation ==
+                std::numeric_limits<std::uint64_t>::max()) {
+                next_capture_generation = 0;
+            } else {
+                ++next_capture_generation;
+            }
+        }
+
+        const auto frame_provenance =
+            interval_frame_provenance_digest(context, frame);
+        if (!frame_provenance ||
+            (frame.event_watermark == segment.through_event_watermark &&
+             !last_raw_frame_provenance_sha256.empty() &&
+             *frame_provenance != last_raw_frame_provenance_sha256)) {
+            return false;
+        }
+        auto provenance = extend_segment_provenance(
+            segment.provenance_sha256, capture_generation,
+            frame.event_watermark, *frame_provenance);
+        if (!provenance || !fold_claims(*claims)) return false;
+
+        if (segment.frame_count == 0) {
+            segment.first_capture_generation = capture_generation;
+        }
+        segment.last_capture_generation = capture_generation;
+        ++segment.frame_count;
+        segment.through_event_watermark = frame.event_watermark;
+        segment.provenance_sha256 = *provenance;
+
+        if (timing) {
+            const auto observation = derived_observation(
+                contract, context, frame.samples, *claims, *timing,
+                contract_sha256);
+            if (!observation) return false;
+            segment.checkpoint = ProfilingRecordedCheckpoint{
+                capture_generation,
+                frame.event_watermark,
+                *observation,
+            };
+            const auto checkpoint_provenance =
+                checkpoint_provenance_digest(segment.checkpoint);
+            provenance = checkpoint_provenance
+                             ? extend_checkpoint_provenance(
+                                   *provenance, *checkpoint_provenance)
+                             : std::nullopt;
+            if (!provenance) return false;
+            segment.provenance_sha256 = *provenance;
+            segment.has_checkpoint = true;
+            last_checkpoint = segment.checkpoint;
+            last_claims = *claims;
+            last_checkpoint_provenance_sha256 = *checkpoint_provenance;
+        }
+        last_raw_frame_provenance_sha256 = *frame_provenance;
+        return true;
+    }
+
+    bool seed_next_segment() {
+        if (!initialize_segment(current_event_watermark) ||
+            !fold_claims(last_claims)) {
+            return false;
+        }
+        const auto provenance = extend_checkpoint_provenance(
+            segment.provenance_sha256,
+            last_checkpoint_provenance_sha256);
+        if (!provenance) return false;
+        segment.first_capture_generation =
+            last_checkpoint.capture_generation;
+        segment.last_capture_generation = last_checkpoint.capture_generation;
+        segment.frame_count = 1;
+        segment.through_event_watermark = current_event_watermark;
+        segment.provenance_sha256 = *provenance;
+        segment.checkpoint = last_checkpoint;
+        segment.has_checkpoint = true;
+        return true;
+    }
+
+    std::optional<ProfilingIntervalSegment> close_segment() const {
+        if (!segment.has_checkpoint || segment.frame_count == 0 ||
+            segment.provenance_sha256.size() != 64) {
+            return std::nullopt;
+        }
+        std::vector<std::uint64_t> zero(contract.sensors.size(), 0);
+        ProfilingIntervalSegment result;
+        result.source_epoch_sha256 = source_epoch_sha256;
+        result.owner_scope_set_sha256 = owner_scope_set_sha256;
+        result.event_semantics_revision_sha256 =
+            contract.interval.event_semantics_revision_sha256;
+        result.after_event_watermark = segment.after_event_watermark;
+        result.through_event_watermark = segment.through_event_watermark;
+        result.first_capture_generation =
+            segment.first_capture_generation;
+        result.last_capture_generation = segment.last_capture_generation;
+        result.frame_count = segment.frame_count;
+        result.provenance_sha256 = segment.provenance_sha256;
+        result.checkpoint = segment.checkpoint;
+        result.peak_observed_claims =
+            claim_closure(contract, segment.peak_observed);
+        result.peak_attributed_claims =
+            claim_closure(contract, segment.peak_attributed);
+        result.external_change_claims = claim_closure(contract, zero);
+        result.unattributed_claims = claim_closure(contract, zero);
+        result.uncertainty_claims =
+            claim_closure(contract, segment.maximum_uncertainty);
+        result.safety_margin_claims =
+            claim_closure(contract, segment.minimum_safety_margin);
+        return result;
+    }
+
+    ProfilingIntervalRecorderResult handle_batch(
+        ProfilingRawIntervalBatch raw,
+        const ProfilingAcquisitionTiming &timing, bool close,
+        bool source_finished) {
+        auto fail = [&](ProfilingIntervalRecorderStatus status,
+                        std::string diagnostic) {
+            if (!source_finished) cleanup();
+            return recorder_result(status, std::move(diagnostic));
+        };
+        if (!raw.diagnostic.empty() ||
+            raw.after_event_watermark != current_event_watermark ||
+            raw.through_event_watermark.value <
+                raw.after_event_watermark.value) {
+            return fail(ProfilingIntervalRecorderStatus::InvalidObservation,
+                        "profiling interval batch is incoherent");
+        }
+        const auto event_count = raw.through_event_watermark.value -
+                                 raw.after_event_watermark.value;
+        const auto remaining =
+            contract.interval.max_interval_frames - total_frame_count;
+        if (event_count !=
+                static_cast<std::uint64_t>(raw.event_frames.size()) ||
+            remaining == 0 || event_count >= remaining) {
+            return fail(ProfilingIntervalRecorderStatus::InvalidObservation,
+                        "profiling interval history is incomplete");
+        }
+
+        auto expected = raw.after_event_watermark.value;
+        for (const auto &frame : raw.event_frames) {
+            if (expected == std::numeric_limits<std::uint64_t>::max()) {
+                return fail(
+                    ProfilingIntervalRecorderStatus::InvalidObservation,
+                    "profiling event watermark wrapped");
+            }
+            ++expected;
+            if (frame.event_watermark.value != expected ||
+                !record_frame(frame, std::nullopt, true)) {
+                return fail(
+                    ProfilingIntervalRecorderStatus::InvalidObservation,
+                    "profiling interval event history does not close");
+            }
+        }
+        if (expected != raw.through_event_watermark.value ||
+            raw.checkpoint.event_watermark !=
+                raw.through_event_watermark ||
+            !record_frame(raw.checkpoint, timing, true)) {
+            return fail(ProfilingIntervalRecorderStatus::InvalidObservation,
+                        "profiling interval checkpoint does not close");
+        }
+        current_event_watermark = raw.through_event_watermark;
+        if (!close) return recorder_result(ProfilingIntervalRecorderStatus::Ok);
+
+        auto closed = close_segment();
+        if (!closed) {
+            return fail(ProfilingIntervalRecorderStatus::DigestUnavailable,
+                        "profiling interval segment could not be sealed");
+        }
+        if (!source_finished && !seed_next_segment()) {
+            cleanup();
+            return recorder_result(
+                ProfilingIntervalRecorderStatus::DigestUnavailable,
+                "profiling interval boundary could not be retained");
+        }
+        return ProfilingIntervalRecorderResult{
+            ProfilingIntervalRecorderStatus::Ok,
+            {},
+            std::move(closed),
+        };
+    }
+
+    ProfilingIntervalRecorderResult read(bool close, bool finish_source,
+                                         const ProfilingCancellationCheck &abort) {
+        if (!is_active) {
+            return recorder_result(ProfilingIntervalRecorderStatus::InvalidState,
+                                   "profiling interval is not active");
+        }
+        if (!finish_source && cancelled(abort)) {
+            return fail_active(ProfilingIntervalRecorderStatus::Cancelled,
+                               "profiling interval recording cancelled");
+        }
+
+        SteadyClock::time_point started;
+        SystemClock::time_point observed_time;
+        try {
+            started = clock.monotonic_now();
+            observed_time = clock.utc_now();
+        } catch (...) {
+            return fail_active(
+                ProfilingIntervalRecorderStatus::InvalidObservation,
+                "profiling interval clock is unavailable");
+        }
+        if (last_read_started) {
+            const auto elapsed = elapsed_between(*last_read_started, started);
+            const auto gap = elapsed ? rounded_up_milliseconds(*elapsed)
+                                     : std::nullopt;
+            if (!gap ||
+                *gap > static_cast<std::uint64_t>(
+                           contract.interval.max_observation_gap.count())) {
+                return fail_active(
+                    ProfilingIntervalRecorderStatus::InvalidObservation,
+                    "profiling observation cadence exceeded its contract");
+            }
+        }
+
+        ProfilingRawIntervalBatch raw;
+        if (finish_source) {
+            const auto owned_token = token;
+            is_active = false;
+            token = {};
+            raw = source->finish(owned_token, current_event_watermark);
+        } else {
+            try {
+                raw = source->read_since(token, current_event_watermark,
+                                         abort);
+            } catch (...) {
+                return fail_active(
+                    ProfilingIntervalRecorderStatus::EvidenceUnavailable,
+                    "profiling interval observation source failed");
+            }
+        }
+        SteadyClock::time_point finished;
+        try {
+            finished = clock.monotonic_now();
+        } catch (...) {
+            return fail_active(
+                ProfilingIntervalRecorderStatus::InvalidObservation,
+                "profiling interval clock is unavailable");
+        }
+        last_read_started = started;
+
+        if (!finish_source &&
+            (cancelled(abort) ||
+             raw.error == ProfilingIntervalSourceError::Cancelled)) {
+            return fail_active(
+                ProfilingIntervalRecorderStatus::Cancelled,
+                raw.diagnostic.empty()
+                    ? "profiling interval recording cancelled"
+                    : std::move(raw.diagnostic));
+        }
+        if (raw.error != ProfilingIntervalSourceError::None) {
+            const auto status =
+                raw.error == ProfilingIntervalSourceError::Cancelled
+                    ? ProfilingIntervalRecorderStatus::Cancelled
+                    : ProfilingIntervalRecorderStatus::EvidenceUnavailable;
+            if (!finish_source) cleanup();
+            return recorder_result(
+                status,
+                raw.diagnostic.empty()
+                    ? "profiling interval observation source is unavailable"
+                    : std::move(raw.diagnostic));
+        }
+        try {
+            const auto timing =
+                acquisition_timing(contract, started, observed_time, finished);
+            if (!timing) {
+                if (!finish_source) cleanup();
+                return recorder_result(
+                    ProfilingIntervalRecorderStatus::InvalidObservation,
+                    "profiling interval acquisition exceeded its contract");
+            }
+            return handle_batch(std::move(raw), *timing, close, finish_source);
+        } catch (...) {
+            if (!finish_source) cleanup();
+            return recorder_result(
+                ProfilingIntervalRecorderStatus::EvidenceUnavailable,
+                "profiling interval evidence processing failed");
+        }
+    }
+};
+
+bool ProfilingIntervalRecorderResult::ok() const noexcept {
+    return status == ProfilingIntervalRecorderStatus::Ok;
+}
+
+ProfilingIntervalRecorder::ProfilingIntervalRecorder(
+    ProfilingDerivationContract contract, ProfilingCollectionClock clock)
+    : state_(std::make_unique<State>(std::move(contract), std::move(clock))) {}
+
+ProfilingIntervalRecorder::ProfilingIntervalRecorder(
+    ProfilingDerivationContract contract,
+    ProfilingIntervalObservationSource &source, ProfilingCollectionClock clock)
+    : state_(std::make_unique<State>(std::move(contract), source,
+                                     std::move(clock))) {}
+
+ProfilingIntervalRecorder::~ProfilingIntervalRecorder() { state_->cleanup(); }
+
+ProfilingIntervalRecorderResult ProfilingIntervalRecorder::begin(
+    const ProfilingTransactionContext &context,
+    const ProfilingCancellationCheck &should_abort) {
+    if (state_->is_active) {
+        return recorder_result(ProfilingIntervalRecorderStatus::InvalidState,
+                               "profiling interval is already active");
+    }
+    if (!contract_is_valid(state_->contract)) {
+        return recorder_result(ProfilingIntervalRecorderStatus::InvalidContract,
+                               "profiling derivation contract is invalid");
+    }
+    const auto contract_sha256 =
+        derivation_contract_digest(state_->contract);
+    const auto owner_scope_set_sha256 =
+        owner_scope_set_digest(state_->contract.owner_scopes);
+    if (!contract_sha256 || !owner_scope_set_sha256) {
+        return recorder_result(
+            ProfilingIntervalRecorderStatus::DigestUnavailable,
+            "profiling interval contract identity is unavailable");
+    }
+    if (context.observation_contract_sha256 != *contract_sha256) {
+        return recorder_result(
+            ProfilingIntervalRecorderStatus::InvalidContract,
+            "profiling derivation contract identity does not match context");
+    }
+    if (cancelled(should_abort)) {
+        return recorder_result(ProfilingIntervalRecorderStatus::Cancelled,
+                               "profiling interval recording cancelled");
+    }
+
+    ProfilingRawIntervalReadRequest request;
+    request.read.sensor_ids.reserve(state_->contract.sensors.size());
+    for (const auto &sensor : state_->contract.sensors) {
+        request.read.sensor_ids.push_back(sensor.sensor_id);
+    }
+    request.read.owner_scope_ids =
+        owner_scope_ids(state_->contract.owner_scopes);
+    request.read.owner_scope_set_sha256 = *owner_scope_set_sha256;
+    request.event_semantics_revision_sha256 =
+        state_->contract.interval.event_semantics_revision_sha256;
+
+    SteadyClock::time_point started;
+    SystemClock::time_point observed_time;
+    try {
+        started = state_->clock.monotonic_now();
+        observed_time = state_->clock.utc_now();
+    } catch (...) {
+        return recorder_result(
+            ProfilingIntervalRecorderStatus::InvalidObservation,
+            "profiling interval clock is unavailable");
+    }
+
+    ProfilingRawIntervalBeginResult raw;
+    try {
+        raw = state_->source->begin(request, should_abort);
+    } catch (...) {
+        return recorder_result(
+            ProfilingIntervalRecorderStatus::EvidenceUnavailable,
+            "profiling interval observation source failed");
+    }
+    if (raw.error == ProfilingIntervalSourceError::None) {
+        state_->token = raw.token;
+        state_->current_event_watermark = raw.checkpoint.event_watermark;
+        state_->is_active = true;
+        try {
+            state_->context = context;
+            state_->contract_sha256 = *contract_sha256;
+            state_->owner_scope_set_sha256 = *owner_scope_set_sha256;
+            state_->source_epoch_sha256 = raw.checkpoint.source_epoch_sha256;
+            state_->last_read_started = started;
+            state_->next_capture_generation = 1;
+            state_->total_frame_count = 0;
+            state_->last_raw_frame_provenance_sha256.clear();
+            state_->last_checkpoint_provenance_sha256.clear();
+            state_->last_checkpoint = {};
+            state_->last_claims = {};
+        } catch (...) {
+            return state_->fail_active(
+                ProfilingIntervalRecorderStatus::InvalidObservation,
+                "profiling interval state could not be retained");
+        }
+    }
+    if (cancelled(should_abort) ||
+        raw.error == ProfilingIntervalSourceError::Cancelled) {
+        state_->cleanup();
+        return recorder_result(
+            ProfilingIntervalRecorderStatus::Cancelled,
+            raw.diagnostic.empty() ? "profiling interval recording cancelled"
+                                   : std::move(raw.diagnostic));
+    }
+    if (raw.error != ProfilingIntervalSourceError::None) {
+        return recorder_result(
+            ProfilingIntervalRecorderStatus::EvidenceUnavailable,
+            raw.diagnostic.empty()
+                ? "profiling interval observation source is unavailable"
+                : std::move(raw.diagnostic));
+    }
+
+    SteadyClock::time_point finished;
+    try {
+        finished = state_->clock.monotonic_now();
+    } catch (...) {
+        return state_->fail_active(
+            ProfilingIntervalRecorderStatus::InvalidObservation,
+            "profiling interval clock is unavailable");
+    }
+
+    if (raw.token.opaque_id == 0 || !raw.diagnostic.empty() ||
+        !digest_is_valid(state_->source_epoch_sha256) ||
+        raw.checkpoint.owner_scope_set_sha256 !=
+            state_->owner_scope_set_sha256 ||
+        raw.checkpoint.event_semantics_revision_sha256 !=
+            state_->contract.interval.event_semantics_revision_sha256) {
+        return state_->fail_active(
+            ProfilingIntervalRecorderStatus::InvalidObservation,
+            "profiling interval begin checkpoint is incoherent");
+    }
+    try {
+        const auto timing = acquisition_timing(state_->contract, started,
+                                               observed_time, finished);
+        if (timing &&
+            state_->initialize_segment(state_->current_event_watermark) &&
+            state_->record_frame(raw.checkpoint, *timing, true)) {
+            return recorder_result(ProfilingIntervalRecorderStatus::Ok);
+        }
+    } catch (...) {
+        return state_->fail_active(
+            ProfilingIntervalRecorderStatus::EvidenceUnavailable,
+            "profiling interval evidence processing failed");
+    }
+    return state_->fail_active(
+        ProfilingIntervalRecorderStatus::InvalidObservation,
+        "profiling interval begin checkpoint does not close");
+}
+
+ProfilingIntervalRecorderResult ProfilingIntervalRecorder::poll(
+    const ProfilingCancellationCheck &should_abort) {
+    return state_->read(false, false, should_abort);
+}
+
+ProfilingIntervalRecorderResult ProfilingIntervalRecorder::checkpoint(
+    const ProfilingCancellationCheck &should_abort) {
+    return state_->read(true, false, should_abort);
+}
+
+ProfilingIntervalRecorderResult ProfilingIntervalRecorder::finish() {
+    return state_->read(true, true, {});
+}
+
+bool ProfilingIntervalRecorder::active() const noexcept {
+    return state_->is_active;
 }
 
 } // namespace lemon::residency

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -1256,6 +1256,17 @@ struct ProfilingIntervalRecorder::State {
                    contract.interval.event_semantics_revision_sha256;
     }
 
+    bool frame_repeats_last_checkpoint(
+        const ProfilingRawIntervalFrame &frame) const {
+        if (!frame_matches_stream(frame)) return false;
+        const auto claims = derive_claim_amounts(contract, frame.samples, false);
+        const auto provenance = interval_frame_provenance_digest(context, frame);
+        return claims &&
+               claims->source_generation == frame.event_watermark.value &&
+               provenance &&
+               *provenance == last_raw_frame_provenance_sha256;
+    }
+
     bool initialize_segment(ProfilingEventWatermark after) {
         segment = {};
         segment.after_event_watermark = after;
@@ -1425,9 +1436,15 @@ struct ProfilingIntervalRecorder::State {
                                  raw.after_event_watermark.value;
         const auto remaining =
             contract.interval.max_interval_frames - total_frame_count;
+        const bool reuses_final_checkpoint =
+            source_finished && remaining == 0 && event_count == 0 &&
+            raw.event_frames.empty() &&
+            raw.checkpoint.event_watermark == current_event_watermark &&
+            frame_repeats_last_checkpoint(raw.checkpoint);
         if (event_count !=
                 static_cast<std::uint64_t>(raw.event_frames.size()) ||
-            remaining == 0 || event_count >= remaining) {
+            (!reuses_final_checkpoint &&
+             (remaining == 0 || event_count >= remaining))) {
             return fail(ProfilingIntervalRecorderStatus::InvalidObservation,
                         "profiling interval history is incomplete");
         }
@@ -1450,7 +1467,8 @@ struct ProfilingIntervalRecorder::State {
         if (expected != raw.through_event_watermark.value ||
             raw.checkpoint.event_watermark !=
                 raw.through_event_watermark ||
-            !record_frame(raw.checkpoint, timing, true)) {
+            (!reuses_final_checkpoint &&
+             !record_frame(raw.checkpoint, timing, true))) {
             return fail(ProfilingIntervalRecorderStatus::InvalidObservation,
                         "profiling interval checkpoint does not close");
         }

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -599,7 +599,7 @@ reconcile_samples(const ProfilingDerivationContract &contract,
     for (std::size_t index = 0; index < contract.sensors.size(); ++index) {
         sensor_indices.emplace(contract.sensors[index].sensor_id, index);
     }
-    const std::set<std::string> owner_scope_ids(
+    const std::set<std::string> expected_owner_scope_id_set(
         expected_owner_scope_ids.begin(), expected_owner_scope_ids.end());
 
     std::vector<SensorValues> values(contract.sensors.size());
@@ -612,7 +612,7 @@ reconcile_samples(const ProfilingDerivationContract &contract,
             sensor_values.total = sample.value;
             continue;
         }
-        if (owner_scope_ids.count(*sample.owner_scope_id) == 0 ||
+        if (expected_owner_scope_id_set.count(*sample.owner_scope_id) == 0 ||
             !sensor_values.owners.emplace(*sample.owner_scope_id, sample.value)
                  .second) {
             return std::nullopt;

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -141,17 +141,58 @@ bool digest_is_valid(std::string_view value) noexcept {
            });
 }
 
+bool owner_scopes_are_valid(
+    const std::vector<ProfilingOwnerScopeBinding> &owner_scopes) {
+    if (owner_scopes.empty() ||
+        owner_scopes.size() > max_journal_array_entries) {
+        return false;
+    }
+
+    std::set<std::string> owner_scope_ids;
+    std::set<std::string> containment_identities;
+    for (const auto &owner_scope : owner_scopes) {
+        if (!identifier_is_valid(owner_scope.owner_scope_id) ||
+            !digest_is_valid(owner_scope.containment_identity_sha256) ||
+            !owner_scope_ids.insert(owner_scope.owner_scope_id).second ||
+            !containment_identities
+                 .insert(owner_scope.containment_identity_sha256)
+                 .second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::vector<std::string> owner_scope_ids(
+    const std::vector<ProfilingOwnerScopeBinding> &owner_scopes) {
+    std::vector<std::string> result;
+    result.reserve(owner_scopes.size());
+    for (const auto &owner_scope : owner_scopes) {
+        result.push_back(owner_scope.owner_scope_id);
+    }
+    return result;
+}
+
 bool contract_is_valid(const ProfilingDerivationContract &contract) {
     if (!identifier_is_valid(contract.provider_id) ||
         !digest_is_valid(contract.provider_revision_sha256) ||
         contract.sensors.empty() ||
         contract.sensors.size() > max_journal_array_entries ||
-        contract.owner_scope_ids.empty() ||
-        contract.owner_scope_ids.size() > max_journal_array_entries ||
+        !owner_scopes_are_valid(contract.owner_scopes) ||
         contract.freshness_window <= std::chrono::seconds::zero() ||
         contract.max_source_skew <= std::chrono::milliseconds::zero() ||
         contract.max_source_skew.count() / 1000 >=
-            contract.freshness_window.count()) {
+            contract.freshness_window.count() ||
+        !digest_is_valid(
+            contract.interval.event_semantics_revision_sha256) ||
+        contract.interval.max_observation_gap <=
+            std::chrono::milliseconds::zero() ||
+        contract.interval.baseline_stability_window <=
+            std::chrono::milliseconds::zero() ||
+        contract.interval.release_stability_window <=
+            std::chrono::milliseconds::zero() ||
+        contract.interval.max_interval_frames == 0 ||
+        contract.interval.max_interval_frames > max_profiling_interval_frames) {
         return false;
     }
 
@@ -168,13 +209,6 @@ bool contract_is_valid(const ProfilingDerivationContract &contract) {
         }
     }
 
-    std::set<std::string> owner_scope_ids;
-    for (const auto &owner_scope_id : contract.owner_scope_ids) {
-        if (!identifier_is_valid(owner_scope_id) ||
-            !owner_scope_ids.insert(owner_scope_id).second) {
-            return false;
-        }
-    }
     return true;
 }
 
@@ -321,6 +355,29 @@ std::optional<std::string> sha256_hex(std::string_view bytes) {
     return result;
 }
 
+std::optional<std::string> owner_scope_set_digest(
+    const std::vector<ProfilingOwnerScopeBinding> &input_owner_scopes) {
+    if (!owner_scopes_are_valid(input_owner_scopes)) return std::nullopt;
+
+    auto owner_scopes = input_owner_scopes;
+    std::sort(owner_scopes.begin(), owner_scopes.end(),
+              [](const ProfilingOwnerScopeBinding &left,
+                 const ProfilingOwnerScopeBinding &right) {
+                  return std::tie(left.owner_scope_id,
+                                  left.containment_identity_sha256) <
+                         std::tie(right.owner_scope_id,
+                                  right.containment_identity_sha256);
+              });
+
+    std::string bytes = "lemonade/profiling-owner-scope-set/v1";
+    append_u64(bytes, static_cast<std::uint64_t>(owner_scopes.size()));
+    for (const auto &owner_scope : owner_scopes) {
+        append_string(bytes, owner_scope.owner_scope_id);
+        append_string(bytes, owner_scope.containment_identity_sha256);
+    }
+    return sha256_hex(bytes);
+}
+
 std::optional<std::string>
 derivation_contract_digest(const ProfilingDerivationContract &contract) {
     if (!contract_is_valid(contract)) return std::nullopt;
@@ -336,10 +393,11 @@ derivation_contract_digest(const ProfilingDerivationContract &contract) {
                                   right.claim_family, right.uncertainty_bound,
                                   right.safety_ceiling);
               });
-    auto owner_scope_ids = contract.owner_scope_ids;
-    std::sort(owner_scope_ids.begin(), owner_scope_ids.end());
+    const auto owner_scope_set_sha256 =
+        owner_scope_set_digest(contract.owner_scopes);
+    if (!owner_scope_set_sha256) return std::nullopt;
 
-    std::string bytes = "lemonade/profiling-derivation-contract/v1";
+    std::string bytes = "lemonade/profiling-derivation-contract/v2";
     append_string(bytes, contract.provider_id);
     append_string(bytes, contract.provider_revision_sha256);
     append_u64(bytes, static_cast<std::uint64_t>(sensors.size()));
@@ -353,14 +411,19 @@ derivation_contract_digest(const ProfilingDerivationContract &contract) {
         append_u64(bytes, sensor.uncertainty_bound);
         append_u64(bytes, sensor.safety_ceiling);
     }
-    append_u64(bytes, static_cast<std::uint64_t>(owner_scope_ids.size()));
-    for (const auto &owner_scope_id : owner_scope_ids) {
-        append_string(bytes, owner_scope_id);
-    }
+    append_string(bytes, *owner_scope_set_sha256);
     append_u64(bytes,
                static_cast<std::uint64_t>(contract.freshness_window.count()));
     append_u64(bytes,
                static_cast<std::uint64_t>(contract.max_source_skew.count()));
+    append_string(bytes, contract.interval.event_semantics_revision_sha256);
+    append_u64(bytes, static_cast<std::uint64_t>(
+                          contract.interval.max_observation_gap.count()));
+    append_u64(bytes, static_cast<std::uint64_t>(
+                          contract.interval.baseline_stability_window.count()));
+    append_u64(bytes, static_cast<std::uint64_t>(
+                          contract.interval.release_stability_window.count()));
+    append_u64(bytes, contract.interval.max_interval_frames);
     return sha256_hex(bytes);
 }
 
@@ -444,12 +507,13 @@ source_generation(const std::vector<ProfilingRawSample> &samples) noexcept {
 std::optional<std::vector<SensorValues>>
 reconcile_samples(const ProfilingDerivationContract &contract,
                   const std::vector<ProfilingRawSample> &samples) {
+    const auto expected_owner_scope_ids = owner_scope_ids(contract.owner_scopes);
     if (contract.sensors.size() > std::numeric_limits<std::size_t>::max() /
-                                      (contract.owner_scope_ids.size() + 1)) {
+                                      (expected_owner_scope_ids.size() + 1)) {
         return std::nullopt;
     }
     const auto expected_count =
-        contract.sensors.size() * (contract.owner_scope_ids.size() + 1);
+        contract.sensors.size() * (expected_owner_scope_ids.size() + 1);
     if (samples.size() != expected_count) return std::nullopt;
 
     std::map<std::string, std::size_t> sensor_indices;
@@ -457,7 +521,7 @@ reconcile_samples(const ProfilingDerivationContract &contract,
         sensor_indices.emplace(contract.sensors[index].sensor_id, index);
     }
     const std::set<std::string> owner_scope_ids(
-        contract.owner_scope_ids.begin(), contract.owner_scope_ids.end());
+        expected_owner_scope_ids.begin(), expected_owner_scope_ids.end());
 
     std::vector<SensorValues> values(contract.sensors.size());
     for (const auto &sample : samples) {
@@ -478,10 +542,10 @@ reconcile_samples(const ProfilingDerivationContract &contract,
 
     for (auto &sensor_values : values) {
         if (!sensor_values.total ||
-            sensor_values.owners.size() != contract.owner_scope_ids.size()) {
+            sensor_values.owners.size() != expected_owner_scope_ids.size()) {
             return std::nullopt;
         }
-        for (const auto &owner_scope_id : contract.owner_scope_ids) {
+        for (const auto &owner_scope_id : expected_owner_scope_ids) {
             const auto owner = sensor_values.owners.find(owner_scope_id);
             if (owner == sensor_values.owners.end() ||
                 owner->second > std::numeric_limits<std::uint64_t>::max() -
@@ -563,12 +627,56 @@ std::optional<std::string> profiling_derivation_contract_sha256(
     return derivation_contract_digest(contract);
 }
 
+std::optional<std::string> profiling_owner_scope_set_sha256(
+    const std::vector<ProfilingOwnerScopeBinding> &owner_scopes) {
+    return owner_scope_set_digest(owner_scopes);
+}
+
 ProfilingRawReadResult UnavailableProfilingObservationSource::read(
     const ProfilingRawReadRequest &, const ProfilingCancellationCheck &) {
     return ProfilingRawReadResult{
         ProfilingSourceError::Unavailable,
         {},
+        {},
         "profiling observation source is unavailable",
+    };
+}
+
+ProfilingRawIntervalBeginResult
+UnavailableProfilingIntervalObservationSource::begin(
+    const ProfilingRawIntervalReadRequest &,
+    const ProfilingCancellationCheck &) {
+    return ProfilingRawIntervalBeginResult{
+        ProfilingIntervalSourceError::Unavailable,
+        {},
+        {},
+        "profiling interval observation source is unavailable",
+    };
+}
+
+ProfilingRawIntervalBatch
+UnavailableProfilingIntervalObservationSource::read_since(
+    ProfilingRawIntervalToken, ProfilingEventWatermark after_event_watermark,
+    const ProfilingCancellationCheck &) {
+    return ProfilingRawIntervalBatch{
+        ProfilingIntervalSourceError::Unavailable,
+        after_event_watermark,
+        after_event_watermark,
+        {},
+        {},
+        "profiling interval observation source is unavailable",
+    };
+}
+
+ProfilingRawIntervalBatch UnavailableProfilingIntervalObservationSource::finish(
+    ProfilingRawIntervalToken, ProfilingEventWatermark after_event_watermark) {
+    return ProfilingRawIntervalBatch{
+        ProfilingIntervalSourceError::Unavailable,
+        after_event_watermark,
+        after_event_watermark,
+        {},
+        {},
+        "profiling interval observation source is unavailable",
     };
 }
 
@@ -617,6 +725,13 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
                               "profiling derivation contract identity does not "
                               "match context");
         }
+        const auto owner_scope_set_sha256 =
+            owner_scope_set_digest(contract_.owner_scopes);
+        if (!owner_scope_set_sha256) {
+            return result_for(
+                ProfilingCollectionStatus::DigestUnavailable,
+                "profiling owner-scope identity is unavailable");
+        }
         if (cancelled(should_abort)) {
             return result_for(ProfilingCollectionStatus::Cancelled,
                               "profiling observation collection cancelled");
@@ -650,7 +765,8 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
         for (const auto &sensor : contract_.sensors) {
             request.sensor_ids.push_back(sensor.sensor_id);
         }
-        request.owner_scope_ids = contract_.owner_scope_ids;
+        request.owner_scope_ids = owner_scope_ids(contract_.owner_scopes);
+        request.owner_scope_set_sha256 = *owner_scope_set_sha256;
 
         ProfilingRawReadResult raw;
         try {
@@ -674,6 +790,11 @@ ProfilingObservationCollectionResult ProfilingObservationCollector::collect(
                 raw.diagnostic.empty()
                     ? "profiling observation source is unavailable"
                     : std::move(raw.diagnostic));
+        }
+        if (raw.owner_scope_set_sha256 != *owner_scope_set_sha256) {
+            return result_for(
+                ProfilingCollectionStatus::InvalidObservation,
+                "profiling owner-scope identity does not match the contract");
         }
         const auto elapsed = elapsed_between(started, finished);
         const auto skew = elapsed ? rounded_up_milliseconds(*elapsed)

--- a/test/cpp/test_residency_profiling_interval.cpp
+++ b/test/cpp/test_residency_profiling_interval.cpp
@@ -1,0 +1,747 @@
+#include "lemon/residency/profiling_provider.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using namespace lemon::residency;
+using namespace std::chrono_literals;
+
+namespace {
+
+template <typename T, typename = void>
+struct HasPhase : std::false_type {};
+
+template <typename T>
+struct HasPhase<T, std::void_t<decltype(T::phase)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct HasLifecycleState : std::false_type {};
+
+template <typename T>
+struct HasLifecycleState<T, std::void_t<decltype(T::lifecycle_state)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasAttestation : std::false_type {};
+
+template <typename T>
+struct HasAttestation<T, std::void_t<decltype(T::attestation)>>
+    : std::true_type {};
+
+static_assert(!HasPhase<ProfilingIntervalSegment>::value);
+static_assert(!HasLifecycleState<ProfilingIntervalSegment>::value);
+static_assert(!HasAttestation<ProfilingIntervalSegment>::value);
+static_assert(noexcept(
+    std::declval<ProfilingIntervalObservationSource &>().finish(
+        ProfilingRawIntervalToken{}, ProfilingEventWatermark{})));
+
+struct TestState {
+    std::atomic<bool> ok{true};
+
+    void require(bool condition, const char *message) {
+        if (condition) return;
+        ok.store(false);
+        std::cerr << "FAIL: " << message << '\n';
+    }
+};
+
+std::string digest(char value) { return std::string(64, value); }
+
+ProfilingDerivationContract contract() {
+    ProfilingDerivationContract value;
+    value.provider_id = "provider/scripted-interval";
+    value.provider_revision_sha256 = digest('e');
+    value.sensors = {
+        ProfilingSensorContract{"sensor/gtt-used", "gpu/gtt",
+                                ClaimFamily::ConsumableCapacity, 10, 1000},
+    };
+    value.owner_scopes = {
+        ProfilingOwnerScopeBinding{"owner/model-alpha", digest('f')},
+    };
+    value.freshness_window = 60s;
+    value.max_source_skew = 20ms;
+    value.interval.event_semantics_revision_sha256 = digest('9');
+    value.interval.max_observation_gap = 50ms;
+    value.interval.baseline_stability_window = 100ms;
+    value.interval.release_stability_window = 200ms;
+    value.interval.max_interval_frames = 128;
+    return value;
+}
+
+ProfilingTransactionContext context(
+    const ProfilingDerivationContract &derivation_contract = contract()) {
+    const auto contract_sha256 =
+        profiling_derivation_contract_sha256(derivation_contract);
+    if (!contract_sha256) throw std::runtime_error("invalid test contract");
+
+    ProfilingTransactionContext value;
+    value.deployment_id = digest('a');
+    value.sequence = 1;
+    value.profiling_transaction_id = "profile/scripted-interval";
+    value.selector_sha256 = digest('b');
+    value.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    value.observation_contract_sha256 = *contract_sha256;
+    value.predictor_contract_sha256 = digest('d');
+    return value;
+}
+
+ProfilingCollectionClock clock() {
+    auto monotonic = std::make_shared<std::uint64_t>(0);
+    auto utc = std::make_shared<std::uint64_t>(1000);
+    ProfilingCollectionClock value;
+    value.monotonic_now = [monotonic] {
+        const auto result = std::chrono::steady_clock::time_point{} +
+                            std::chrono::milliseconds(*monotonic);
+        *monotonic += 5;
+        return result;
+    };
+    value.utc_now = [utc] {
+        const auto result = std::chrono::system_clock::time_point{} +
+                            std::chrono::seconds(*utc);
+        ++*utc;
+        return result;
+    };
+    return value;
+}
+
+ProfilingCollectionClock clock_at(std::uint64_t utc_seconds) {
+    auto value = clock();
+    auto utc = std::make_shared<std::uint64_t>(utc_seconds);
+    value.utc_now = [utc] {
+        const auto result = std::chrono::system_clock::time_point{} +
+                            std::chrono::seconds(*utc);
+        ++*utc;
+        return result;
+    };
+    return value;
+}
+
+ProfilingRawIntervalFrame frame(std::uint64_t watermark,
+                                std::uint64_t total,
+                                std::uint64_t owner) {
+    ProfilingRawIntervalFrame value;
+    value.source_epoch_sha256 = digest('1');
+    const auto owner_scope_set =
+        profiling_owner_scope_set_sha256(contract().owner_scopes);
+    if (!owner_scope_set) throw std::runtime_error("invalid owner scope set");
+    value.owner_scope_set_sha256 = *owner_scope_set;
+    value.event_semantics_revision_sha256 = digest('9');
+    value.event_watermark = ProfilingEventWatermark{watermark};
+    value.samples = {
+        ProfilingRawSample{"sensor/gtt-used", std::nullopt, total, watermark},
+        ProfilingRawSample{"sensor/gtt-used", "owner/model-alpha", owner,
+                           watermark},
+    };
+    return value;
+}
+
+ProfilingRawIntervalBatch batch(std::uint64_t after, std::uint64_t through,
+                                std::vector<ProfilingRawIntervalFrame> events,
+                                ProfilingRawIntervalFrame checkpoint) {
+    return ProfilingRawIntervalBatch{
+        ProfilingIntervalSourceError::None,
+        ProfilingEventWatermark{after},
+        ProfilingEventWatermark{through},
+        std::move(events),
+        std::move(checkpoint),
+        {},
+    };
+}
+
+class ScriptedIntervalSource final : public ProfilingIntervalObservationSource {
+public:
+    ProfilingRawIntervalBeginResult begin_result;
+    std::deque<ProfilingRawIntervalBatch> reads;
+    ProfilingRawIntervalBatch finish_result;
+    bool throw_on_read = false;
+    std::function<void()> on_begin;
+    std::size_t begin_calls = 0;
+    std::size_t read_calls = 0;
+    std::size_t finish_calls = 0;
+
+    ProfilingRawIntervalBeginResult
+    begin(const ProfilingRawIntervalReadRequest &request,
+          const ProfilingCancellationCheck &should_abort) override {
+        ++begin_calls;
+        last_request = request;
+        if (should_abort && should_abort()) {
+            return ProfilingRawIntervalBeginResult{
+                ProfilingIntervalSourceError::Cancelled,
+                {},
+                {},
+                "scripted begin cancelled",
+            };
+        }
+        if (on_begin) on_begin();
+        return begin_result;
+    }
+
+    ProfilingRawIntervalBatch
+    read_since(ProfilingRawIntervalToken token,
+               ProfilingEventWatermark after_event_watermark,
+               const ProfilingCancellationCheck &should_abort) override {
+        ++read_calls;
+        last_token = token;
+        last_after = after_event_watermark;
+        if (throw_on_read) throw std::runtime_error("scripted read failure");
+        if (should_abort && should_abort()) {
+            return ProfilingRawIntervalBatch{
+                ProfilingIntervalSourceError::Cancelled,
+                after_event_watermark,
+                after_event_watermark,
+                {},
+                {},
+                "scripted read cancelled",
+            };
+        }
+        if (reads.empty()) {
+            return ProfilingRawIntervalBatch{
+                ProfilingIntervalSourceError::Unavailable,
+                after_event_watermark,
+                after_event_watermark,
+                {},
+                {},
+                "script exhausted",
+            };
+        }
+        auto result = std::move(reads.front());
+        reads.pop_front();
+        return result;
+    }
+
+    ProfilingRawIntervalBatch
+    finish(ProfilingRawIntervalToken token,
+           ProfilingEventWatermark after_event_watermark) noexcept override {
+        ++finish_calls;
+        last_token = token;
+        last_after = after_event_watermark;
+        return finish_result;
+    }
+
+    ProfilingRawIntervalReadRequest last_request;
+    ProfilingRawIntervalToken last_token;
+    ProfilingEventWatermark last_after;
+};
+
+ScriptedIntervalSource source() {
+    ScriptedIntervalSource value;
+    value.begin_result = ProfilingRawIntervalBeginResult{
+        ProfilingIntervalSourceError::None,
+        ProfilingRawIntervalToken{7},
+        frame(10, 100, 100),
+        {},
+    };
+    value.reads.push_back(batch(
+        10, 12, {frame(11, 200, 200), frame(12, 300, 300)},
+        frame(12, 300, 300)));
+    value.finish_result =
+        batch(12, 13, {frame(13, 100, 100)}, frame(13, 100, 100));
+    return value;
+}
+
+const ClaimFamilyClosure *family(const std::vector<ClaimFamilyClosure> &claims,
+                                 ClaimFamily wanted) {
+    for (const auto &candidate : claims) {
+        if (candidate.family == wanted) return &candidate;
+    }
+    return nullptr;
+}
+
+void require_capacity(TestState &state,
+                      const std::vector<ClaimFamilyClosure> &claims,
+                      std::uint64_t expected, const char *message) {
+    const auto *capacity = family(claims, ClaimFamily::ConsumableCapacity);
+    const bool matches = capacity != nullptr &&
+                         capacity->completeness == ClaimCompleteness::Bounded &&
+                         capacity->entries.size() == 1 &&
+                         capacity->entries.front().constraint_id == "gpu/gtt" &&
+                         capacity->entries.front().unit == ClaimUnit::Bytes &&
+                         capacity->entries.front().amount == expected;
+    state.require(matches, message);
+}
+
+void require_capacity_zero(TestState &state,
+                           const std::vector<ClaimFamilyClosure> &claims,
+                           const char *message) {
+    const auto *capacity = family(claims, ClaimFamily::ConsumableCapacity);
+    state.require(capacity != nullptr &&
+                      capacity->completeness == ClaimCompleteness::KnownZero &&
+                      capacity->entries.empty(),
+                  message);
+}
+
+void test_records_complete_interval_segments(TestState &state) {
+    auto scripted = source();
+    ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+
+    const auto started = recorder.begin(context(), [] { return false; });
+    state.require(started.ok() && !started.segment.has_value() &&
+                      recorder.active(),
+                  "a valid atomic checkpoint opens the interval");
+    const auto owner_scope_set =
+        profiling_owner_scope_set_sha256(contract().owner_scopes);
+    state.require(owner_scope_set.has_value() &&
+                      scripted.last_request.read.owner_scope_set_sha256 ==
+                          *owner_scope_set &&
+                      scripted.last_request.event_semantics_revision_sha256 ==
+                          digest('9'),
+                  "the recorder binds containment and event semantics");
+
+    const auto checkpoint = recorder.checkpoint([] { return false; });
+    state.require(checkpoint.ok() && checkpoint.segment.has_value(),
+                  "a complete retained batch closes one segment");
+    if (checkpoint.segment) {
+        const auto &segment = *checkpoint.segment;
+        state.require(segment.after_event_watermark.value == 10 &&
+                          segment.through_event_watermark.value == 12 &&
+                          segment.first_capture_generation == 1 &&
+                          segment.last_capture_generation == 4 &&
+                          segment.frame_count == 4,
+                      "the segment keeps separate event and capture order");
+        state.require(segment.checkpoint.capture_generation == 4 &&
+                          segment.checkpoint.event_watermark.value == 12 &&
+                          segment.checkpoint.observation.source_generation ==
+                              12,
+                      "the checkpoint binds both ordering domains");
+        require_capacity(state, segment.peak_observed_claims, 300,
+                         "the segment derives the hidden workload peak");
+        require_capacity(state, segment.peak_attributed_claims, 300,
+                         "the segment peak remains owner attributed");
+        require_capacity_zero(state, segment.external_change_claims,
+                              "complete event history proves no external change");
+        require_capacity_zero(state, segment.unattributed_claims,
+                              "every interval frame proves current owner closure");
+        require_capacity(state, segment.uncertainty_claims, 10,
+                         "the segment retains maximum uncertainty");
+        require_capacity(state, segment.safety_margin_claims, 690,
+                         "the segment retains minimum safety slack");
+        state.require(segment.provenance_sha256.size() == 64,
+                      "the segment binds its ordered transcript");
+    }
+
+    const auto finished = recorder.finish();
+    state.require(finished.ok() && finished.segment.has_value() &&
+                      !recorder.active() && scripted.finish_calls == 1,
+                  "finish drains and unregisters the interval once");
+    if (finished.segment) {
+        state.require(finished.segment->after_event_watermark.value == 12 &&
+                          finished.segment->through_event_watermark.value ==
+                              13 &&
+                          finished.segment->checkpoint.capture_generation == 6,
+                      "the final segment begins at the prior atomic boundary");
+    }
+}
+
+void test_zero_event_watermark_is_not_a_capture_generation(TestState &state) {
+    auto scripted = source();
+    scripted.begin_result.checkpoint = frame(0, 100, 100);
+    scripted.finish_result = batch(0, 0, {}, frame(0, 100, 100));
+    ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+
+    const auto started = recorder.begin(context(), [] { return false; });
+    const auto finished = recorder.finish();
+
+    state.require(started.ok() && finished.ok() && finished.segment.has_value(),
+                  "a source-native zero watermark remains a valid cursor");
+    if (finished.segment) {
+        state.require(finished.segment->checkpoint.event_watermark.value == 0 &&
+                          finished.segment->checkpoint.capture_generation == 2,
+                      "Server capture order stays independent from watermark zero");
+    }
+}
+
+void test_poll_retains_history_for_the_next_checkpoint(TestState &state) {
+    auto scripted = source();
+    scripted.reads.push_back(batch(
+        12, 13, {frame(13, 400, 400)}, frame(13, 400, 400)));
+    scripted.finish_result =
+        batch(13, 14, {frame(14, 100, 100)}, frame(14, 100, 100));
+    ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+
+    const auto started = recorder.begin(context(), [] { return false; });
+    const auto polled = recorder.poll([] { return false; });
+    const auto checkpointed = recorder.checkpoint([] { return false; });
+
+    state.require(started.ok() && polled.ok() &&
+                      !polled.segment.has_value() && recorder.active() &&
+                      checkpointed.segment.has_value() &&
+                      scripted.last_after.value == 12,
+                  "poll advances the cursor without closing the interval");
+    if (checkpointed.segment) {
+        const auto &segment = *checkpointed.segment;
+        state.require(segment.after_event_watermark.value == 10 &&
+                          segment.through_event_watermark.value == 13 &&
+                          segment.first_capture_generation == 1 &&
+                          segment.last_capture_generation == 6 &&
+                          segment.frame_count == 6 &&
+                          segment.provenance_sha256.size() == 64,
+                      "the next checkpoint retains every polled frame");
+        require_capacity(state, segment.peak_observed_claims, 400,
+                         "the checkpoint retains the polled peak");
+    }
+
+    const auto finished = recorder.finish();
+    state.require(finished.ok() && !recorder.active() &&
+                      scripted.finish_calls == 1 &&
+                      scripted.last_token.opaque_id == 7 &&
+                      scripted.last_after.value == 13,
+                  "finish drains the owned token at the final cursor");
+
+    auto alternate_source = source();
+    alternate_source.reads.front().event_frames.front() =
+        frame(11, 250, 250);
+    alternate_source.reads.push_back(batch(
+        12, 13, {frame(13, 400, 400)}, frame(13, 400, 400)));
+    alternate_source.finish_result =
+        batch(13, 14, {frame(14, 100, 100)}, frame(14, 100, 100));
+    ProfilingIntervalRecorder alternate(contract(), alternate_source, clock());
+    const auto alternate_started =
+        alternate.begin(context(), [] { return false; });
+    const auto alternate_polled = alternate.poll([] { return false; });
+    const auto alternate_checkpointed =
+        alternate.checkpoint([] { return false; });
+
+    state.require(alternate_started.ok() && alternate_polled.ok() &&
+                      alternate_checkpointed.segment.has_value() &&
+                      checkpointed.segment.has_value() &&
+                      alternate_checkpointed.segment->frame_count ==
+                          checkpointed.segment->frame_count &&
+                      alternate_checkpointed.segment->through_event_watermark ==
+                          checkpointed.segment->through_event_watermark &&
+                      alternate_checkpointed.segment->provenance_sha256 !=
+                          checkpointed.segment->provenance_sha256,
+                  "polled frames change provenance even below the same peak");
+    if (alternate_checkpointed.segment) {
+        require_capacity(state,
+                         alternate_checkpointed.segment->peak_observed_claims,
+                         400, "the alternate transcript has the same peak");
+        require_capacity(
+            state, alternate_checkpointed.segment->uncertainty_claims, 10,
+            "the alternate transcript has the same uncertainty");
+        require_capacity(
+            state, alternate_checkpointed.segment->safety_margin_claims, 590,
+            "the alternate transcript has the same safety margin");
+    }
+    const auto alternate_finished = alternate.finish();
+    state.require(alternate_finished.ok() &&
+                      alternate_source.finish_calls == 1,
+                  "the alternate transcript also drains exactly once");
+}
+
+void test_transient_external_demand_fails_closed(TestState &state) {
+    auto scripted = source();
+    scripted.reads.clear();
+    scripted.reads.push_back(batch(
+        10, 12, {frame(11, 200, 100), frame(12, 100, 100)},
+        frame(12, 100, 100)));
+    ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+
+    const auto started = recorder.begin(context(), [] { return false; });
+    const auto result = recorder.checkpoint([] { return false; });
+
+    state.require(started.ok() &&
+                      result.status ==
+                          ProfilingIntervalRecorderStatus::InvalidObservation &&
+                      !result.segment.has_value(),
+                  "transient external demand invalidates the whole interval");
+    state.require(!recorder.active() && scripted.finish_calls == 1,
+                  "invalid history is drained before returning failure");
+}
+
+void test_rejects_incomplete_or_rebound_history(TestState &state) {
+    struct Mutation {
+        const char *message;
+        std::function<void(ProfilingRawIntervalBatch &)> apply;
+    };
+    const std::vector<Mutation> mutations{
+        {"a missing retained event invalidates the interval",
+         [](auto &value) { value.event_frames.erase(value.event_frames.begin()); }},
+        {"an out-of-order event invalidates the interval",
+         [](auto &value) {
+             value.event_frames.front().event_watermark =
+                 ProfilingEventWatermark{12};
+         }},
+        {"a source epoch change invalidates the interval",
+         [](auto &value) {
+             value.event_frames.front().source_epoch_sha256 = digest('2');
+         }},
+        {"an owner-containment change invalidates the interval",
+         [](auto &value) {
+             value.event_frames.front().owner_scope_set_sha256 = digest('2');
+         }},
+        {"an event-semantics change invalidates the interval",
+         [](auto &value) {
+             value.event_frames.front().event_semantics_revision_sha256 =
+                 digest('2');
+         }},
+        {"a sample-generation mismatch invalidates the interval",
+         [](auto &value) {
+             value.event_frames.front().samples.front().source_generation = 99;
+         }},
+        {"a mismatched atomic checkpoint invalidates the interval",
+         [](auto &value) {
+             value.checkpoint.event_watermark = ProfilingEventWatermark{11};
+         }},
+        {"a stale requested cursor invalidates the interval",
+         [](auto &value) {
+             value.after_event_watermark = ProfilingEventWatermark{9};
+         }},
+        {"a changed no-event checkpoint cannot reuse its watermark",
+         [](auto &value) {
+             value.through_event_watermark = value.after_event_watermark;
+             value.event_frames.clear();
+             value.checkpoint = frame(10, 300, 300);
+         }},
+        {"a changed checkpoint cannot reuse the final event watermark",
+         [](auto &value) { value.checkpoint = frame(12, 250, 250); }},
+    };
+
+    for (const auto &mutation : mutations) {
+        auto scripted = source();
+        mutation.apply(scripted.reads.front());
+        ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+        const auto started = recorder.begin(context(), [] { return false; });
+        const auto result = recorder.checkpoint([] { return false; });
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               InvalidObservation &&
+                          !result.segment.has_value(),
+                      mutation.message);
+        state.require(scripted.finish_calls == 1 && !recorder.active(),
+                      "invalid history is always drained");
+    }
+}
+
+void test_segment_provenance_binds_checkpoint_evidence(TestState &state) {
+    auto first_source = source();
+    auto second_source = source();
+    ProfilingIntervalRecorder first(contract(), first_source, clock_at(1000));
+    ProfilingIntervalRecorder second(contract(), second_source, clock_at(2000));
+
+    const auto first_started = first.begin(context(), [] { return false; });
+    const auto second_started = second.begin(context(), [] { return false; });
+    const auto first_segment = first.checkpoint([] { return false; });
+    const auto second_segment = second.checkpoint([] { return false; });
+
+    state.require(first_started.ok() && second_started.ok() &&
+                      first_segment.segment.has_value() &&
+                      second_segment.segment.has_value() &&
+                      first_segment.segment->checkpoint.observation.observed_at !=
+                          second_segment.segment->checkpoint.observation.observed_at &&
+                      first_segment.segment->provenance_sha256 !=
+                          second_segment.segment->provenance_sha256,
+                  "segment provenance binds checkpoint timing evidence");
+}
+
+void test_enforces_cadence_and_frame_bound(TestState &state) {
+    {
+        auto monotonic = std::make_shared<
+            std::deque<std::chrono::steady_clock::time_point>>();
+        monotonic->push_back(std::chrono::steady_clock::time_point{});
+        monotonic->push_back(std::chrono::steady_clock::time_point{} + 5ms);
+        monotonic->push_back(std::chrono::steady_clock::time_point{} + 100ms);
+        ProfilingCollectionClock delayed_clock;
+        delayed_clock.monotonic_now = [monotonic] {
+            if (monotonic->empty()) {
+                throw std::runtime_error("scripted clock exhausted");
+            }
+            const auto result = monotonic->front();
+            monotonic->pop_front();
+            return result;
+        };
+        delayed_clock.utc_now = [] {
+            return std::chrono::system_clock::time_point{} + 1000s;
+        };
+        auto scripted = source();
+        ProfilingIntervalRecorder recorder(contract(), scripted,
+                                            std::move(delayed_clock));
+        const auto started = recorder.begin(context(), [] { return false; });
+        const auto result = recorder.checkpoint([] { return false; });
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               InvalidObservation &&
+                          scripted.read_calls == 0 &&
+                          scripted.finish_calls == 1,
+                      "an observation cadence gap fails before another read");
+    }
+
+    {
+        auto bounded_contract = contract();
+        bounded_contract.interval.max_interval_frames = 3;
+        auto scripted = source();
+        ProfilingIntervalRecorder recorder(bounded_contract, scripted, clock());
+        const auto started =
+            recorder.begin(context(bounded_contract), [] { return false; });
+        const auto result = recorder.checkpoint([] { return false; });
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               InvalidObservation &&
+                          scripted.finish_calls == 1,
+                      "the whole interval cannot exceed its retained-frame bound");
+    }
+}
+
+void test_source_failures_discard_interval(TestState &state) {
+    {
+        auto scripted = source();
+        scripted.reads.front().error =
+            ProfilingIntervalSourceError::HistoryLost;
+        scripted.reads.front().diagnostic = "scripted history overflow";
+        ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+        const auto started = recorder.begin(context(), [] { return false; });
+        const auto result = recorder.checkpoint([] { return false; });
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               EvidenceUnavailable &&
+                          !result.segment.has_value() &&
+                          scripted.finish_calls == 1,
+                      "reported history loss discards the whole interval");
+    }
+
+    {
+        auto scripted = source();
+        scripted.finish_result.error =
+            ProfilingIntervalSourceError::HistoryLost;
+        scripted.finish_result.diagnostic = "scripted final history loss";
+        ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+        const auto started = recorder.begin(context(), [] { return false; });
+        const auto result = recorder.finish();
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               EvidenceUnavailable &&
+                          !result.segment.has_value() && !recorder.active() &&
+                          scripted.finish_calls == 1,
+                      "a failed final drain cannot yield a segment");
+    }
+
+    {
+        auto monotonic = std::make_shared<
+            std::deque<std::chrono::steady_clock::time_point>>();
+        monotonic->push_back(std::chrono::steady_clock::time_point{});
+        monotonic->push_back(std::chrono::steady_clock::time_point{} + 5ms);
+        monotonic->push_back(std::chrono::steady_clock::time_point{} + 10ms);
+        ProfilingCollectionClock failing_clock;
+        failing_clock.monotonic_now = [monotonic] {
+            if (monotonic->empty()) {
+                throw std::runtime_error("scripted clock exhausted");
+            }
+            const auto result = monotonic->front();
+            monotonic->pop_front();
+            return result;
+        };
+        failing_clock.utc_now = [] {
+            return std::chrono::system_clock::time_point{} + 1000s;
+        };
+        auto scripted = source();
+        ProfilingIntervalRecorder recorder(contract(), scripted,
+                                            std::move(failing_clock));
+        const auto started = recorder.begin(context(), [] { return false; });
+        const auto result = recorder.finish();
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               InvalidObservation &&
+                          !recorder.active() && scripted.finish_calls == 1,
+                      "a post-drain clock failure does not finish twice");
+    }
+}
+
+void test_failures_and_destruction_release_source(TestState &state) {
+    {
+        auto monotonic = std::make_shared<
+            std::deque<std::chrono::steady_clock::time_point>>();
+        monotonic->push_back(std::chrono::steady_clock::time_point{});
+        ProfilingCollectionClock failing_clock;
+        failing_clock.monotonic_now = [monotonic] {
+            if (monotonic->empty()) {
+                throw std::runtime_error("scripted post-begin clock failure");
+            }
+            const auto result = monotonic->front();
+            monotonic->pop_front();
+            return result;
+        };
+        failing_clock.utc_now = [] {
+            return std::chrono::system_clock::time_point{} + 1000s;
+        };
+        auto scripted = source();
+        ProfilingIntervalRecorder recorder(contract(), scripted,
+                                            std::move(failing_clock));
+        const auto result = recorder.begin(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingIntervalRecorderStatus::InvalidObservation &&
+                          scripted.finish_calls == 1 && !recorder.active(),
+                      "a post-begin clock failure drains the registered interval");
+    }
+
+    {
+        std::atomic<bool> abort{false};
+        auto scripted = source();
+        scripted.on_begin = [&abort] { abort.store(true); };
+        ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+        const auto result = recorder.begin(
+            context(), [&abort] { return abort.load(); });
+        state.require(result.status ==
+                              ProfilingIntervalRecorderStatus::Cancelled &&
+                          scripted.finish_calls == 1 && !recorder.active(),
+                      "post-registration cancellation drains the interval");
+    }
+
+    {
+        auto scripted = source();
+        scripted.throw_on_read = true;
+        ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+        const auto started = recorder.begin(context(), [] { return false; });
+        const auto result = recorder.poll([] { return false; });
+        state.require(started.ok() &&
+                          result.status == ProfilingIntervalRecorderStatus::
+                                               EvidenceUnavailable &&
+                          scripted.finish_calls == 1 && !recorder.active(),
+                      "source exceptions trigger uncancellable cleanup");
+    }
+
+    auto scripted = source();
+    {
+        ProfilingIntervalRecorder recorder(contract(), scripted, clock());
+        const auto started = recorder.begin(context(), [] { return false; });
+        state.require(started.ok() && recorder.active(),
+                      "the cleanup fixture owns an active interval");
+    }
+    state.require(scripted.finish_calls == 1,
+                  "recorder destruction drains an abandoned interval");
+}
+
+void test_default_recorder_is_unavailable(TestState &state) {
+    ProfilingIntervalRecorder recorder(contract(), clock());
+    const auto result = recorder.begin(context(), [] { return false; });
+    state.require(result.status ==
+                          ProfilingIntervalRecorderStatus::EvidenceUnavailable &&
+                      !result.segment.has_value() && !recorder.active(),
+                  "the production recorder defaults to unavailable");
+}
+
+} // namespace
+
+int main() {
+    TestState state;
+    test_default_recorder_is_unavailable(state);
+    test_records_complete_interval_segments(state);
+    test_zero_event_watermark_is_not_a_capture_generation(state);
+    test_poll_retains_history_for_the_next_checkpoint(state);
+    test_transient_external_demand_fails_closed(state);
+    test_rejects_incomplete_or_rebound_history(state);
+    test_segment_provenance_binds_checkpoint_evidence(state);
+    test_enforces_cadence_and_frame_bound(state);
+    test_source_failures_discard_interval(state);
+    test_failures_and_destruction_release_source(state);
+    return state.ok.load() ? 0 : 1;
+}

--- a/test/cpp/test_residency_profiling_interval.cpp
+++ b/test/cpp/test_residency_profiling_interval.cpp
@@ -485,9 +485,15 @@ void test_rejects_incomplete_or_rebound_history(TestState &state) {
              value.event_frames.front().event_semantics_revision_sha256 =
                  digest('2');
          }},
-        {"a sample-generation mismatch invalidates the interval",
+        {"mixed sample generations invalidate the interval",
          [](auto &value) {
              value.event_frames.front().samples.front().source_generation = 99;
+         }},
+        {"a sample generation outside its event watermark invalidates the interval",
+         [](auto &value) {
+             for (auto &sample : value.event_frames.front().samples) {
+                 sample.source_generation = 99;
+             }
          }},
         {"a mismatched atomic checkpoint invalidates the interval",
          [](auto &value) {
@@ -589,6 +595,80 @@ void test_enforces_cadence_and_frame_bound(TestState &state) {
                                                InvalidObservation &&
                           scripted.finish_calls == 1,
                       "the whole interval cannot exceed its retained-frame bound");
+    }
+}
+
+void test_frame_bound_remains_finishable(TestState &state) {
+    {
+        auto bounded_contract = contract();
+        bounded_contract.interval.max_interval_frames = 1;
+        auto scripted = source();
+        scripted.finish_result =
+            batch(10, 10, {}, frame(10, 100, 100));
+        ProfilingIntervalRecorder recorder(bounded_contract, scripted, clock());
+
+        const auto started =
+            recorder.begin(context(bounded_contract), [] { return false; });
+        const auto finished = recorder.finish();
+
+        state.require(started.ok() && finished.ok() &&
+                          finished.segment.has_value() &&
+                          !recorder.active() && scripted.finish_calls == 1,
+                      "a one-frame interval can drain and seal unchanged");
+        if (finished.segment) {
+            state.require(finished.segment->frame_count == 1 &&
+                              finished.segment->checkpoint.capture_generation ==
+                                  1,
+                          "an unchanged final drain reuses the retained checkpoint");
+        }
+    }
+
+    {
+        auto bounded_contract = contract();
+        bounded_contract.interval.max_interval_frames = 4;
+        auto scripted = source();
+        scripted.finish_result =
+            batch(12, 12, {}, frame(12, 300, 300));
+        ProfilingIntervalRecorder recorder(bounded_contract, scripted, clock());
+
+        const auto started =
+            recorder.begin(context(bounded_contract), [] { return false; });
+        const auto polled = recorder.poll([] { return false; });
+        const auto finished = recorder.finish();
+
+        state.require(started.ok() && polled.ok() &&
+                          !polled.segment.has_value() && finished.ok() &&
+                          finished.segment.has_value() &&
+                          !recorder.active() && scripted.finish_calls == 1,
+                      "an interval that reaches its frame bound remains finishable");
+        if (finished.segment) {
+            state.require(finished.segment->frame_count == 4 &&
+                              finished.segment->checkpoint.capture_generation ==
+                                  4 &&
+                              finished.segment->through_event_watermark.value ==
+                                  12,
+                          "the final drain adds no frame beyond the bound");
+        }
+    }
+
+    {
+        auto bounded_contract = contract();
+        bounded_contract.interval.max_interval_frames = 1;
+        auto scripted = source();
+        scripted.finish_result =
+            batch(10, 10, {}, frame(10, 200, 200));
+        ProfilingIntervalRecorder recorder(bounded_contract, scripted, clock());
+
+        const auto started =
+            recorder.begin(context(bounded_contract), [] { return false; });
+        const auto finished = recorder.finish();
+
+        state.require(started.ok() &&
+                          finished.status == ProfilingIntervalRecorderStatus::
+                                                 InvalidObservation &&
+                          !finished.segment.has_value() && !recorder.active() &&
+                          scripted.finish_calls == 1,
+                      "a changed final checkpoint cannot bypass the frame bound");
     }
 }
 
@@ -741,6 +821,7 @@ int main() {
     test_rejects_incomplete_or_rebound_history(state);
     test_segment_provenance_binds_checkpoint_evidence(state);
     test_enforces_cadence_and_frame_bound(state);
+    test_frame_bound_remains_finishable(state);
     test_source_failures_discard_interval(state);
     test_failures_and_destruction_release_source(state);
     return state.ok.load() ? 0 : 1;

--- a/test/cpp/test_residency_profiling_provider.cpp
+++ b/test/cpp/test_residency_profiling_provider.cpp
@@ -532,7 +532,7 @@ void test_collector_derives_observation_from_raw_samples(TestState &state) {
         observation.observation_contract_sha256 ==
             transaction_context.observation_contract_sha256,
         "the derived observation carries the matched contract identity");
-    state.require(observation.observation_generation == 7,
+    state.require(observation.source_generation == 7,
                   "the Server derives the coherent native generation");
     state.require(observation.observed_at == "1970-01-01T00:16:40Z",
                   "the Server assigns observation time");

--- a/test/cpp/test_residency_profiling_provider.cpp
+++ b/test/cpp/test_residency_profiling_provider.cpp
@@ -149,6 +149,10 @@ static_assert(!HasUnattributedClaims<ProfilingDerivedObservation>::value);
 static_assert(!HasPhase<ProfilingObservationCollectionResult>::value);
 static_assert(!HasLifecycleState<ProfilingObservationCollectionResult>::value);
 static_assert(!HasAttestation<ProfilingObservationCollectionResult>::value);
+static_assert(!HasHealth<ProfilingRawIntervalFrame>::value);
+static_assert(!HasOwnerCoverage<ProfilingRawIntervalFrame>::value);
+static_assert(!HasLifecycleState<ProfilingRawIntervalFrame>::value);
+static_assert(!HasAttestation<ProfilingRawIntervalFrame>::value);
 static_assert(
     std::is_same_v<decltype(ProfilingSensorContract::uncertainty_bound),
                    std::uint64_t>);
@@ -170,7 +174,9 @@ struct TestState {
 
 void test_default_source_is_unavailable(TestState &state) {
     UnavailableProfilingObservationSource source;
-    ProfilingRawReadRequest request{{"sensor/gtt-used"}, {"owner/model-alpha"}};
+    ProfilingRawReadRequest request{{"sensor/gtt-used"},
+                                    {"owner/model-alpha"},
+                                    std::string(64, 'c')};
 
     const auto result = source.read(request, [] { return false; });
 
@@ -183,10 +189,49 @@ void test_default_source_is_unavailable(TestState &state) {
                   "the unavailable source reports a stable diagnostic");
 }
 
+void test_default_interval_source_is_unavailable(TestState &state) {
+    UnavailableProfilingIntervalObservationSource source;
+    ProfilingRawIntervalReadRequest request;
+    request.read = ProfilingRawReadRequest{{"sensor/gtt-used"},
+                                          {"owner/model-alpha"},
+                                          std::string(64, 'c')};
+    request.event_semantics_revision_sha256 = std::string(64, 'd');
+
+    const auto result = source.begin(request, [] { return false; });
+
+    state.require(result.error == ProfilingIntervalSourceError::Unavailable,
+                  "the production interval source defaults to unavailable");
+    state.require(result.token.opaque_id == 0,
+                  "the unavailable interval source cannot return a token");
+    state.require(result.checkpoint.samples.empty(),
+                  "the unavailable interval source cannot return a checkpoint");
+    state.require(result.diagnostic ==
+                      "profiling interval observation source is unavailable",
+                  "the unavailable interval source reports a stable diagnostic");
+
+    const auto batch = source.read_since(
+        {}, ProfilingEventWatermark{41}, [] { return false; });
+    state.require(batch.error == ProfilingIntervalSourceError::Unavailable &&
+                      batch.after_event_watermark.value == 41 &&
+                      batch.through_event_watermark.value == 41 &&
+                      batch.event_frames.empty() &&
+                      batch.checkpoint.samples.empty(),
+                  "the unavailable interval source cannot return history");
+
+    const auto finished = source.finish({}, ProfilingEventWatermark{42});
+    state.require(finished.error ==
+                          ProfilingIntervalSourceError::Unavailable &&
+                      finished.after_event_watermark.value == 42 &&
+                      finished.through_event_watermark.value == 42 &&
+                      finished.event_frames.empty() &&
+                      finished.checkpoint.samples.empty(),
+                  "the unavailable interval source cannot claim a final drain");
+}
+
 std::string digest(char value) { return std::string(64, value); }
 
 constexpr char known_contract_sha256[] =
-    "a1abcdbffca73bbd6f0238f9ff647c417aa46734a364ad78c709f53fe0a963d1";
+    "a62d1c4f2bd4345138b4cffd52e29da00bd1d06788831c4cb7fbe5dded344870";
 
 ProfilingDerivationContract contract() {
     ProfilingDerivationContract value;
@@ -196,9 +241,16 @@ ProfilingDerivationContract contract() {
         ProfilingSensorContract{"sensor/gtt-used", "gpu/gtt",
                                 ClaimFamily::ConsumableCapacity, 512, 4864},
     };
-    value.owner_scope_ids = {"owner/model-alpha"};
+    value.owner_scopes = {
+        ProfilingOwnerScopeBinding{"owner/model-alpha", digest('f')},
+    };
     value.freshness_window = std::chrono::seconds(60);
     value.max_source_skew = std::chrono::milliseconds(20);
+    value.interval.event_semantics_revision_sha256 = digest('9');
+    value.interval.max_observation_gap = std::chrono::milliseconds(50);
+    value.interval.baseline_stability_window = std::chrono::milliseconds(100);
+    value.interval.release_stability_window = std::chrono::milliseconds(200);
+    value.interval.max_interval_frames = 128;
     return value;
 }
 
@@ -254,6 +306,7 @@ ProfilingRawReadResult successful_read(std::uint64_t total = 4096,
                                generation},
         },
         {},
+        {},
     };
 }
 
@@ -272,14 +325,19 @@ public:
         if (on_read_) on_read_();
         if (should_abort && should_abort()) {
             return ProfilingRawReadResult{
-                ProfilingSourceError::Cancelled, {}, "scripted read cancelled"};
+                ProfilingSourceError::Cancelled, {},
+                request.owner_scope_set_sha256, "scripted read cancelled"};
         }
         if (script_.empty()) {
             return ProfilingRawReadResult{
-                ProfilingSourceError::Unavailable, {}, "script exhausted"};
+                ProfilingSourceError::Unavailable, {},
+                request.owner_scope_set_sha256, "script exhausted"};
         }
         auto result = std::move(script_.front());
         script_.pop_front();
+        if (result.owner_scope_set_sha256.empty()) {
+            result.owner_scope_set_sha256 = request.owner_scope_set_sha256;
+        }
         return result;
     }
 
@@ -335,11 +393,11 @@ void test_derivation_contract_identity(TestState &state) {
     auto reordered = derivation_contract;
     reordered.sensors.push_back(ProfilingSensorContract{
         "sensor/vram-used", "gpu/vram", ClaimFamily::ConsumableCapacity, 1, 5});
-    reordered.owner_scope_ids.push_back("owner/model-beta");
+    reordered.owner_scopes.push_back(
+        ProfilingOwnerScopeBinding{"owner/model-beta", digest('8')});
     auto canonical = reordered;
     std::reverse(reordered.sensors.begin(), reordered.sensors.end());
-    std::reverse(reordered.owner_scope_ids.begin(),
-                 reordered.owner_scope_ids.end());
+    std::reverse(reordered.owner_scopes.begin(), reordered.owner_scopes.end());
     const auto canonical_identity =
         profiling_derivation_contract_sha256(canonical);
     const auto reordered_identity =
@@ -348,12 +406,32 @@ void test_derivation_contract_identity(TestState &state) {
         canonical_identity.has_value() && reordered_identity.has_value() &&
             canonical_identity == reordered_identity,
         "sensor and owner ordering does not change contract identity");
+    const auto canonical_owner_set =
+        profiling_owner_scope_set_sha256(canonical.owner_scopes);
+    const auto reordered_owner_set =
+        profiling_owner_scope_set_sha256(reordered.owner_scopes);
+    state.require(canonical_owner_set.has_value() &&
+                      canonical_owner_set == reordered_owner_set,
+                  "owner-scope identity is canonical and order independent");
 
     auto invalid = derivation_contract;
     invalid.sensors.front().safety_ceiling =
         invalid.sensors.front().uncertainty_bound;
     state.require(!profiling_derivation_contract_sha256(invalid).has_value(),
                   "an invalid derivation contract has no identity");
+
+    invalid = derivation_contract;
+    invalid.owner_scopes.push_back(invalid.owner_scopes.front());
+    invalid.owner_scopes.back().owner_scope_id = "owner/model-beta";
+    state.require(!profiling_owner_scope_set_sha256(invalid.owner_scopes)
+                       .has_value(),
+                  "one containment identity cannot be counted twice");
+
+    invalid = derivation_contract;
+    invalid.interval.max_interval_frames =
+        max_profiling_interval_frames + 1;
+    state.require(!profiling_derivation_contract_sha256(invalid).has_value(),
+                  "the interval frame budget has a finite contract bound");
 }
 
 void test_stale_contract_identity_fails_before_source_access(TestState &state) {
@@ -380,12 +458,29 @@ void test_stale_contract_identity_fails_before_source_access(TestState &state) {
          [](auto &value) { value.sensors.front().safety_ceiling = 4865; }},
         {"owner scopes are bound",
          [](auto &value) {
-             value.owner_scope_ids.front() = "owner/model-beta";
+             value.owner_scopes.front().owner_scope_id = "owner/model-beta";
+         }},
+        {"owner containment identity is bound",
+         [](auto &value) {
+             value.owner_scopes.front().containment_identity_sha256 =
+                 digest('7');
          }},
         {"freshness policy is bound",
          [](auto &value) { value.freshness_window = 61s; }},
         {"source skew policy is bound",
          [](auto &value) { value.max_source_skew = 21ms; }},
+        {"event semantics are bound",
+         [](auto &value) {
+             value.interval.event_semantics_revision_sha256 = digest('6');
+         }},
+        {"observation cadence is bound",
+         [](auto &value) { value.interval.max_observation_gap = 51ms; }},
+        {"baseline stability is bound",
+         [](auto &value) { value.interval.baseline_stability_window = 101ms; }},
+        {"release stability is bound",
+         [](auto &value) { value.interval.release_stability_window = 201ms; }},
+        {"interval frame retention is bound",
+         [](auto &value) { value.interval.max_interval_frames = 129; }},
     };
 
     const auto stale_context = context();
@@ -468,6 +563,12 @@ void test_collector_derives_observation_from_raw_samples(TestState &state) {
         state.require(source.requests.front().owner_scope_ids ==
                           std::vector<std::string>{"owner/model-alpha"},
                       "the Server supplies owner scopes");
+        const auto expected_owner_scope_set =
+            profiling_owner_scope_set_sha256(derivation_contract.owner_scopes);
+        state.require(expected_owner_scope_set.has_value() &&
+                          source.requests.front().owner_scope_set_sha256 ==
+                              *expected_owner_scope_set,
+                      "the Server binds the requested containment scope set");
     }
 }
 
@@ -623,6 +724,18 @@ void test_collector_fails_closed(TestState &state) {
 
     {
         auto read = successful_read();
+        read.owner_scope_set_sha256 = digest('1');
+        ScriptedProfilingObservationSource source({std::move(read)});
+        ProfilingObservationCollector collector(contract(), source, clock());
+        const auto result = collector.collect(context(), [] { return false; });
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidObservation &&
+                          !result.observation.has_value(),
+                      "a stale owner-containment binding fails closed");
+    }
+
+    {
+        auto read = successful_read();
         read.error = ProfilingSourceError::Failed;
         read.diagnostic = std::string(300, 'x');
         ScriptedProfilingObservationSource source({std::move(read)});
@@ -771,6 +884,7 @@ void test_collector_fails_closed(TestState &state) {
 int main() {
     TestState state;
     test_default_source_is_unavailable(state);
+    test_default_interval_source_is_unavailable(state);
     test_derivation_contract_identity(state);
     test_stale_contract_identity_fails_before_source_access(state);
     test_collector_derives_observation_from_raw_samples(state);


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 1281 additions, 64 deletions" src="https://img.shields.io/badge/IMPL-%2B1281%20%E2%88%9264-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 952 additions, 10 deletions" src="https://img.shields.io/badge/TEST-%2B952%20%E2%88%9210-6F5F9A?style=flat" height="16"></picture> <picture><img alt="DOC: 10 additions, 2 deletions" src="https://img.shields.io/badge/DOC-%2B10%20%E2%88%922-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 6 touched" src="https://img.shields.io/badge/FILES-6-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 1281 additions, 64 deletions" src="https://img.shields.io/badge/IMPL-%2B1281%20%E2%88%9264-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 3 implementation files" src="https://img.shields.io/badge/FILES-3-5F6B78?style=flat" height="16"></picture>
  - [`CMakeLists.txt`](https://github.com/nisavid/lemonade/pull/133/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) <picture><img alt="19 additions, 0 deletions" title="19 additions, 0 deletions" src="https://img.shields.io/badge/%2B19-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/profiling_provider.h`](https://github.com/nisavid/lemonade/pull/133/files#diff-29107e48e5034466d25c7ad4f67dfdaa4f3d58571ddb4523129ec48b43b80a2c) <picture><img alt="198 additions, 2 deletions" title="198 additions, 2 deletions" src="https://img.shields.io/badge/%2B198-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_provider.cpp`](https://github.com/nisavid/lemonade/pull/133/files#diff-5212fed0ccb231b81eceebeb55bdd403330258d266ced17520b5b58cd6758614) <picture><img alt="1064 additions, 62 deletions" title="1064 additions, 62 deletions" src="https://img.shields.io/badge/%2B1064-%E2%88%9262-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 952 additions, 10 deletions" src="https://img.shields.io/badge/TEST-%2B952%20%E2%88%9210-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 2 test files" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_profiling_interval.cpp`](https://github.com/nisavid/lemonade/pull/133/files#diff-dbf738490779139a1033552049b4d891450f0d31e1f215de666aa36d816bc21c) <picture><img alt="828 additions, 0 deletions" title="828 additions, 0 deletions" src="https://img.shields.io/badge/%2B828-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_residency_profiling_provider.cpp`](https://github.com/nisavid/lemonade/pull/133/files#diff-71a96f8621cd1ed5320380d5f561f9454e172ce0f8f9eedcc02c4e737d0ff422) <picture><img alt="124 additions, 10 deletions" title="124 additions, 10 deletions" src="https://img.shields.io/badge/%2B124-%E2%88%9210-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="DOC: 10 additions, 2 deletions" src="https://img.shields.io/badge/DOC-%2B10%20%E2%88%922-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 1 documentation file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`CONTEXT.md`](https://github.com/nisavid/lemonade/pull/133/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14) <picture><img alt="10 additions, 2 deletions" title="10 additions, 2 deletions" src="https://img.shields.io/badge/%2B10-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Adds an inactive, event-complete profiling interval contract and recorder so later Server orchestration can prove retained history, exact owner closure, cadence, and cleanup before sealing lifecycle evidence. Refs #120; live source wiring, phase/lifecycle sealing, activation, publication, and signing remain follow-up scope.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build <configured build> --target cpp-ci-tests -j2` — passed.
- `ctest --test-dir <configured build> -L cpp-ci --output-on-failure` — 66/66 tests passed.
- Independent Standards and Spec reviews found no remaining P0–P3 issues at the published revision; focused interval tests also passed strict-warning builds and 50–100 repeated runs.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interval-based residency profiling with configurable observation frames, event watermarks, polling, checkpoints, and completion results.
  * Added provenance details for source generation, observation health, claim coverage, and owner-scope identity.
  * Added validation for stale or incomplete owner-scope bindings and malformed profiling history.
  * Added clear unavailable-source handling for environments without interval profiling support.

* **Documentation**
  * Expanded residency profiling terminology and contracts, including observation intervals and event watermarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
