### PR TITLE
feat(residency/profiling): seal complete capture lifecycles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -978,6 +978,7 @@ set(SOURCES_CORE
     src/cpp/server/residency/generated_contract.cpp
     src/cpp/server/residency/local_overlay.cpp
     src/cpp/server/residency/profiling_capture_authority.cpp
+    src/cpp/server/residency/profiling_common.cpp
     src/cpp/server/residency/profiling_provider.cpp
     src/cpp/server/residency/profiling_transaction.cpp
     src/cpp/server/wrapped_server.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -977,6 +977,7 @@ set(SOURCES_CORE
     src/cpp/server/residency/explanations.cpp
     src/cpp/server/residency/generated_contract.cpp
     src/cpp/server/residency/local_overlay.cpp
+    src/cpp/server/residency/profiling_capture_authority.cpp
     src/cpp/server/residency/profiling_provider.cpp
     src/cpp/server/residency/profiling_transaction.cpp
     src/cpp/server/wrapped_server.cpp
@@ -3525,6 +3526,27 @@ if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_INTERVAL_TEST_SRC}")
         COMMAND test_residency_profiling_interval
     )
     set_tests_properties(ResidencyProfilingInterval PROPERTIES TIMEOUT 30)
+endif()
+
+set(_RESIDENCY_PROFILING_CAPTURE_AUTHORITY_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_residency_profiling_capture_authority.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RESIDENCY_PROFILING_CAPTURE_AUTHORITY_TEST_SRC}")
+    add_executable(
+        test_residency_profiling_capture_authority
+        test/cpp/test_residency_profiling_capture_authority.cpp
+    )
+    target_link_libraries(test_residency_profiling_capture_authority PRIVATE
+        lemonade-server-core
+    )
+    add_cpp_ci_test(
+        ResidencyProfilingCaptureAuthority
+        CI ON
+        COMMAND test_residency_profiling_capture_authority
+    )
+    set_tests_properties(
+        ResidencyProfilingCaptureAuthority PROPERTIES TIMEOUT 30
+    )
 endif()
 
 # Routing-helper reconciliation: durable needed-set + non-blocking prune that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -288,7 +288,7 @@ A deployment-scoped, content-addressed qualification derived from one isolated, 
 _Avoid_: Confusing it with the conservative claim overlay, generalizing an exact local qualification, treating local calibration as a release revision, or exporting it automatically.
 
 **Residency profiling transaction**:
-An exclusive, server-owned qualification of one exact operation and identity whose workload, baseline, and lifecycle are completely isolated and attributed. Unattributed external demand prevents it from establishing a local overlay.
+An exclusive, server-owned qualification of one exact operation and identity whose workload, baseline, and lifecycle are completely isolated and attributed. It withholds all phase attestations until one continuous interval proves a stable baseline, completed workload, retained release transition, and stable final drain; any unattributed external demand rejects the whole capture.
 _Avoid_: Treating an ordinary concurrent benchmark, global memory sample, or partially attributed run as qualification evidence.
 
 **Profiling source sample**:
@@ -304,7 +304,7 @@ A phase-neutral Server result from one contract-matched raw closure, carrying Se
 _Avoid_: Inferring external or unattributed interval change from one snapshot, or treating one accepted collection as baseline, workload, release, or completed qualification evidence.
 
 **Profiling observation interval**:
-A Server-owned whole-transaction record that begins with an atomic subscription and snapshot after exclusive admission and ends with an atomic drain and unsubscription after the target becomes terminal. It is complete only when one bound source epoch and owner-scope set exposes every relevant resource mutation without lost history; the Server, not the adapter, derives interval attribution.
+A Server-owned whole-transaction record that begins with an atomic subscription and snapshot after exclusive admission and ends with an atomic drain and unsubscription after the target becomes terminal. It is complete only when one bound source epoch and owner-scope set exposes every relevant resource mutation without lost history; the Server, not the adapter, derives interval attribution and assigns baseline, workload, and release lifecycle states together after the final drain.
 _Avoid_: Inferring isolation from point samples, accepting a provider-supplied clean-interval decision, or ending observation before target release.
 
 **Profiling event watermark**:

--- a/src/cpp/include/lemon/residency/claims.h
+++ b/src/cpp/include/lemon/residency/claims.h
@@ -28,6 +28,19 @@ enum class ClaimStatus {
     InvalidRelease,
 };
 
+enum class ConstraintEvidenceKind {
+    ClaimFamily,
+    OwnerCoverage,
+};
+
+struct ConstraintEvidenceRequirement {
+    ConstraintEvidenceKind kind;
+    std::optional<ClaimFamily> family;
+};
+
+std::optional<ConstraintEvidenceRequirement>
+constraint_evidence_requirement(ConstraintKind constraint) noexcept;
+
 struct ClaimTotal {
     std::string constraint_id;
     ClaimUnit unit = ClaimUnit::Bytes;
@@ -86,6 +99,9 @@ struct CheckedClaimSetResult {
 };
 
 CheckedClaimSetResult check_claim_closure(std::vector<ClaimFamilyClosure> closure);
+bool claim_families_cover_ordinary_constraints(
+    const CheckedClaimSet &claims,
+    const std::vector<ConstraintKind> &constraints) noexcept;
 CheckedClaimSetResult checked_add(const CheckedClaimSet &left, const CheckedClaimSet &right);
 CheckedClaimSetResult checked_subtract(const CheckedClaimSet &left,
                                       const CheckedClaimSet &right);

--- a/src/cpp/include/lemon/residency/profiling_capture_authority.h
+++ b/src/cpp/include/lemon/residency/profiling_capture_authority.h
@@ -12,6 +12,8 @@ namespace residency {
 
 struct ProfilingCaptureSchedule {
     std::chrono::milliseconds observation_poll_interval{0};
+    // Reserves scheduler wakeup and recorder overhead in each start-to-start gap.
+    std::chrono::milliseconds poll_cycle_overhead_allowance{0};
     ProfilingCollectionClock clock;
 };
 

--- a/src/cpp/include/lemon/residency/profiling_capture_authority.h
+++ b/src/cpp/include/lemon/residency/profiling_capture_authority.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "lemon/residency/profiling_provider.h"
+
+#include <chrono>
+
+namespace lemon {
+
+class Router;
+
+namespace residency {
+
+struct ProfilingCaptureSchedule {
+    std::chrono::milliseconds observation_poll_interval{0};
+    ProfilingCollectionClock clock;
+};
+
+class ProfilingWorkloadDriver {
+public:
+    virtual ~ProfilingWorkloadDriver() = default;
+
+    // Both calls are synchronous, run on the Router lease owner, retain no
+    // references, and leave no unjoined work. Release is self-contained, does
+    // not wait for observation progress, and safely completes a partial run.
+    virtual void run(
+        Router &router,
+        const ProfilingTransactionContext &context,
+        const ProfilingCancellationCheck &should_abort) = 0;
+    virtual void release(
+        Router &router,
+        const ProfilingTransactionContext &context) noexcept = 0;
+};
+
+class ProfilingCaptureAuthority {
+public:
+    ProfilingCaptureAuthority(
+        ProfilingDerivationContract contract,
+        ProfilingCaptureSchedule schedule);
+    // The injected source must outlive this authority.
+    ProfilingCaptureAuthority(
+        ProfilingDerivationContract contract,
+        ProfilingIntervalObservationSource &source,
+        ProfilingCaptureSchedule schedule);
+
+    ProfilingCaptureAuthority(const ProfilingCaptureAuthority &) = delete;
+    ProfilingCaptureAuthority &
+    operator=(const ProfilingCaptureAuthority &) = delete;
+    ProfilingCaptureAuthority(ProfilingCaptureAuthority &&) = delete;
+    ProfilingCaptureAuthority &
+    operator=(ProfilingCaptureAuthority &&) = delete;
+
+    ProfilingTransactionCapture capture(
+        Router &router,
+        const ProfilingTransactionContext &context,
+        ProfilingWorkloadDriver &workload,
+        const ProfilingCancellationCheck &should_abort);
+
+private:
+    ProfilingDerivationContract contract_;
+    UnavailableProfilingIntervalObservationSource unavailable_source_;
+    ProfilingIntervalObservationSource *source_ = nullptr;
+    ProfilingCaptureSchedule schedule_;
+};
+
+} // namespace residency
+} // namespace lemon

--- a/src/cpp/server/residency/claims.cpp
+++ b/src/cpp/server/residency/claims.cpp
@@ -223,6 +223,43 @@ ClaimSourcesResult rejected_sources(const ClaimFailure &failure) {
 
 } // namespace
 
+std::optional<ConstraintEvidenceRequirement>
+constraint_evidence_requirement(ConstraintKind constraint) noexcept {
+    switch (constraint) {
+    case ConstraintKind::GpuSharedResidency:
+    case ConstraintKind::GpuProviderResolvedCapacity:
+        return ConstraintEvidenceRequirement{
+            ConstraintEvidenceKind::ClaimFamily,
+            std::optional<ClaimFamily>{ClaimFamily::ConsumableCapacity},
+        };
+    case ConstraintKind::HostMemAvailableFloor:
+    case ConstraintKind::HostEffectsProviderResolved:
+        return ConstraintEvidenceRequirement{
+            ConstraintEvidenceKind::ClaimFamily,
+            std::optional<ClaimFamily>{ClaimFamily::SafetyFloor},
+        };
+    case ConstraintKind::ModelTypePool:
+    case ConstraintKind::FlmTypeSlot:
+        return ConstraintEvidenceRequirement{
+            ConstraintEvidenceKind::ClaimFamily,
+            std::optional<ClaimFamily>{ClaimFamily::CardinalityPool},
+        };
+    case ConstraintKind::Ownership:
+        return ConstraintEvidenceRequirement{
+            ConstraintEvidenceKind::OwnerCoverage,
+            std::nullopt,
+        };
+    case ConstraintKind::NpuCrossFamily:
+    case ConstraintKind::NpuExclusive:
+        return ConstraintEvidenceRequirement{
+            ConstraintEvidenceKind::ClaimFamily,
+            std::optional<ClaimFamily>{
+                ClaimFamily::CompatibilityExclusivity},
+        };
+    }
+    return std::nullopt;
+}
+
 bool ClaimTotal::operator==(const ClaimTotal &other) const noexcept {
     return constraint_id == other.constraint_id && unit == other.unit && amount == other.amount;
 }
@@ -432,6 +469,26 @@ CheckedClaimSetResult check_claim_closure(std::vector<ClaimFamilyClosure> closur
     } catch (const ClaimFailure &failure) {
         return rejected_claims(failure);
     }
+}
+
+bool claim_families_cover_ordinary_constraints(
+    const CheckedClaimSet &claims,
+    const std::vector<ConstraintKind> &constraints) noexcept {
+    if (constraints.empty()) return false;
+    for (const auto constraint : constraints) {
+        const auto requirement = constraint_evidence_requirement(constraint);
+        if (!requirement) return false;
+        if (requirement->kind == ConstraintEvidenceKind::OwnerCoverage) {
+            continue;
+        }
+        if (!requirement->family) return false;
+        const auto completeness = claims.completeness(*requirement->family);
+        if (completeness == ClaimCompleteness::NotApplicable ||
+            completeness == ClaimCompleteness::Unknown) {
+            return false;
+        }
+    }
+    return true;
 }
 
 CheckedClaimSetResult checked_add(const CheckedClaimSet &left, const CheckedClaimSet &right) {

--- a/src/cpp/server/residency/local_overlay.cpp
+++ b/src/cpp/server/residency/local_overlay.cpp
@@ -1273,6 +1273,11 @@ void normalize_profiling_draft(ProfilingInputEnvelopeDraft &draft) {
     normalize_selector(draft.selector);
     normalize_generations(draft.generations);
     const auto checked = checked_claims(std::move(draft.attributed_claims));
+    if (!claim_families_cover_ordinary_constraints(
+            checked, draft.selector.catalog_selector.constraints)) {
+        reject(OverlayContractStatus::IncompleteClaimClosure,
+               "attributed claims omit a required selector family");
+    }
     draft.attributed_claims = claim_closure(checked);
     require_digest(draft.baseline_observation_sha256,
                    "baseline observation digest");

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -1,18 +1,10 @@
 #include "lemon/residency/profiling_capture_authority.h"
 
 #include "lemon/residency/claims.h"
+#include "profiling_common.h"
 
-#include <mbedtls/md.h>
-#include <mbedtls/version.h>
-#if MBEDTLS_VERSION_MAJOR >= 4
-#include <psa/crypto.h>
-#endif
-
-#include <algorithm>
-#include <array>
 #include <atomic>
 #include <chrono>
-#include <cmath>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -29,6 +21,12 @@ namespace {
 
 using SteadyClock = std::chrono::steady_clock;
 using SystemClock = std::chrono::system_clock;
+using profiling_internal::append_string;
+using profiling_internal::append_u64;
+using profiling_internal::cancelled;
+using profiling_internal::digest_is_valid;
+using profiling_internal::elapsed_between;
+using profiling_internal::sha256_hex;
 
 constexpr std::string_view phase_provenance_domain =
     "lemonade/profiling-phase-interval/v1";
@@ -37,32 +35,9 @@ ProfilingTransactionCapture capture_failure(std::string diagnostic) {
     if (diagnostic.empty()) {
         diagnostic = "profiling interval capture failed";
     }
-    if (diagnostic.size() > max_local_overlay_diagnostic_bytes) {
-        std::size_t boundary = max_local_overlay_diagnostic_bytes;
-        while (boundary > 0 &&
-               (static_cast<unsigned char>(diagnostic[boundary]) & 0xc0u) ==
-                   0x80u) {
-            --boundary;
-        }
-        diagnostic.resize(boundary);
-    }
-    return ProfilingTransactionCapture{{}, {}, {}, std::move(diagnostic)};
-}
-
-bool cancelled(const ProfilingCancellationCheck &should_abort) noexcept {
-    try {
-        return should_abort && should_abort();
-    } catch (...) {
-        return true;
-    }
-}
-
-bool digest_is_valid(std::string_view value) noexcept {
-    return value.size() == 64 &&
-           std::all_of(value.begin(), value.end(), [](char character) {
-               return (character >= '0' && character <= '9') ||
-                      (character >= 'a' && character <= 'f');
-           });
+    return ProfilingTransactionCapture{
+        {}, {}, {},
+        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
 }
 
 void initialize_clock(ProfilingCollectionClock &clock) {
@@ -80,7 +55,7 @@ bool schedule_is_valid(const ProfilingDerivationContract &contract,
         contract.interval.max_observation_gap <= contract.max_source_skew) {
         return false;
     }
-    return schedule.observation_poll_interval <=
+    return schedule.observation_poll_interval <
            contract.interval.max_observation_gap - contract.max_source_skew;
 }
 
@@ -89,19 +64,10 @@ std::optional<bool> elapsed_at_least(
     SteadyClock::time_point finished,
     std::chrono::milliseconds required) noexcept {
     if (required <= std::chrono::milliseconds::zero()) return std::nullopt;
-    const auto started_seconds =
-        std::chrono::duration<long double>(started.time_since_epoch()).count();
-    const auto finished_seconds =
-        std::chrono::duration<long double>(finished.time_since_epoch()).count();
-    const auto required_seconds =
-        std::chrono::duration<long double>(required).count();
-    if (!std::isfinite(started_seconds) ||
-        !std::isfinite(finished_seconds) ||
-        !std::isfinite(required_seconds) ||
-        finished_seconds < started_seconds) {
-        return std::nullopt;
-    }
-    return finished_seconds - started_seconds >= required_seconds;
+    const auto elapsed = elapsed_between(started, finished);
+    if (!elapsed) return std::nullopt;
+    return std::chrono::duration_cast<std::chrono::milliseconds>(*elapsed) >=
+           required;
 }
 
 bool segment_moved(const ProfilingIntervalSegment &segment) noexcept {
@@ -221,53 +187,6 @@ bool segment_chain_is_valid(
         }
     }
     return true;
-}
-
-void append_u64(std::string &bytes, std::uint64_t value) {
-    for (int shift = 56; shift >= 0; shift -= 8) {
-        bytes.push_back(static_cast<char>((value >> shift) & 0xffu));
-    }
-}
-
-void append_string(std::string &bytes, std::string_view value) {
-    append_u64(bytes, static_cast<std::uint64_t>(value.size()));
-    bytes.append(value.data(), value.size());
-}
-
-std::optional<std::string> sha256_hex(std::string_view bytes) {
-#if MBEDTLS_VERSION_MAJOR >= 4
-    static std::once_flag initialized;
-    static psa_status_t initialization_status = PSA_ERROR_BAD_STATE;
-    std::call_once(initialized,
-                   [] { initialization_status = psa_crypto_init(); });
-    if (initialization_status != PSA_SUCCESS) return std::nullopt;
-#endif
-
-    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    if (info == nullptr) return std::nullopt;
-
-    mbedtls_md_context_t context;
-    mbedtls_md_init(&context);
-    std::array<unsigned char, 32> digest{};
-    const bool failed =
-        mbedtls_md_setup(&context, info, 0) != 0 ||
-        mbedtls_md_starts(&context) != 0 ||
-        mbedtls_md_update(
-            &context,
-            reinterpret_cast<const unsigned char *>(bytes.data()),
-            bytes.size()) != 0 ||
-        mbedtls_md_finish(&context, digest.data()) != 0;
-    mbedtls_md_free(&context);
-    if (failed) return std::nullopt;
-
-    static constexpr char hex[] = "0123456789abcdef";
-    std::string result;
-    result.reserve(64);
-    for (const auto byte : digest) {
-        result.push_back(hex[(byte >> 4) & 0x0f]);
-        result.push_back(hex[byte & 0x0f]);
-    }
-    return result;
 }
 
 std::string_view phase_wire(ProfilingPhase phase) noexcept {

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -59,6 +59,37 @@ bool schedule_is_valid(const ProfilingDerivationContract &contract,
            contract.interval.max_observation_gap - contract.max_source_skew;
 }
 
+bool contract_covers_selector(
+    const ProfilingDerivationContract &contract,
+    const ProfilingTransactionContext &context) {
+    const auto contract_sha256 =
+        profiling_derivation_contract_sha256(contract);
+    if (!contract_sha256 ||
+        *contract_sha256 != context.observation_contract_sha256 ||
+        context.selector.catalog_selector.constraints.size() != 2) {
+        return false;
+    }
+
+    bool has_owner_coverage = false;
+    std::size_t capacity_constraints = 0;
+    for (const auto constraint :
+         context.selector.catalog_selector.constraints) {
+        const auto requirement = constraint_evidence_requirement(constraint);
+        if (!requirement) return false;
+        if (requirement->kind == ConstraintEvidenceKind::OwnerCoverage) {
+            has_owner_coverage = true;
+            continue;
+        }
+        if (requirement->family != ClaimFamily::ConsumableCapacity ||
+            (constraint != ConstraintKind::GpuSharedResidency &&
+             constraint != ConstraintKind::GpuProviderResolvedCapacity)) {
+            return false;
+        }
+        ++capacity_constraints;
+    }
+    return has_owner_coverage && capacity_constraints == 1;
+}
+
 std::optional<bool> elapsed_at_least(
     SteadyClock::time_point started,
     SteadyClock::time_point finished,
@@ -835,6 +866,10 @@ ProfilingTransactionCapture ProfilingCaptureAuthority::capture(
     try {
         if (!schedule_is_valid(contract_, schedule_)) {
             return capture_failure("profiling capture schedule is invalid");
+        }
+        if (!contract_covers_selector(contract_, context)) {
+            return capture_failure(
+                "profiling derivation contract does not cover selector");
         }
         CaptureOperation operation(contract_, *source_, schedule_, router,
                                    context, workload, should_abort);

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -51,12 +51,21 @@ bool schedule_is_valid(const ProfilingDerivationContract &contract,
                        const ProfilingCaptureSchedule &schedule) noexcept {
     if (schedule.observation_poll_interval <=
             std::chrono::milliseconds::zero() ||
+        schedule.poll_cycle_overhead_allowance <=
+            std::chrono::milliseconds::zero() ||
         contract.max_source_skew <= std::chrono::milliseconds::zero() ||
         contract.interval.max_observation_gap <= contract.max_source_skew) {
         return false;
     }
-    return schedule.observation_poll_interval <
-           contract.interval.max_observation_gap - contract.max_source_skew;
+    const auto cycle_budget_after_source =
+        contract.interval.max_observation_gap - contract.max_source_skew;
+    if (cycle_budget_after_source <=
+        schedule.poll_cycle_overhead_allowance) {
+        return false;
+    }
+    return schedule.observation_poll_interval <=
+           cycle_budget_after_source -
+               schedule.poll_cycle_overhead_allowance;
 }
 
 bool contract_covers_selector(

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -1,0 +1,928 @@
+#include "lemon/residency/profiling_capture_authority.h"
+
+#include "lemon/residency/claims.h"
+
+#include <mbedtls/md.h>
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR >= 4
+#include <psa/crypto.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace lemon::residency {
+namespace {
+
+using SteadyClock = std::chrono::steady_clock;
+using SystemClock = std::chrono::system_clock;
+
+constexpr std::string_view phase_provenance_domain =
+    "lemonade/profiling-phase-interval/v1";
+
+ProfilingTransactionCapture capture_failure(std::string diagnostic) {
+    if (diagnostic.empty()) {
+        diagnostic = "profiling interval capture failed";
+    }
+    if (diagnostic.size() > max_local_overlay_diagnostic_bytes) {
+        std::size_t boundary = max_local_overlay_diagnostic_bytes;
+        while (boundary > 0 &&
+               (static_cast<unsigned char>(diagnostic[boundary]) & 0xc0u) ==
+                   0x80u) {
+            --boundary;
+        }
+        diagnostic.resize(boundary);
+    }
+    return ProfilingTransactionCapture{{}, {}, {}, std::move(diagnostic)};
+}
+
+bool cancelled(const ProfilingCancellationCheck &should_abort) noexcept {
+    try {
+        return should_abort && should_abort();
+    } catch (...) {
+        return true;
+    }
+}
+
+bool digest_is_valid(std::string_view value) noexcept {
+    return value.size() == 64 &&
+           std::all_of(value.begin(), value.end(), [](char character) {
+               return (character >= '0' && character <= '9') ||
+                      (character >= 'a' && character <= 'f');
+           });
+}
+
+void initialize_clock(ProfilingCollectionClock &clock) {
+    if (!clock.monotonic_now) {
+        clock.monotonic_now = [] { return SteadyClock::now(); };
+    }
+    if (!clock.utc_now) clock.utc_now = [] { return SystemClock::now(); };
+}
+
+bool schedule_is_valid(const ProfilingDerivationContract &contract,
+                       const ProfilingCaptureSchedule &schedule) noexcept {
+    if (schedule.observation_poll_interval <=
+            std::chrono::milliseconds::zero() ||
+        contract.max_source_skew <= std::chrono::milliseconds::zero() ||
+        contract.interval.max_observation_gap <= contract.max_source_skew) {
+        return false;
+    }
+    return schedule.observation_poll_interval <=
+           contract.interval.max_observation_gap - contract.max_source_skew;
+}
+
+std::optional<bool> elapsed_at_least(
+    SteadyClock::time_point started,
+    SteadyClock::time_point finished,
+    std::chrono::milliseconds required) noexcept {
+    if (required <= std::chrono::milliseconds::zero()) return std::nullopt;
+    const auto started_seconds =
+        std::chrono::duration<long double>(started.time_since_epoch()).count();
+    const auto finished_seconds =
+        std::chrono::duration<long double>(finished.time_since_epoch()).count();
+    const auto required_seconds =
+        std::chrono::duration<long double>(required).count();
+    if (!std::isfinite(started_seconds) ||
+        !std::isfinite(finished_seconds) ||
+        !std::isfinite(required_seconds) ||
+        finished_seconds < started_seconds) {
+        return std::nullopt;
+    }
+    return finished_seconds - started_seconds >= required_seconds;
+}
+
+bool segment_moved(const ProfilingIntervalSegment &segment) noexcept {
+    return segment.after_event_watermark != segment.through_event_watermark;
+}
+
+bool claim_closure_is_zero(std::vector<ClaimFamilyClosure> closure) {
+    const auto checked = check_claim_closure(std::move(closure));
+    if (!checked.accepted()) return false;
+    for (const auto family : {ClaimFamily::ConsumableCapacity,
+                              ClaimFamily::SafetyFloor,
+                              ClaimFamily::CardinalityPool,
+                              ClaimFamily::CompatibilityExclusivity}) {
+        if (!checked.claims->entries(family).empty()) return false;
+    }
+    return true;
+}
+
+bool claim_closures_equal(std::vector<ClaimFamilyClosure> left,
+                          std::vector<ClaimFamilyClosure> right) {
+    const auto checked_left = check_claim_closure(std::move(left));
+    const auto checked_right = check_claim_closure(std::move(right));
+    return checked_left.accepted() && checked_right.accepted() &&
+           *checked_left.claims == *checked_right.claims;
+}
+
+bool release_is_bounded(
+    const std::vector<ClaimFamilyClosure> &baseline,
+    const std::vector<ClaimFamilyClosure> &release,
+    const std::vector<ClaimFamilyClosure> &uncertainty) {
+    const auto checked_baseline = check_claim_closure(baseline);
+    const auto checked_release = check_claim_closure(release);
+    const auto checked_uncertainty = check_claim_closure(uncertainty);
+    if (!checked_baseline.accepted() || !checked_release.accepted() ||
+        !checked_uncertainty.accepted()) {
+        return false;
+    }
+    const auto upper_bound =
+        checked_add(*checked_baseline.claims, *checked_uncertainty.claims);
+    return upper_bound.accepted() &&
+           checked_subtract(*upper_bound.claims, *checked_release.claims)
+               .accepted();
+}
+
+bool observation_is_valid(const ProfilingDerivedObservation &observation,
+                          const ProfilingDerivationContract &contract,
+                          const ProfilingTransactionContext &context) {
+    return observation.provider_id == contract.provider_id &&
+           observation.provider_revision_sha256 ==
+               contract.provider_revision_sha256 &&
+           digest_is_valid(observation.raw_provenance_sha256) &&
+           observation.observation_contract_sha256 ==
+               context.observation_contract_sha256 &&
+           observation.max_source_skew_milliseconds ==
+               static_cast<std::uint64_t>(contract.max_source_skew.count()) &&
+           observation.source_skew_milliseconds <=
+               observation.max_source_skew_milliseconds &&
+           observation.health == ProfilingObservationHealth::Valid &&
+           observation.owner_coverage == ProfilingOwnerCoverage::Complete &&
+           check_claim_closure(observation.observed_claims).accepted() &&
+           check_claim_closure(observation.attributed_claims).accepted() &&
+           check_claim_closure(observation.uncertainty_claims).accepted() &&
+           check_claim_closure(observation.safety_margin_claims).accepted();
+}
+
+bool segment_is_valid(const ProfilingIntervalSegment &segment,
+                      const ProfilingDerivationContract &contract,
+                      const ProfilingTransactionContext &context,
+                      std::string_view owner_scope_set_sha256) {
+    return digest_is_valid(segment.source_epoch_sha256) &&
+           segment.owner_scope_set_sha256 == owner_scope_set_sha256 &&
+           segment.event_semantics_revision_sha256 ==
+               contract.interval.event_semantics_revision_sha256 &&
+           segment.first_capture_generation != 0 &&
+           segment.first_capture_generation <=
+               segment.last_capture_generation &&
+           segment.frame_count != 0 &&
+           digest_is_valid(segment.provenance_sha256) &&
+           segment.checkpoint.capture_generation ==
+               segment.last_capture_generation &&
+           segment.checkpoint.event_watermark ==
+               segment.through_event_watermark &&
+           observation_is_valid(segment.checkpoint.observation, contract,
+                                context) &&
+           check_claim_closure(segment.peak_observed_claims).accepted() &&
+           check_claim_closure(segment.peak_attributed_claims).accepted() &&
+           claim_closure_is_zero(segment.external_change_claims) &&
+           claim_closure_is_zero(segment.unattributed_claims) &&
+           check_claim_closure(segment.uncertainty_claims).accepted() &&
+           check_claim_closure(segment.safety_margin_claims).accepted();
+}
+
+bool segment_chain_is_valid(
+    const std::vector<const ProfilingIntervalSegment *> &segments,
+    const ProfilingDerivationContract &contract,
+    const ProfilingTransactionContext &context) {
+    const auto owner_scope_set_sha256 =
+        profiling_owner_scope_set_sha256(contract.owner_scopes);
+    if (!owner_scope_set_sha256 || segments.empty()) return false;
+
+    const auto &first = *segments.front();
+    for (std::size_t index = 0; index < segments.size(); ++index) {
+        const auto &segment = *segments[index];
+        if (!segment_is_valid(segment, contract, context,
+                              *owner_scope_set_sha256) ||
+            segment.source_epoch_sha256 != first.source_epoch_sha256) {
+            return false;
+        }
+        if (index != 0) {
+            const auto &previous = *segments[index - 1];
+            if (previous.through_event_watermark !=
+                    segment.after_event_watermark ||
+                previous.last_capture_generation !=
+                    segment.first_capture_generation) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void append_u64(std::string &bytes, std::uint64_t value) {
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        bytes.push_back(static_cast<char>((value >> shift) & 0xffu));
+    }
+}
+
+void append_string(std::string &bytes, std::string_view value) {
+    append_u64(bytes, static_cast<std::uint64_t>(value.size()));
+    bytes.append(value.data(), value.size());
+}
+
+std::optional<std::string> sha256_hex(std::string_view bytes) {
+#if MBEDTLS_VERSION_MAJOR >= 4
+    static std::once_flag initialized;
+    static psa_status_t initialization_status = PSA_ERROR_BAD_STATE;
+    std::call_once(initialized,
+                   [] { initialization_status = psa_crypto_init(); });
+    if (initialization_status != PSA_SUCCESS) return std::nullopt;
+#endif
+
+    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    if (info == nullptr) return std::nullopt;
+
+    mbedtls_md_context_t context;
+    mbedtls_md_init(&context);
+    std::array<unsigned char, 32> digest{};
+    const bool failed =
+        mbedtls_md_setup(&context, info, 0) != 0 ||
+        mbedtls_md_starts(&context) != 0 ||
+        mbedtls_md_update(
+            &context,
+            reinterpret_cast<const unsigned char *>(bytes.data()),
+            bytes.size()) != 0 ||
+        mbedtls_md_finish(&context, digest.data()) != 0;
+    mbedtls_md_free(&context);
+    if (failed) return std::nullopt;
+
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(64);
+    for (const auto byte : digest) {
+        result.push_back(hex[(byte >> 4) & 0x0f]);
+        result.push_back(hex[byte & 0x0f]);
+    }
+    return result;
+}
+
+std::string_view phase_wire(ProfilingPhase phase) noexcept {
+    switch (phase) {
+    case ProfilingPhase::Baseline:
+        return "baseline";
+    case ProfilingPhase::Workload:
+        return "workload";
+    case ProfilingPhase::Release:
+        return "release";
+    default:
+        return {};
+    }
+}
+
+std::optional<std::string> phase_provenance_sha256(
+    ProfilingPhase phase,
+    const ProfilingTransactionContext &context,
+    const std::vector<ProfilingIntervalSegment> &segments) {
+    const auto wire = phase_wire(phase);
+    if (wire.empty() || segments.empty()) return std::nullopt;
+
+    std::string bytes;
+    append_string(bytes, phase_provenance_domain);
+    append_string(bytes, wire);
+    append_string(bytes, context.deployment_id);
+    append_u64(bytes, context.sequence);
+    append_string(bytes, context.profiling_transaction_id);
+    append_string(bytes, context.selector_sha256);
+    append_string(bytes, context.observation_contract_sha256);
+    append_string(bytes, context.predictor_contract_sha256);
+    append_u64(bytes, context.generations.model);
+    append_u64(bytes, context.generations.backend);
+    append_u64(bytes, context.generations.device);
+    append_u64(bytes, context.generations.topology);
+    append_u64(bytes, context.generations.driver);
+    append_u64(bytes, context.generations.configuration);
+    append_u64(bytes, context.generations.workload);
+    append_u64(bytes, static_cast<std::uint64_t>(segments.size()));
+    for (const auto &segment : segments) {
+        if (!digest_is_valid(segment.provenance_sha256)) {
+            return std::nullopt;
+        }
+        append_string(bytes, segment.provenance_sha256);
+    }
+    return sha256_hex(bytes);
+}
+
+ProfilingPhaseAttestationDraft phase_draft(
+    ProfilingPhase phase,
+    ProfilingLifecycleState lifecycle_state,
+    const ProfilingTransactionContext &context,
+    const ProfilingIntervalSegment &selected,
+    const std::string &provenance_sha256,
+    bool use_interval_peaks) {
+    const auto &observation = selected.checkpoint.observation;
+    ProfilingPhaseAttestationDraft draft;
+    draft.schema = supported_local_overlay_schema;
+    draft.phase = phase;
+    draft.deployment_id = context.deployment_id;
+    draft.profiling_transaction_id = context.profiling_transaction_id;
+    draft.selector_sha256 = context.selector_sha256;
+    draft.provider_id = observation.provider_id;
+    draft.provider_revision_sha256 = observation.provider_revision_sha256;
+    draft.provenance_sha256 = provenance_sha256;
+    draft.observation_contract_sha256 =
+        observation.observation_contract_sha256;
+    draft.predictor_contract_sha256 = context.predictor_contract_sha256;
+    draft.generations = context.generations;
+    draft.observation_generation = selected.checkpoint.capture_generation;
+    draft.observed_at = observation.observed_at;
+    draft.fresh_until = observation.fresh_until;
+    draft.source_skew_milliseconds =
+        observation.source_skew_milliseconds;
+    draft.max_source_skew_milliseconds =
+        observation.max_source_skew_milliseconds;
+    draft.health = observation.health;
+    draft.owner_coverage = observation.owner_coverage;
+    draft.observed_claims = use_interval_peaks
+                                ? selected.peak_observed_claims
+                                : observation.observed_claims;
+    draft.attributed_claims = use_interval_peaks
+                                  ? selected.peak_attributed_claims
+                                  : observation.attributed_claims;
+    draft.external_change_claims = selected.external_change_claims;
+    draft.unattributed_claims = selected.unattributed_claims;
+    draft.uncertainty_claims = selected.uncertainty_claims;
+    draft.safety_margin_claims = selected.safety_margin_claims;
+    draft.lifecycle_state = lifecycle_state;
+    return draft;
+}
+
+class WorkloadReleaseGuard {
+public:
+    WorkloadReleaseGuard(Router &router,
+                         const ProfilingTransactionContext &context,
+                         ProfilingWorkloadDriver &workload) noexcept
+        : router_(router), context_(context), workload_(workload) {}
+
+    ~WorkloadReleaseGuard() { release(); }
+
+    void enter() noexcept { entered_ = true; }
+
+    void release() noexcept {
+        if (!entered_ || released_) return;
+        released_ = true;
+        workload_.release(router_, context_);
+    }
+
+private:
+    Router &router_;
+    const ProfilingTransactionContext &context_;
+    ProfilingWorkloadDriver &workload_;
+    bool entered_ = false;
+    bool released_ = false;
+};
+
+class CaptureOperation {
+public:
+    CaptureOperation(const ProfilingDerivationContract &contract,
+                     ProfilingIntervalObservationSource &source,
+                     const ProfilingCaptureSchedule &schedule,
+                     Router &router,
+                     const ProfilingTransactionContext &context,
+                     ProfilingWorkloadDriver &workload,
+                     const ProfilingCancellationCheck &should_abort)
+        : contract_(contract), schedule_(schedule), router_(router),
+          context_(context), workload_(workload),
+          should_abort_(should_abort),
+          recorder_(contract, source, schedule.clock) {}
+
+    ~CaptureOperation() {
+        if (!observer_.joinable()) return;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stop_requested_ = true;
+        }
+        condition_.notify_all();
+        observer_.join();
+    }
+
+    ProfilingTransactionCapture run() {
+        const auto started = recorder_.begin(context_, should_abort_);
+        if (!started.ok()) return recorder_failure(started);
+        if (!settle_baseline()) return capture_failure(diagnostic_);
+
+        try {
+            observer_ = std::thread([this] { observe(); });
+        } catch (...) {
+            return capture_failure("profiling observer could not start");
+        }
+
+        if (!wait_until([](const SharedState &state) {
+                return state.observer_ready || state.failed;
+            })) {
+            return finish_failed_capture();
+        }
+        if (cancelled(should_abort_)) {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                diagnostic_ = "profiling interval capture cancelled";
+            }
+            return finish_failed_capture();
+        }
+
+        WorkloadReleaseGuard release_guard(router_, context_, workload_);
+        bool workload_completed = true;
+        release_guard.enter();
+        try {
+            workload_.run(router_, context_, [this] {
+                return observer_failed_.load(std::memory_order_acquire) ||
+                       cancelled(should_abort_);
+            });
+        } catch (...) {
+            workload_completed = false;
+        }
+        const bool capture_cancelled = cancelled(should_abort_);
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            state_.workload_done = true;
+        }
+        condition_.notify_all();
+        if (!wait_until([](const SharedState &state) {
+                return state.workload_boundary_ready || state.failed;
+            })) {
+            release_guard.release();
+            return finish_failed_capture();
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            state_.release_started = true;
+        }
+        condition_.notify_all();
+        if (!wait_until([](const SharedState &state) {
+                return state.release_observer_ready || state.failed;
+            })) {
+            release_guard.release();
+            return finish_failed_capture();
+        }
+
+        release_guard.release();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            state_.release_done = true;
+        }
+        condition_.notify_all();
+        if (!wait_until([](const SharedState &state) {
+                return state.complete || state.failed;
+            })) {
+            return finish_failed_capture();
+        }
+        join_observer();
+
+        if (!workload_completed || capture_cancelled ||
+            cancelled(should_abort_)) {
+            return capture_failure("profiling workload did not complete");
+        }
+        return seal_capture();
+    }
+
+private:
+    struct SharedState {
+        bool observer_ready = false;
+        bool workload_done = false;
+        bool workload_boundary_ready = false;
+        bool release_started = false;
+        bool release_observer_ready = false;
+        bool release_done = false;
+        bool complete = false;
+        bool failed = false;
+    };
+
+    template <typename Predicate>
+    bool wait_until(Predicate predicate) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        condition_.wait(lock, [&] { return predicate(state_); });
+        return !state_.failed;
+    }
+
+    std::optional<SteadyClock::time_point> monotonic_now() {
+        try {
+            return schedule_.clock.monotonic_now();
+        } catch (...) {
+            diagnostic_ = "profiling capture clock is unavailable";
+            return std::nullopt;
+        }
+    }
+
+    bool settle_baseline() {
+        auto stable_started = monotonic_now();
+        if (!stable_started) return false;
+        for (;;) {
+            if (cancelled(should_abort_)) {
+                diagnostic_ = "profiling interval capture cancelled";
+                return false;
+            }
+            std::this_thread::sleep_for(
+                schedule_.observation_poll_interval);
+            const auto boundary =
+                recorder_.checkpoint(should_abort_);
+            if (!boundary.ok() || !boundary.segment) {
+                diagnostic_ = boundary.diagnostic.empty()
+                                  ? "profiling baseline could not be proven"
+                                  : boundary.diagnostic;
+                return false;
+            }
+            baseline_segments_.push_back(*boundary.segment);
+            const auto observed = monotonic_now();
+            if (!observed) return false;
+            if (segment_moved(*boundary.segment)) {
+                stable_started = observed;
+                continue;
+            }
+            const auto stable = elapsed_at_least(
+                *stable_started, *observed,
+                contract_.interval.baseline_stability_window);
+            if (!stable) {
+                diagnostic_ = "profiling baseline clock regressed";
+                return false;
+            }
+            if (*stable) return true;
+        }
+    }
+
+    void observe() noexcept {
+        try {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                state_.observer_ready = true;
+            }
+            condition_.notify_all();
+
+            if (!poll_until_workload_done()) return;
+            const auto workload_boundary = recorder_.checkpoint(
+                [this] { return observer_should_abort(); });
+            if (!workload_boundary.ok() || !workload_boundary.segment) {
+                fail_observer(workload_boundary.diagnostic.empty()
+                                  ? "profiling workload boundary is incomplete"
+                                  : workload_boundary.diagnostic);
+                return;
+            }
+            workload_segments_.push_back(*workload_boundary.segment);
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                state_.workload_boundary_ready = true;
+                condition_.notify_all();
+                condition_.wait(lock, [this] {
+                    return state_.release_started || stop_requested_;
+                });
+                if (stop_requested_) {
+                    lock.unlock();
+                    fail_observer("profiling observer stopped before release");
+                    return;
+                }
+                state_.release_observer_ready = true;
+            }
+            condition_.notify_all();
+
+            if (!poll_until_release_done()) return;
+            const auto release_boundary = recorder_.checkpoint(
+                [this] { return observer_should_abort(); });
+            if (!release_boundary.ok() || !release_boundary.segment) {
+                fail_observer(release_boundary.diagnostic.empty()
+                                  ? "profiling release boundary is incomplete"
+                                  : release_boundary.diagnostic);
+                return;
+            }
+            if (!segment_moved(*release_boundary.segment)) {
+                fail_observer(
+                    "profiling release transition was not observed");
+                return;
+            }
+            release_segments_.push_back(*release_boundary.segment);
+            if (!settle_release()) return;
+            if (cancelled(should_abort_)) {
+                fail_observer("profiling interval capture cancelled");
+                return;
+            }
+
+            const auto finished = recorder_.finish();
+            if (!finished.ok() || !finished.segment ||
+                segment_moved(*finished.segment)) {
+                fail_observer(finished.diagnostic.empty()
+                                  ? "profiling final drain did not remain stable"
+                                  : finished.diagnostic);
+                return;
+            }
+            release_segments_.push_back(*finished.segment);
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                state_.complete = true;
+            }
+            condition_.notify_all();
+        } catch (...) {
+            fail_observer("profiling observer failed");
+        }
+    }
+
+    bool poll_until_workload_done() {
+        for (;;) {
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                if (state_.workload_done) return true;
+                if (stop_requested_) {
+                    lock.unlock();
+                    fail_observer("profiling observer stopped during workload");
+                    return false;
+                }
+                condition_.wait_for(
+                    lock, schedule_.observation_poll_interval, [this] {
+                        return state_.workload_done || stop_requested_;
+                    });
+                if (state_.workload_done) return true;
+                if (stop_requested_) continue;
+            }
+            const auto polled = recorder_.poll(
+                [this] { return observer_should_abort(); });
+            if (!polled.ok()) {
+                fail_observer(polled.diagnostic.empty()
+                                  ? "profiling workload observation failed"
+                                  : polled.diagnostic);
+                return false;
+            }
+        }
+    }
+
+    bool poll_until_release_done() {
+        for (;;) {
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                if (state_.release_done) return true;
+                if (stop_requested_) {
+                    lock.unlock();
+                    fail_observer("profiling observer stopped during release");
+                    return false;
+                }
+                condition_.wait_for(
+                    lock, schedule_.observation_poll_interval, [this] {
+                        return state_.release_done || stop_requested_;
+                    });
+                if (state_.release_done) return true;
+                if (stop_requested_) continue;
+            }
+            const auto polled = recorder_.poll(
+                [this] { return observer_should_abort(); });
+            if (!polled.ok()) {
+                fail_observer(polled.diagnostic.empty()
+                                  ? "profiling release observation failed"
+                                  : polled.diagnostic);
+                return false;
+            }
+        }
+    }
+
+    bool settle_release() {
+        auto stable_started = monotonic_now();
+        if (!stable_started) {
+            fail_observer(diagnostic_);
+            return false;
+        }
+        for (;;) {
+            if (cancelled(should_abort_)) {
+                fail_observer("profiling interval capture cancelled");
+                return false;
+            }
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                if (stop_requested_) {
+                    lock.unlock();
+                    fail_observer("profiling observer stopped while releasing");
+                    return false;
+                }
+                condition_.wait_for(
+                    lock, schedule_.observation_poll_interval,
+                    [this] { return stop_requested_; });
+                if (stop_requested_) continue;
+            }
+            const auto boundary = recorder_.checkpoint(
+                [this] { return observer_should_abort(); });
+            if (!boundary.ok() || !boundary.segment) {
+                fail_observer(boundary.diagnostic.empty()
+                                  ? "profiling release could not stabilize"
+                                  : boundary.diagnostic);
+                return false;
+            }
+            release_segments_.push_back(*boundary.segment);
+            const auto observed = monotonic_now();
+            if (!observed) {
+                fail_observer(diagnostic_);
+                return false;
+            }
+            if (segment_moved(*boundary.segment)) {
+                stable_started = observed;
+                continue;
+            }
+            const auto stable = elapsed_at_least(
+                *stable_started, *observed,
+                contract_.interval.release_stability_window);
+            if (!stable) {
+                fail_observer("profiling release clock regressed");
+                return false;
+            }
+            if (*stable) return true;
+        }
+    }
+
+    void fail_observer(std::string diagnostic) noexcept {
+        observer_failed_.store(true, std::memory_order_release);
+        if (recorder_.active()) {
+            try {
+                recorder_.finish();
+            } catch (...) {
+            }
+        }
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (diagnostic_.empty()) diagnostic_ = std::move(diagnostic);
+            state_.failed = true;
+        }
+        condition_.notify_all();
+    }
+
+    bool observer_should_abort() noexcept {
+        if (cancelled(should_abort_)) return true;
+        std::lock_guard<std::mutex> lock(mutex_);
+        return stop_requested_;
+    }
+
+    ProfilingTransactionCapture recorder_failure(
+        const ProfilingIntervalRecorderResult &result) {
+        return capture_failure(
+            result.diagnostic.empty()
+                ? "profiling interval recorder rejected the capture"
+                : result.diagnostic);
+    }
+
+    ProfilingTransactionCapture finish_failed_capture() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stop_requested_ = true;
+        }
+        condition_.notify_all();
+        join_observer();
+        return capture_failure(diagnostic_);
+    }
+
+    void join_observer() {
+        if (observer_.joinable()) observer_.join();
+    }
+
+    ProfilingTransactionCapture seal_capture() {
+        std::vector<const ProfilingIntervalSegment *> chain;
+        chain.reserve(baseline_segments_.size() +
+                      workload_segments_.size() +
+                      release_segments_.size());
+        for (const auto &segment : baseline_segments_) {
+            chain.push_back(&segment);
+        }
+        for (const auto &segment : workload_segments_) {
+            chain.push_back(&segment);
+        }
+        for (const auto &segment : release_segments_) {
+            chain.push_back(&segment);
+        }
+        if (baseline_segments_.empty() || workload_segments_.size() != 1 ||
+            release_segments_.empty() ||
+            !segment_chain_is_valid(chain, contract_, context_)) {
+            return capture_failure(
+                "profiling interval segments do not form one closed capture");
+        }
+
+        const auto &baseline = baseline_segments_.back();
+        const auto &workload = workload_segments_.front();
+        const auto &release = release_segments_.back();
+        if (baseline.checkpoint.capture_generation >=
+                workload.checkpoint.capture_generation ||
+            workload.checkpoint.capture_generation >=
+                release.checkpoint.capture_generation ||
+            !claim_closures_equal(
+                baseline.checkpoint.observation.observed_claims,
+                baseline.checkpoint.observation.attributed_claims) ||
+            !claim_closures_equal(workload.peak_observed_claims,
+                                  workload.peak_attributed_claims) ||
+            !claim_closures_equal(
+                release.checkpoint.observation.observed_claims,
+                release.checkpoint.observation.attributed_claims) ||
+            !release_is_bounded(
+                baseline.checkpoint.observation.observed_claims,
+                release.checkpoint.observation.observed_claims,
+                release.uncertainty_claims)) {
+            return capture_failure(
+                "profiling interval lifecycle evidence is not closed");
+        }
+
+        const auto baseline_provenance = phase_provenance_sha256(
+            ProfilingPhase::Baseline, context_, baseline_segments_);
+        const auto workload_provenance = phase_provenance_sha256(
+            ProfilingPhase::Workload, context_, workload_segments_);
+        const auto release_provenance = phase_provenance_sha256(
+            ProfilingPhase::Release, context_, release_segments_);
+        if (!baseline_provenance || !workload_provenance ||
+            !release_provenance) {
+            return capture_failure(
+                "profiling phase provenance could not be sealed");
+        }
+
+        auto sealed_baseline = seal_profiling_phase_attestation(phase_draft(
+            ProfilingPhase::Baseline,
+            ProfilingLifecycleState::BaselineQuiescent, context_, baseline,
+            *baseline_provenance, false));
+        auto sealed_workload = seal_profiling_phase_attestation(phase_draft(
+            ProfilingPhase::Workload,
+            ProfilingLifecycleState::WorkloadComplete, context_, workload,
+            *workload_provenance, true));
+        auto sealed_release = seal_profiling_phase_attestation(phase_draft(
+            ProfilingPhase::Release,
+            ProfilingLifecycleState::ReleaseVerified, context_, release,
+            *release_provenance, false));
+        if (!sealed_baseline.accepted() || !sealed_workload.accepted() ||
+            !sealed_release.accepted()) {
+            const auto &diagnostic =
+                !sealed_baseline.accepted()
+                    ? sealed_baseline.diagnostic
+                    : !sealed_workload.accepted()
+                          ? sealed_workload.diagnostic
+                          : sealed_release.diagnostic;
+            return capture_failure(
+                diagnostic.empty()
+                    ? "profiling phase attestations could not be sealed"
+                    : diagnostic);
+        }
+
+        return ProfilingTransactionCapture{
+            std::string(sealed_baseline.candidate->canonical_bytes()),
+            std::string(sealed_workload.candidate->canonical_bytes()),
+            std::string(sealed_release.candidate->canonical_bytes()),
+            {},
+        };
+    }
+
+    const ProfilingDerivationContract &contract_;
+    const ProfilingCaptureSchedule &schedule_;
+    Router &router_;
+    const ProfilingTransactionContext &context_;
+    ProfilingWorkloadDriver &workload_;
+    const ProfilingCancellationCheck &should_abort_;
+    ProfilingIntervalRecorder recorder_;
+    std::vector<ProfilingIntervalSegment> baseline_segments_;
+    std::vector<ProfilingIntervalSegment> workload_segments_;
+    std::vector<ProfilingIntervalSegment> release_segments_;
+    std::thread observer_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    SharedState state_;
+    std::atomic<bool> observer_failed_{false};
+    bool stop_requested_ = false;
+    std::string diagnostic_;
+};
+
+} // namespace
+
+ProfilingCaptureAuthority::ProfilingCaptureAuthority(
+    ProfilingDerivationContract contract,
+    ProfilingCaptureSchedule schedule)
+    : contract_(std::move(contract)), source_(&unavailable_source_),
+      schedule_(std::move(schedule)) {
+    initialize_clock(schedule_.clock);
+}
+
+ProfilingCaptureAuthority::ProfilingCaptureAuthority(
+    ProfilingDerivationContract contract,
+    ProfilingIntervalObservationSource &source,
+    ProfilingCaptureSchedule schedule)
+    : contract_(std::move(contract)), source_(&source),
+      schedule_(std::move(schedule)) {
+    initialize_clock(schedule_.clock);
+}
+
+ProfilingTransactionCapture ProfilingCaptureAuthority::capture(
+    Router &router,
+    const ProfilingTransactionContext &context,
+    ProfilingWorkloadDriver &workload,
+    const ProfilingCancellationCheck &should_abort) {
+    try {
+        if (!schedule_is_valid(contract_, schedule_)) {
+            return capture_failure("profiling capture schedule is invalid");
+        }
+        CaptureOperation operation(contract_, *source_, schedule_, router,
+                                   context, workload, should_abort);
+        return operation.run();
+    } catch (...) {
+        return capture_failure("profiling capture authority failed");
+    }
+}
+
+} // namespace lemon::residency

--- a/src/cpp/server/residency/profiling_common.cpp
+++ b/src/cpp/server/residency/profiling_common.cpp
@@ -1,0 +1,115 @@
+#include "profiling_common.h"
+
+#include <mbedtls/md.h>
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR >= 4
+#include <psa/crypto.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <mutex>
+#include <type_traits>
+
+namespace lemon::residency::profiling_internal {
+
+std::string bounded_diagnostic(std::string value) {
+    if (value.size() <= max_local_overlay_diagnostic_bytes) return value;
+    std::size_t boundary = max_local_overlay_diagnostic_bytes;
+    while (boundary > 0 &&
+           (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u) {
+        --boundary;
+    }
+    value.resize(boundary);
+    return value;
+}
+
+bool cancelled(const ProfilingCancellationCheck &should_abort) noexcept {
+    if (!should_abort) return false;
+    try {
+        return should_abort();
+    } catch (...) {
+        return true;
+    }
+}
+
+bool digest_is_valid(std::string_view value) noexcept {
+    return value.size() == 64 &&
+           std::all_of(value.begin(), value.end(), [](char character) {
+               return (character >= '0' && character <= '9') ||
+                      (character >= 'a' && character <= 'f');
+           });
+}
+
+void append_u64(std::string &bytes, std::uint64_t value) {
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        bytes.push_back(static_cast<char>((value >> shift) & 0xffu));
+    }
+}
+
+void append_string(std::string &bytes, std::string_view value) {
+    append_u64(bytes, static_cast<std::uint64_t>(value.size()));
+    bytes.append(value.data(), value.size());
+}
+
+std::optional<std::string> sha256_hex(std::string_view bytes) {
+#if MBEDTLS_VERSION_MAJOR >= 4
+    static std::once_flag initialized;
+    static psa_status_t initialization_status = PSA_ERROR_BAD_STATE;
+    std::call_once(initialized,
+                   [] { initialization_status = psa_crypto_init(); });
+    if (initialization_status != PSA_SUCCESS) return std::nullopt;
+#endif
+
+    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    if (info == nullptr) return std::nullopt;
+
+    mbedtls_md_context_t context;
+    mbedtls_md_init(&context);
+    std::array<unsigned char, 32> digest{};
+    const bool failed =
+        mbedtls_md_setup(&context, info, 0) != 0 ||
+        mbedtls_md_starts(&context) != 0 ||
+        mbedtls_md_update(
+            &context,
+            reinterpret_cast<const unsigned char *>(bytes.data()),
+            bytes.size()) != 0 ||
+        mbedtls_md_finish(&context, digest.data()) != 0;
+    mbedtls_md_free(&context);
+    if (failed) return std::nullopt;
+
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(64);
+    for (const auto byte : digest) {
+        result.push_back(hex[(byte >> 4) & 0x0f]);
+        result.push_back(hex[byte & 0x0f]);
+    }
+    return result;
+}
+
+std::optional<std::chrono::steady_clock::duration> elapsed_between(
+    std::chrono::steady_clock::time_point started,
+    std::chrono::steady_clock::time_point finished) noexcept {
+    using Duration = std::chrono::steady_clock::duration;
+    using Rep = Duration::rep;
+    static_assert(std::is_integral_v<Rep>);
+
+    const auto start = started.time_since_epoch().count();
+    const auto finish = finished.time_since_epoch().count();
+    if (finish < start) return std::nullopt;
+
+    using UnsignedRep = std::make_unsigned_t<Rep>;
+    const auto ticks = static_cast<UnsignedRep>(finish) -
+                       static_cast<UnsignedRep>(start);
+    if constexpr (std::is_signed_v<Rep>) {
+        if (ticks > static_cast<UnsignedRep>(
+                        std::numeric_limits<Rep>::max())) {
+            return std::nullopt;
+        }
+    }
+    return Duration(static_cast<Rep>(ticks));
+}
+
+} // namespace lemon::residency::profiling_internal

--- a/src/cpp/server/residency/profiling_common.h
+++ b/src/cpp/server/residency/profiling_common.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "lemon/residency/profiling_transaction.h"
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace lemon::residency::profiling_internal {
+
+std::string bounded_diagnostic(std::string value);
+
+bool cancelled(const ProfilingCancellationCheck &should_abort) noexcept;
+
+bool digest_is_valid(std::string_view value) noexcept;
+
+void append_u64(std::string &bytes, std::uint64_t value);
+
+void append_string(std::string &bytes, std::string_view value);
+
+std::optional<std::string> sha256_hex(std::string_view bytes);
+
+std::optional<std::chrono::steady_clock::duration> elapsed_between(
+    std::chrono::steady_clock::time_point started,
+    std::chrono::steady_clock::time_point finished) noexcept;
+
+} // namespace lemon::residency::profiling_internal

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -1,10 +1,6 @@
 #include "lemon/residency/profiling_provider.h"
 
-#include <mbedtls/md.h>
-#include <mbedtls/version.h>
-#if MBEDTLS_VERSION_MAJOR >= 4
-#include <psa/crypto.h>
-#endif
+#include "profiling_common.h"
 
 #include <algorithm>
 #include <array>
@@ -29,23 +25,19 @@ namespace {
 
 using SteadyClock = std::chrono::steady_clock;
 using SystemClock = std::chrono::system_clock;
+using profiling_internal::append_string;
+using profiling_internal::append_u64;
+using profiling_internal::bounded_diagnostic;
+using profiling_internal::cancelled;
+using profiling_internal::digest_is_valid;
+using profiling_internal::elapsed_between;
+using profiling_internal::sha256_hex;
 
 struct SensorValues {
     std::optional<std::uint64_t> total;
     std::map<std::string, std::uint64_t> owners;
     std::uint64_t attributed_total = 0;
 };
-
-std::string bounded_diagnostic(std::string value) {
-    if (value.size() <= max_local_overlay_diagnostic_bytes) return value;
-    std::size_t boundary = max_local_overlay_diagnostic_bytes;
-    while (boundary > 0 &&
-           (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u) {
-        --boundary;
-    }
-    value.resize(boundary);
-    return value;
-}
 
 ProfilingObservationCollectionResult
 result_for(ProfilingCollectionStatus status, std::string diagnostic = {}) {
@@ -54,15 +46,6 @@ result_for(ProfilingCollectionStatus status, std::string diagnostic = {}) {
         bounded_diagnostic(std::move(diagnostic)),
         std::nullopt,
     };
-}
-
-bool cancelled(const ProfilingCancellationCheck &should_abort) noexcept {
-    if (!should_abort) return false;
-    try {
-        return should_abort();
-    } catch (...) {
-        return true;
-    }
 }
 
 std::optional<std::size_t> family_index(ClaimFamily family) noexcept {
@@ -177,14 +160,6 @@ bool identifier_is_valid(std::string_view value) noexcept {
            value.size() <= max_local_overlay_identifier_bytes &&
            std::all_of(value.begin(), value.end(), [](unsigned char character) {
                return character >= 0x21 && character <= 0x7e;
-           });
-}
-
-bool digest_is_valid(std::string_view value) noexcept {
-    return value.size() == 64 &&
-           std::all_of(value.begin(), value.end(), [](char character) {
-               return (character >= '0' && character <= '9') ||
-                      (character >= 'a' && character <= 'f');
            });
 }
 
@@ -358,17 +333,6 @@ std::string format_utc(std::int64_t seconds) {
     return result.size() == 20 ? result : std::string{};
 }
 
-void append_u64(std::string &bytes, std::uint64_t value) {
-    for (int shift = 56; shift >= 0; shift -= 8) {
-        bytes.push_back(static_cast<char>((value >> shift) & 0xffu));
-    }
-}
-
-void append_string(std::string &bytes, std::string_view value) {
-    append_u64(bytes, static_cast<std::uint64_t>(value.size()));
-    bytes.append(value.data(), value.size());
-}
-
 void append_claim_closure(std::string &bytes,
                           std::vector<ClaimFamilyClosure> closure) {
     std::sort(closure.begin(), closure.end(),
@@ -397,41 +361,6 @@ void append_claim_closure(std::string &bytes,
             append_u64(bytes, entry.amount);
         }
     }
-}
-
-std::optional<std::string> sha256_hex(std::string_view bytes) {
-#if MBEDTLS_VERSION_MAJOR >= 4
-    static std::once_flag initialized;
-    static psa_status_t initialization_status = PSA_ERROR_BAD_STATE;
-    std::call_once(initialized,
-                   [] { initialization_status = psa_crypto_init(); });
-    if (initialization_status != PSA_SUCCESS) return std::nullopt;
-#endif
-
-    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    if (info == nullptr) return std::nullopt;
-
-    mbedtls_md_context_t context;
-    mbedtls_md_init(&context);
-    std::array<unsigned char, 32> digest{};
-    const bool failed =
-        mbedtls_md_setup(&context, info, 0) != 0 ||
-        mbedtls_md_starts(&context) != 0 ||
-        mbedtls_md_update(&context,
-                          reinterpret_cast<const unsigned char *>(bytes.data()),
-                          bytes.size()) != 0 ||
-        mbedtls_md_finish(&context, digest.data()) != 0;
-    mbedtls_md_free(&context);
-    if (failed) return std::nullopt;
-
-    static constexpr char hex[] = "0123456789abcdef";
-    std::string result;
-    result.reserve(64);
-    for (const auto byte : digest) {
-        result.push_back(hex[(byte >> 4) & 0x0f]);
-        result.push_back(hex[byte & 0x0f]);
-    }
-    return result;
 }
 
 std::optional<std::string> owner_scope_set_digest(
@@ -677,39 +606,6 @@ derive_claim_amounts(const ProfilingDerivationContract &contract,
         result.safety_margin.push_back(remaining - sensor.uncertainty_bound);
     }
     return result;
-}
-
-std::optional<SteadyClock::duration>
-elapsed_between(SteadyClock::time_point started,
-                SteadyClock::time_point finished) noexcept {
-    using Rep = SteadyClock::duration::rep;
-    static_assert(std::is_integral_v<Rep>);
-
-    const auto start = count_as_i64(started.time_since_epoch().count());
-    const auto finish = count_as_i64(finished.time_since_epoch().count());
-    if (!start || !finish || *finish < *start) return std::nullopt;
-
-    std::uint64_t ticks = 0;
-    if (*start < 0 && *finish >= 0) {
-        const auto magnitude =
-            static_cast<std::uint64_t>(-(*start + 1)) + 1;
-        ticks = magnitude + static_cast<std::uint64_t>(*finish);
-    } else {
-        ticks = static_cast<std::uint64_t>(*finish - *start);
-    }
-    if constexpr (std::is_signed_v<Rep>) {
-        if (ticks > static_cast<std::uint64_t>(
-                        std::numeric_limits<Rep>::max())) {
-            return std::nullopt;
-        }
-    } else if constexpr (std::numeric_limits<Rep>::digits <
-                         std::numeric_limits<std::uint64_t>::digits) {
-        if (ticks > static_cast<std::uint64_t>(
-                        std::numeric_limits<Rep>::max())) {
-            return std::nullopt;
-        }
-    }
-    return SteadyClock::duration(static_cast<Rep>(ticks));
 }
 
 std::optional<std::uint64_t>

--- a/src/cpp/server/residency/profiling_provider.cpp
+++ b/src/cpp/server/residency/profiling_provider.cpp
@@ -234,6 +234,8 @@ bool contract_is_valid(const ProfilingDerivationContract &contract) {
             contract.interval.event_semantics_revision_sha256) ||
         contract.interval.max_observation_gap <=
             std::chrono::milliseconds::zero() ||
+        contract.max_source_skew >=
+            contract.interval.max_observation_gap ||
         contract.interval.baseline_stability_window <=
             std::chrono::milliseconds::zero() ||
         contract.interval.release_stability_window <=

--- a/src/cpp/server/residency/profiling_transaction.cpp
+++ b/src/cpp/server/residency/profiling_transaction.cpp
@@ -1,8 +1,7 @@
 #include "lemon/residency/profiling_transaction.h"
 
 #include "lemon/router.h"
-
-#include <mbedtls/md.h>
+#include "profiling_common.h"
 
 #include <array>
 #include <chrono>
@@ -20,6 +19,8 @@ namespace lemon::residency {
 namespace {
 
 using Clock = std::chrono::steady_clock;
+using profiling_internal::bounded_diagnostic;
+using profiling_internal::sha256_hex;
 
 std::string system_utc_now() {
     const auto now = std::chrono::system_clock::now();
@@ -33,33 +34,6 @@ std::string system_utc_now() {
     std::ostringstream output;
     output << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
     return output.str();
-}
-
-std::optional<std::string> raw_sha256(std::string_view bytes) {
-    const auto *info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    if (info == nullptr) {
-        return std::nullopt;
-    }
-    mbedtls_md_context_t context;
-    mbedtls_md_init(&context);
-    std::array<unsigned char, 32> digest{};
-    const bool failed =
-        mbedtls_md_setup(&context, info, 0) != 0 || mbedtls_md_starts(&context) != 0 ||
-        mbedtls_md_update(&context, reinterpret_cast<const unsigned char *>(bytes.data()),
-                          bytes.size()) != 0 ||
-        mbedtls_md_finish(&context, digest.data()) != 0;
-    mbedtls_md_free(&context);
-    if (failed) {
-        return std::nullopt;
-    }
-    static constexpr char hex[] = "0123456789abcdef";
-    std::string result;
-    result.reserve(64);
-    for (const auto byte : digest) {
-        result.push_back(hex[(byte >> 4) & 0x0f]);
-        result.push_back(hex[byte & 0x0f]);
-    }
-    return result;
 }
 
 std::int64_t days_from_civil(int year, unsigned month, unsigned day) noexcept {
@@ -111,16 +85,6 @@ std::optional<std::int64_t> utc_seconds(std::string_view value) noexcept {
     }
     return days_from_civil(year, static_cast<unsigned>(month), static_cast<unsigned>(day)) * 86400 +
            hour * 3600 + minute * 60 + second;
-}
-
-std::string bounded_diagnostic(std::string value) {
-    if (value.size() > max_local_overlay_diagnostic_bytes) {
-        std::size_t boundary = max_local_overlay_diagnostic_bytes;
-        while (boundary > 0 && (static_cast<unsigned char>(value[boundary]) & 0xc0u) == 0x80u)
-            --boundary;
-        value.resize(boundary);
-    }
-    return value;
 }
 
 ProfilingTransactionResult result_for(ProfilingTransactionStatus status,
@@ -589,9 +553,9 @@ ProfilingTransactionResult ProfilingTransaction::run(ProfilingTransactionContext
                               "profiling evidence is stale or future-dated");
         }
 
-        const auto baseline_sha256 = raw_sha256(capture_result.baseline_attestation);
-        const auto workload_sha256 = raw_sha256(capture_result.workload_attestation);
-        const auto release_sha256 = raw_sha256(capture_result.release_attestation);
+        const auto baseline_sha256 = sha256_hex(capture_result.baseline_attestation);
+        const auto workload_sha256 = sha256_hex(capture_result.workload_attestation);
+        const auto release_sha256 = sha256_hex(capture_result.release_attestation);
         if (!baseline_sha256.has_value() || !workload_sha256.has_value() ||
             !release_sha256.has_value()) {
             return result_for(ProfilingTransactionStatus::Failed,

--- a/src/cpp/server/residency/profiling_transaction.cpp
+++ b/src/cpp/server/residency/profiling_transaction.cpp
@@ -124,6 +124,26 @@ bool claim_sets_equal(const std::vector<ClaimFamilyClosure> &left,
            *checked_left.claims == *checked_right.claims;
 }
 
+bool claim_set_covers_ordinary_constraints(
+    const std::vector<ClaimFamilyClosure> &claims,
+    const std::vector<ConstraintKind> &constraints) {
+    const auto checked = check_claim_closure(claims);
+    return checked.accepted() &&
+           claim_families_cover_ordinary_constraints(*checked.claims,
+                                                      constraints);
+}
+
+bool phase_covers_required_claim_families(
+    const ParsedProfilingPhaseAttestation &phase,
+    const std::vector<ConstraintKind> &constraints) {
+    return claim_set_covers_ordinary_constraints(phase.observed_claims(), constraints) &&
+           claim_set_covers_ordinary_constraints(phase.attributed_claims(), constraints) &&
+           claim_set_covers_ordinary_constraints(phase.external_change_claims(), constraints) &&
+           claim_set_covers_ordinary_constraints(phase.unattributed_claims(), constraints) &&
+           claim_set_covers_ordinary_constraints(phase.uncertainty_claims(), constraints) &&
+           claim_set_covers_ordinary_constraints(phase.safety_margin_claims(), constraints);
+}
+
 bool release_is_bounded(const ParsedProfilingPhaseAttestation &baseline,
                         const ParsedProfilingPhaseAttestation &release) {
     auto baseline_claims = check_claim_closure(baseline.observed_claims());
@@ -503,7 +523,14 @@ ProfilingTransactionResult ProfilingTransaction::run(ProfilingTransactionContext
                              workload_phase.attributed_claims()) &&
             claim_sets_equal(release_phase.observed_claims(), release_phase.attributed_claims()) &&
             release_is_bounded(baseline_phase, release_phase);
-        if (!common_reference_matches || !phase_order_is_valid || !attribution_is_closed) {
+        const auto &required_constraints =
+            context.selector.catalog_selector.constraints;
+        const auto required_claims_are_closed =
+            phase_covers_required_claim_families(baseline_phase, required_constraints) &&
+            phase_covers_required_claim_families(workload_phase, required_constraints) &&
+            phase_covers_required_claim_families(release_phase, required_constraints);
+        if (!common_reference_matches || !phase_order_is_valid ||
+            !attribution_is_closed || !required_claims_are_closed) {
             return result_for(ProfilingTransactionStatus::InvalidEvidence,
                               "profiling phase attestations do not form a closed transaction");
         }

--- a/src/cpp/server/residency/profiling_transaction.cpp
+++ b/src/cpp/server/residency/profiling_transaction.cpp
@@ -530,8 +530,8 @@ ProfilingTransactionResult ProfilingTransaction::run(ProfilingTransactionContext
             release_phase.phase() == ProfilingPhase::Release &&
             baseline_phase.observation_generation() < workload_phase.observation_generation() &&
             workload_phase.observation_generation() < release_phase.observation_generation() &&
-            baseline_phase.observed_at() < workload_phase.observed_at() &&
-            workload_phase.observed_at() < release_phase.observed_at();
+            baseline_phase.observed_at() <= workload_phase.observed_at() &&
+            workload_phase.observed_at() <= release_phase.observed_at();
         const auto attribution_is_closed =
             claim_sets_equal(baseline_phase.observed_claims(),
                              baseline_phase.attributed_claims()) &&

--- a/test/cpp/test_residency_local_overlay.cpp
+++ b/test/cpp/test_residency_local_overlay.cpp
@@ -599,6 +599,17 @@ void require_profiling_input_codec() {
                      OverlayContractStatus::IncompleteClaimClosure,
                      "profiling input accepted an unknown claim family");
 
+    auto omitted_required_family = profiling_draft();
+    for (auto &family : omitted_required_family.attributed_claims) {
+        if (family.family == ClaimFamily::SafetyFloor) {
+            family.completeness = ClaimCompleteness::NotApplicable;
+        }
+    }
+    require_rejected(
+        seal_profiling_input(std::move(omitted_required_family)),
+        OverlayContractStatus::IncompleteClaimClosure,
+        "profiling input accepted a required selector family as not applicable");
+
 }
 
 void require_overlay_object_codec() {

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -1,0 +1,1436 @@
+#include "lemon/config_file.h"
+#include "lemon/residency/profiling_capture_authority.h"
+#include "lemon/router.h"
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace lemon;
+using namespace lemon::residency;
+using namespace std::chrono_literals;
+
+static_assert(std::has_virtual_destructor_v<ProfilingWorkloadDriver>);
+static_assert(noexcept(std::declval<ProfilingWorkloadDriver &>().release(
+    std::declval<Router &>(),
+    std::declval<const ProfilingTransactionContext &>())));
+
+struct TestState {
+    std::atomic<bool> ok{true};
+
+    void require(bool condition, const char *message) {
+        if (condition) return;
+        ok.store(false);
+        std::cerr << "FAIL: " << message << '\n';
+    }
+};
+
+std::string digest(char value) { return std::string(64, value); }
+
+struct ThreadLifetime {
+    std::uint64_t token = 0;
+};
+
+const std::shared_ptr<const ThreadLifetime> &current_thread_lifetime() {
+    static std::atomic<std::uint64_t> next_token{1};
+    thread_local const auto lifetime =
+        std::make_shared<const ThreadLifetime>(
+            ThreadLifetime{next_token.fetch_add(1)});
+    return lifetime;
+}
+
+std::uint64_t current_thread_token() {
+    return current_thread_lifetime()->token;
+}
+
+class ReleaseSettleProbe {
+public:
+    explicit ReleaseSettleProbe(
+        std::atomic<bool> *cancelled = nullptr) noexcept
+        : cancelled_(cancelled) {}
+
+    void note_release_read() noexcept {
+        completed_release_reads_.fetch_add(1, std::memory_order_relaxed);
+        clocks_since_release_read_.store(0, std::memory_order_release);
+    }
+
+    void note_monotonic_read() noexcept {
+        const auto prior = clocks_since_release_read_.load(
+            std::memory_order_acquire);
+        if (prior < 0) return;
+        const auto current = clocks_since_release_read_.fetch_add(
+                                 1, std::memory_order_acq_rel) +
+                             1;
+        if (current != 3 ||
+            settle_checkpoint_started_.exchange(
+                true, std::memory_order_acq_rel)) {
+            return;
+        }
+        release_reads_at_settle_entry_.store(
+            completed_release_reads_.load(std::memory_order_acquire),
+            std::memory_order_release);
+        if (cancelled_) {
+            cancelled_->store(true, std::memory_order_release);
+        }
+    }
+
+    bool consume_settle_checkpoint() noexcept {
+        return settle_checkpoint_started_.load(std::memory_order_acquire) &&
+               !settle_checkpoint_consumed_.exchange(
+                   true, std::memory_order_acq_rel);
+    }
+
+    bool settle_checkpoint_started() const noexcept {
+        return settle_checkpoint_started_.load(std::memory_order_acquire);
+    }
+
+    std::size_t completed_release_reads() const noexcept {
+        return completed_release_reads_.load(std::memory_order_acquire);
+    }
+
+    std::size_t release_reads_at_settle_entry() const noexcept {
+        return release_reads_at_settle_entry_.load(
+            std::memory_order_acquire);
+    }
+
+private:
+    std::atomic<int> clocks_since_release_read_{-1};
+    std::atomic<bool> settle_checkpoint_started_{false};
+    std::atomic<bool> settle_checkpoint_consumed_{false};
+    std::atomic<std::size_t> completed_release_reads_{0};
+    std::atomic<std::size_t> release_reads_at_settle_entry_{0};
+    std::atomic<bool> *cancelled_ = nullptr;
+};
+
+std::vector<ClaimFamilyClosure> claims(std::uint64_t bytes = 0) {
+    std::vector<ClaimAmount> capacity;
+    if (bytes != 0) {
+        capacity.push_back(ClaimAmount{"gpu/gtt", ClaimUnit::Bytes, bytes});
+    }
+    return {
+        ClaimFamilyClosure{
+            ClaimFamily::ConsumableCapacity,
+            bytes == 0 ? ClaimCompleteness::KnownZero
+                       : ClaimCompleteness::Bounded,
+            std::move(capacity),
+        },
+        ClaimFamilyClosure{
+            ClaimFamily::SafetyFloor,
+            ClaimCompleteness::KnownZero,
+            {},
+        },
+        ClaimFamilyClosure{
+            ClaimFamily::CardinalityPool,
+            ClaimCompleteness::KnownZero,
+            {},
+        },
+        ClaimFamilyClosure{
+            ClaimFamily::CompatibilityExclusivity,
+            ClaimCompleteness::NotApplicable,
+            {},
+        },
+    };
+}
+
+const ClaimFamilyClosure *capacity_family(
+    const std::vector<ClaimFamilyClosure> &families) {
+    for (const auto &family : families) {
+        if (family.family == ClaimFamily::ConsumableCapacity) return &family;
+    }
+    return nullptr;
+}
+
+bool has_capacity(const std::vector<ClaimFamilyClosure> &families,
+                  std::uint64_t expected) {
+    const auto *family = capacity_family(families);
+    return family != nullptr &&
+           family->completeness == ClaimCompleteness::Bounded &&
+           family->entries.size() == 1 &&
+           family->entries.front().constraint_id == "gpu/gtt" &&
+           family->entries.front().unit == ClaimUnit::Bytes &&
+           family->entries.front().amount == expected;
+}
+
+LocalOverlaySelectorIdentity selector() {
+    RuntimeCatalogSelector catalog;
+    catalog.source_support_baseline = std::string(40, 'a');
+    catalog.base_variant = "llamacpp-rocm";
+    catalog.platform = "linux-amd-rocm-llamacpp";
+    catalog.backend_channel = "stable";
+    catalog.model_type = "llm";
+    catalog.operation_template = OperationTemplate::Adm;
+    catalog.operation_kind = OperationKind::Admission;
+    catalog.constraints = {
+        ConstraintKind::Ownership,
+        ConstraintKind::GpuSharedResidency,
+        ConstraintKind::ModelTypePool,
+        ConstraintKind::HostMemAvailableFloor,
+    };
+    catalog.recovery = "native_subprocess_tree";
+    catalog.material_profiles = {
+        {"configuration_profile",
+         "profile-free-residency-estimation-v1-text-only"},
+        {"hardware_profile", "hatchery-gfx1151-shared-gtt-v1"},
+        {"workload_profile", "hatchery-text-generation-campaign-v1"},
+    };
+
+    return LocalOverlaySelectorIdentity{
+        digest('1'), std::move(catalog), "model/alpha", digest('2'),
+        digest('3'), digest('4'),         digest('5'), digest('6'),
+        digest('7'), digest('8'),         digest('9'), digest('a'),
+    };
+}
+
+ProfilingDerivationContract contract() {
+    ProfilingDerivationContract value;
+    value.provider_id = "provider/dynamic-interval";
+    value.provider_revision_sha256 = digest('e');
+    value.sensors = {
+        ProfilingSensorContract{
+            "sensor/gtt-used",
+            "gpu/gtt",
+            ClaimFamily::ConsumableCapacity,
+            10,
+            1000,
+        },
+    };
+    value.owner_scopes = {
+        ProfilingOwnerScopeBinding{"owner/model-alpha", digest('f')},
+    };
+    value.freshness_window = 10min;
+    value.max_source_skew = 20ms;
+    value.interval.event_semantics_revision_sha256 = digest('9');
+    value.interval.max_observation_gap = 500ms;
+    value.interval.baseline_stability_window = 1ms;
+    value.interval.release_stability_window = 1ms;
+    value.interval.max_interval_frames = 128;
+    return value;
+}
+
+ProfilingTransactionContext context(
+    const ProfilingDerivationContract &derivation_contract = contract()) {
+    const auto contract_sha256 =
+        profiling_derivation_contract_sha256(derivation_contract);
+    if (!contract_sha256) throw std::runtime_error("invalid test contract");
+
+    ProfilingTransactionContext result;
+    result.deployment_id = digest('b');
+    result.sequence = 1;
+    result.profiling_transaction_id = "profile/capture-authority";
+    result.selector = selector();
+    result.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    result.observation_contract_sha256 = *contract_sha256;
+    result.predictor_contract_sha256 = digest('0');
+
+    ProfilingInputEnvelopeDraft input;
+    input.schema = supported_local_overlay_schema;
+    input.deployment_id = result.deployment_id;
+    input.sequence = result.sequence;
+    input.profiling_transaction_id = result.profiling_transaction_id;
+    input.selector = result.selector;
+    input.generations = result.generations;
+    input.attributed_claims = claims();
+    input.baseline_observation_sha256 = digest('c');
+    input.workload_observation_sha256 = digest('d');
+    input.release_observation_sha256 = digest('e');
+    input.observation_contract_sha256 = result.observation_contract_sha256;
+    input.predictor_contract_sha256 = result.predictor_contract_sha256;
+    input.observed_at = "2026-08-23T10:00:00Z";
+    input.fresh_until = "2026-08-23T10:10:00Z";
+    input.max_clock_skew_milliseconds = 1000;
+    input.attribution_complete = true;
+    input.external_demand_absent = true;
+    input.lifecycle_release_verified = true;
+    const auto sealed = seal_profiling_input(std::move(input));
+    if (!sealed.accepted()) {
+        throw std::runtime_error("profiling context selector could not seal");
+    }
+    result.selector_sha256 = sealed.candidate->selector_sha256();
+    return result;
+}
+
+ProfilingCollectionClock clock(
+    std::shared_ptr<ReleaseSettleProbe> release_settle_probe = {}) {
+    auto monotonic_milliseconds =
+        std::make_shared<std::atomic<std::uint64_t>>(0);
+    ProfilingCollectionClock value;
+    value.monotonic_now = [monotonic_milliseconds,
+                           release_settle_probe] {
+        if (release_settle_probe) {
+            release_settle_probe->note_monotonic_read();
+        }
+        return std::chrono::steady_clock::time_point{} +
+               std::chrono::milliseconds(
+                   monotonic_milliseconds->fetch_add(5));
+    };
+    value.utc_now = [] {
+        return std::chrono::system_clock::time_point{} +
+               std::chrono::seconds(1787479200);
+    };
+    return value;
+}
+
+ProfilingCaptureSchedule schedule(
+    std::shared_ptr<ReleaseSettleProbe> release_settle_probe = {}) {
+    ProfilingCaptureSchedule value;
+    value.observation_poll_interval = 1ms;
+    value.clock = clock(std::move(release_settle_probe));
+    return value;
+}
+
+ProfilingTransactionOptions transaction_options() {
+    ProfilingTransactionOptions value;
+    value.gate_timeout = 500ms;
+    value.retry_interval = 1ms;
+    value.utc_now = [] { return "2026-08-23T10:05:00Z"; };
+    return value;
+}
+
+RuntimeConfig make_config() {
+    nlohmann::json values = ConfigFile::get_defaults();
+    values["max_loaded_models"] = 2;
+    values["log_level"] = "error";
+    values["offline"] = true;
+    values["no_fetch_executables"] = true;
+    return RuntimeConfig(values);
+}
+
+ProfilingRawIntervalFrame frame(
+    const ProfilingDerivationContract &derivation_contract,
+    std::uint64_t watermark,
+    std::uint64_t total,
+    std::uint64_t owner) {
+    const auto owner_scope_set =
+        profiling_owner_scope_set_sha256(derivation_contract.owner_scopes);
+    if (!owner_scope_set) throw std::runtime_error("invalid owner scope set");
+
+    ProfilingRawIntervalFrame value;
+    value.source_epoch_sha256 = digest('1');
+    value.owner_scope_set_sha256 = *owner_scope_set;
+    value.event_semantics_revision_sha256 =
+        derivation_contract.interval.event_semantics_revision_sha256;
+    value.event_watermark = ProfilingEventWatermark{watermark};
+    value.samples = {
+        ProfilingRawSample{
+            "sensor/gtt-used",
+            std::nullopt,
+            total,
+            watermark,
+        },
+        ProfilingRawSample{
+            "sensor/gtt-used",
+            "owner/model-alpha",
+            owner,
+            watermark,
+        },
+    };
+    return value;
+}
+
+enum class SourceStage {
+    Baseline,
+    Workload,
+    Release,
+};
+
+struct DynamicFrameReading {
+    std::uint64_t total = 0;
+    std::uint64_t owner = 0;
+};
+
+struct DynamicIntervalScenario {
+    std::vector<DynamicFrameReading> baseline_stability_events;
+    std::function<void()> after_first_baseline_read;
+    std::vector<DynamicFrameReading> workload_events = {
+        {300, 300},
+        {500, 500},
+        {250, 250},
+    };
+    std::vector<DynamicFrameReading> release_events = {{100, 100}};
+    std::shared_ptr<ReleaseSettleProbe> release_settle_probe;
+    std::optional<DynamicFrameReading> release_stability_event;
+    std::optional<DynamicFrameReading> final_drain_event;
+};
+
+class DynamicIntervalSource final : public ProfilingIntervalObservationSource {
+public:
+    explicit DynamicIntervalSource(
+        ProfilingDerivationContract contract_value,
+        DynamicIntervalScenario scenario = {})
+        : contract_(std::move(contract_value)),
+          scenario_(std::move(scenario)) {
+        frames_.push_back(frame(contract_, 10, 100, 100));
+    }
+
+    ProfilingRawIntervalBeginResult begin(
+        const ProfilingRawIntervalReadRequest &request,
+        const ProfilingCancellationCheck &should_abort) override {
+        if (should_abort && should_abort()) {
+            return {
+                ProfilingIntervalSourceError::Cancelled,
+                {},
+                {},
+                "dynamic begin cancelled",
+            };
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        ++begin_calls_;
+        begin_thread_ = std::this_thread::get_id();
+        begin_thread_token_ = current_thread_token();
+        if (active_) {
+            return {
+                ProfilingIntervalSourceError::Failed,
+                {},
+                {},
+                "dynamic token already active",
+            };
+        }
+        const auto owner_scope_set =
+            profiling_owner_scope_set_sha256(contract_.owner_scopes);
+        if (!owner_scope_set ||
+            request.read.owner_scope_set_sha256 != *owner_scope_set ||
+            request.event_semantics_revision_sha256 !=
+                contract_.interval.event_semantics_revision_sha256) {
+            return {
+                ProfilingIntervalSourceError::Failed,
+                {},
+                {},
+                "dynamic request identity mismatch",
+            };
+        }
+        active_ = true;
+        return {
+            ProfilingIntervalSourceError::None,
+            token_,
+            frames_.back(),
+            {},
+        };
+    }
+
+    ProfilingRawIntervalBatch read_since(
+        ProfilingRawIntervalToken token,
+        ProfilingEventWatermark after_event_watermark,
+        const ProfilingCancellationCheck &should_abort) override {
+        if (should_abort && should_abort()) {
+            return failure_batch(
+                ProfilingIntervalSourceError::Cancelled,
+                after_event_watermark,
+                "dynamic read cancelled");
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        ++read_calls_;
+        if (!active_ || token.opaque_id != token_.opaque_id) {
+            return failure_batch(
+                ProfilingIntervalSourceError::Failed,
+                after_event_watermark,
+                "dynamic token is inactive");
+        }
+
+        auto &stage_read_calls = read_calls_by_stage_[stage_index(stage_)];
+        ++stage_read_calls;
+        if (stage_ == SourceStage::Baseline && stage_read_calls == 1 &&
+            !scenario_.baseline_stability_events.empty()) {
+            for (const auto &reading :
+                 scenario_.baseline_stability_events) {
+                append_frame(reading);
+            }
+            baseline_stability_event_observed_ = true;
+        } else if (stage_ == SourceStage::Release &&
+                   scenario_.release_settle_probe &&
+                   scenario_.release_settle_probe
+                       ->consume_settle_checkpoint() &&
+                   scenario_.release_stability_event) {
+            append_frame(*scenario_.release_stability_event);
+            release_stability_event_observed_ = true;
+            scenario_.release_stability_event.reset();
+        }
+        if (stage_ == SourceStage::Baseline && stage_read_calls == 1 &&
+            scenario_.after_first_baseline_read) {
+            scenario_.after_first_baseline_read();
+        }
+        const auto current_watermark = frames_.back().event_watermark.value;
+        if (after_event_watermark.value > current_watermark) {
+            return failure_batch(
+                ProfilingIntervalSourceError::HistoryLost,
+                after_event_watermark,
+                "dynamic cursor is ahead of retained history");
+        }
+
+        std::vector<ProfilingRawIntervalFrame> events;
+        for (const auto &candidate : frames_) {
+            if (candidate.event_watermark.value >
+                after_event_watermark.value) {
+                events.push_back(candidate);
+            }
+        }
+
+        if (stage_ == SourceStage::Workload && workload_published_ &&
+            current_watermark >= workload_final_watermark_) {
+            workload_poll_thread_ = std::this_thread::get_id();
+            workload_poll_thread_token_ = current_thread_token();
+            workload_observer_lifetime_ = current_thread_lifetime();
+        } else if (stage_ == SourceStage::Release && release_published_ &&
+                   current_watermark >= release_watermark_) {
+            release_poll_thread_ = std::this_thread::get_id();
+            release_poll_thread_token_ = current_thread_token();
+        }
+        if (stage_ == SourceStage::Release &&
+            scenario_.release_settle_probe) {
+            scenario_.release_settle_probe->note_release_read();
+        }
+
+        return {
+            ProfilingIntervalSourceError::None,
+            after_event_watermark,
+            frames_.back().event_watermark,
+            std::move(events),
+            frames_.back(),
+            {},
+        };
+    }
+
+    ProfilingRawIntervalBatch finish(
+        ProfilingRawIntervalToken token,
+        ProfilingEventWatermark after_event_watermark) noexcept override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        ++finish_calls_;
+        finish_thread_ = std::this_thread::get_id();
+        finish_thread_token_ = current_thread_token();
+        finish_observer_lifetime_ = current_thread_lifetime();
+        if (!active_ || token.opaque_id != token_.opaque_id) {
+            return failure_batch(
+                ProfilingIntervalSourceError::Failed,
+                after_event_watermark,
+                "dynamic finish token is inactive");
+        }
+        active_ = false;
+
+        if (scenario_.final_drain_event) {
+            append_frame(*scenario_.final_drain_event);
+            final_drain_event_observed_ = true;
+        }
+
+        std::vector<ProfilingRawIntervalFrame> events;
+        for (const auto &candidate : frames_) {
+            if (candidate.event_watermark.value >
+                after_event_watermark.value) {
+                events.push_back(candidate);
+            }
+        }
+        return {
+            ProfilingIntervalSourceError::None,
+            after_event_watermark,
+            frames_.back().event_watermark,
+            std::move(events),
+            frames_.back(),
+            {},
+        };
+    }
+
+    void publish_workload() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stage_ = SourceStage::Workload;
+            workload_published_ = true;
+            for (const auto &reading : scenario_.workload_events) {
+                append_frame(reading);
+            }
+            workload_final_watermark_ = frames_.back().event_watermark.value;
+        }
+    }
+
+    void publish_release() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stage_ = SourceStage::Release;
+            release_published_ = true;
+            for (const auto &reading : scenario_.release_events) {
+                append_frame(reading);
+            }
+            release_watermark_ = frames_.back().event_watermark.value;
+        }
+    }
+
+    std::size_t begin_calls() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return begin_calls_;
+    }
+
+    std::size_t finish_calls() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return finish_calls_;
+    }
+
+    bool active() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return active_;
+    }
+
+    std::thread::id begin_thread() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return begin_thread_;
+    }
+
+    std::thread::id workload_poll_thread() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return workload_poll_thread_;
+    }
+
+    std::thread::id release_poll_thread() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return release_poll_thread_;
+    }
+
+    std::thread::id finish_thread() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return finish_thread_;
+    }
+
+    std::uint64_t begin_thread_token() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return begin_thread_token_;
+    }
+
+    std::uint64_t workload_poll_thread_token() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return workload_poll_thread_token_;
+    }
+
+    std::uint64_t release_poll_thread_token() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return release_poll_thread_token_;
+    }
+
+    std::uint64_t finish_thread_token() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return finish_thread_token_;
+    }
+
+    bool observer_thread_exited() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return workload_observer_lifetime_.expired() &&
+               finish_observer_lifetime_.expired();
+    }
+
+    std::size_t stage_read_calls(SourceStage stage) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return read_calls_by_stage_[stage_index(stage)];
+    }
+
+    bool baseline_stability_event_observed() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return baseline_stability_event_observed_;
+    }
+
+    bool release_stability_event_observed() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return release_stability_event_observed_;
+    }
+
+    bool final_drain_event_observed() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return final_drain_event_observed_;
+    }
+
+private:
+    static constexpr std::size_t stage_index(SourceStage stage) noexcept {
+        return static_cast<std::size_t>(stage);
+    }
+
+    void append_frame(const DynamicFrameReading &reading) {
+        const auto watermark = frames_.back().event_watermark.value + 1;
+        frames_.push_back(
+            frame(contract_, watermark, reading.total, reading.owner));
+    }
+
+    ProfilingRawIntervalBatch failure_batch(
+        ProfilingIntervalSourceError error,
+        ProfilingEventWatermark after_event_watermark,
+        std::string diagnostic) const {
+        return {
+            error,
+            after_event_watermark,
+            after_event_watermark,
+            {},
+            {},
+            std::move(diagnostic),
+        };
+    }
+
+    ProfilingDerivationContract contract_;
+    DynamicIntervalScenario scenario_;
+    ProfilingRawIntervalToken token_{71};
+    mutable std::mutex mutex_;
+    std::vector<ProfilingRawIntervalFrame> frames_;
+    SourceStage stage_ = SourceStage::Baseline;
+    bool active_ = false;
+    bool workload_published_ = false;
+    bool release_published_ = false;
+    bool baseline_stability_event_observed_ = false;
+    bool release_stability_event_observed_ = false;
+    bool final_drain_event_observed_ = false;
+    std::uint64_t workload_final_watermark_ = 0;
+    std::uint64_t release_watermark_ = 0;
+    std::size_t begin_calls_ = 0;
+    std::size_t read_calls_ = 0;
+    std::size_t finish_calls_ = 0;
+    std::array<std::size_t, 3> read_calls_by_stage_{};
+    std::thread::id begin_thread_;
+    std::thread::id workload_poll_thread_;
+    std::thread::id release_poll_thread_;
+    std::thread::id finish_thread_;
+    std::uint64_t begin_thread_token_ = 0;
+    std::uint64_t workload_poll_thread_token_ = 0;
+    std::uint64_t release_poll_thread_token_ = 0;
+    std::uint64_t finish_thread_token_ = 0;
+    std::weak_ptr<const ThreadLifetime> workload_observer_lifetime_;
+    std::weak_ptr<const ThreadLifetime> finish_observer_lifetime_;
+};
+
+class CountingDriver final : public ProfilingWorkloadDriver {
+public:
+    void run(Router &,
+             const ProfilingTransactionContext &,
+             const ProfilingCancellationCheck &) override {
+        ++run_calls;
+    }
+
+    void release(Router &,
+                 const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+    }
+
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+};
+
+class PredispatchAbort {
+public:
+    void arm_after_baseline_read() noexcept {
+        state_.store(State::PermitRecorderCompletion,
+                     std::memory_order_release);
+    }
+
+    bool should_abort() noexcept {
+        auto expected = State::PermitRecorderCompletion;
+        if (state_.compare_exchange_strong(
+                expected, State::AbortOnNextCheck,
+                std::memory_order_acq_rel)) {
+            return false;
+        }
+        if (expected == State::AbortOnNextCheck) {
+            state_.store(State::Aborted, std::memory_order_release);
+            return true;
+        }
+        return expected == State::Aborted;
+    }
+
+    bool aborted() const noexcept {
+        return state_.load(std::memory_order_acquire) == State::Aborted;
+    }
+
+private:
+    enum class State {
+        Disarmed,
+        PermitRecorderCompletion,
+        AbortOnNextCheck,
+        Aborted,
+    };
+
+    std::atomic<State> state_{State::Disarmed};
+};
+
+class CoordinatedDriver final : public ProfilingWorkloadDriver {
+public:
+    explicit CoordinatedDriver(DynamicIntervalSource &source)
+        : source_(source) {}
+
+    void run(Router &router,
+             const ProfilingTransactionContext &context,
+             const ProfilingCancellationCheck &should_abort) override {
+        ++run_calls;
+        run_thread = std::this_thread::get_id();
+        run_thread_token = current_thread_token();
+        run_router = &router;
+        transaction_id = context.profiling_transaction_id;
+        source_.publish_workload();
+        aborted_during_run = should_abort && should_abort();
+    }
+
+    void release(Router &router,
+                 const ProfilingTransactionContext &context) noexcept override {
+        ++release_calls;
+        release_thread = std::this_thread::get_id();
+        release_thread_token = current_thread_token();
+        release_router = &router;
+        release_transaction_id = context.profiling_transaction_id;
+        try {
+            source_.publish_release();
+        } catch (...) {
+            release_failed = true;
+        }
+    }
+
+    DynamicIntervalSource &source_;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+    std::thread::id run_thread;
+    std::thread::id release_thread;
+    std::uint64_t run_thread_token = 0;
+    std::uint64_t release_thread_token = 0;
+    Router *run_router = nullptr;
+    Router *release_router = nullptr;
+    std::string transaction_id;
+    std::string release_transaction_id;
+    bool aborted_during_run = false;
+    bool release_failed = false;
+};
+
+enum class DriverRunOutcome {
+    Complete,
+    Throw,
+    Cancel,
+};
+
+class AdversarialDriver final : public ProfilingWorkloadDriver {
+public:
+    AdversarialDriver(DynamicIntervalSource &source,
+                      DriverRunOutcome outcome,
+                      bool publish_release,
+                      std::atomic<bool> *caller_cancelled = nullptr)
+        : source_(source), outcome_(outcome),
+          publish_release_(publish_release),
+          caller_cancelled_(caller_cancelled) {}
+
+    void run(Router &,
+             const ProfilingTransactionContext &,
+             const ProfilingCancellationCheck &) override {
+        ++run_calls;
+        source_.publish_workload();
+        if (outcome_ == DriverRunOutcome::Cancel && caller_cancelled_) {
+            caller_cancelled_->store(true, std::memory_order_release);
+        }
+        if (outcome_ == DriverRunOutcome::Throw) {
+            throw std::runtime_error("adversarial workload failure");
+        }
+    }
+
+    void release(Router &,
+                 const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+        if (!publish_release_) return;
+        try {
+            source_.publish_release();
+        } catch (...) {
+            release_failed = true;
+        }
+    }
+
+    DynamicIntervalSource &source_;
+    DriverRunOutcome outcome_ = DriverRunOutcome::Complete;
+    bool publish_release_ = false;
+    std::atomic<bool> *caller_cancelled_ = nullptr;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+    bool release_failed = false;
+};
+
+void require_empty_capture(TestState &state,
+                           const ProfilingTransactionCapture &capture,
+                           const char *message) {
+    state.require(capture.baseline_attestation.empty() &&
+                      capture.workload_attestation.empty() &&
+                      capture.release_attestation.empty() &&
+                      !capture.diagnostic.empty(),
+                  message);
+}
+
+void test_invalid_and_default_source_never_invoke_driver(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+
+    DynamicIntervalSource source(derivation_contract);
+    auto invalid_schedule = schedule();
+    invalid_schedule.observation_poll_interval = 481ms;
+    ProfilingCaptureAuthority invalid(
+        derivation_contract, source, std::move(invalid_schedule));
+    CountingDriver invalid_driver;
+    const auto invalid_capture = invalid.capture(
+        router, transaction_context, invalid_driver, [] { return false; });
+
+    require_empty_capture(
+        state,
+        invalid_capture,
+        "an impossible polling schedule emits no phase attestations");
+    state.require(source.begin_calls() == 0 && invalid_driver.run_calls == 0 &&
+                      invalid_driver.release_calls == 0,
+                  "an invalid schedule is rejected before source or driver access");
+
+    ProfilingCaptureAuthority unavailable(derivation_contract, schedule());
+    CountingDriver unavailable_driver;
+    const auto unavailable_capture = unavailable.capture(
+        router, transaction_context, unavailable_driver,
+        [] { return false; });
+
+    require_empty_capture(
+        state,
+        unavailable_capture,
+        "the default unavailable source emits no phase attestations");
+    state.require(unavailable_driver.run_calls == 0 &&
+                      unavailable_driver.release_calls == 0,
+                  "the unavailable default source never invokes the driver");
+}
+
+void test_captures_canonical_phases_across_a_complete_interval(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    DynamicIntervalSource source(derivation_contract);
+    CoordinatedDriver driver(source);
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule());
+    ProfilingTransaction transaction(router, transaction_options());
+    ProfilingTransactionCapture captured;
+    const auto owner_thread = std::this_thread::get_id();
+    const auto owner_thread_token = current_thread_token();
+
+    const auto result = transaction.run(
+        transaction_context,
+        [&](Router &gated_router,
+            const ProfilingTransactionContext &gated_context,
+            const ProfilingCancellationCheck &should_abort) {
+            captured = authority.capture(
+                gated_router, gated_context, driver, should_abort);
+            return captured;
+        });
+
+    state.require(result.accepted(),
+                  "one complete interval is accepted through ProfilingTransaction");
+    state.require(captured.diagnostic.empty() &&
+                      !captured.baseline_attestation.empty() &&
+                      !captured.workload_attestation.empty() &&
+                      !captured.release_attestation.empty(),
+                  "the authority publishes all three phase bytes atomically");
+
+    const auto baseline =
+        parse_profiling_phase_attestation(captured.baseline_attestation);
+    const auto workload =
+        parse_profiling_phase_attestation(captured.workload_attestation);
+    const auto release =
+        parse_profiling_phase_attestation(captured.release_attestation);
+    state.require(baseline.accepted() && workload.accepted() &&
+                      release.accepted(),
+                  "every emitted phase attestation is canonical and parseable");
+    if (baseline.candidate && workload.candidate && release.candidate) {
+        state.require(
+            baseline.candidate->canonical_bytes() ==
+                    captured.baseline_attestation &&
+                workload.candidate->canonical_bytes() ==
+                    captured.workload_attestation &&
+                release.candidate->canonical_bytes() ==
+                    captured.release_attestation,
+            "phase bytes round-trip through the canonical public parser");
+        state.require(
+            baseline.candidate->phase() == ProfilingPhase::Baseline &&
+                workload.candidate->phase() == ProfilingPhase::Workload &&
+                release.candidate->phase() == ProfilingPhase::Release &&
+                baseline.candidate->lifecycle_state() ==
+                    ProfilingLifecycleState::BaselineQuiescent &&
+                workload.candidate->lifecycle_state() ==
+                    ProfilingLifecycleState::WorkloadComplete &&
+                release.candidate->lifecycle_state() ==
+                    ProfilingLifecycleState::ReleaseVerified,
+            "the Server-owned authority assigns the three lifecycle phases");
+        state.require(
+            has_capacity(baseline.candidate->observed_claims(), 100) &&
+                has_capacity(workload.candidate->observed_claims(), 500) &&
+                has_capacity(release.candidate->observed_claims(), 100),
+            "the workload phase retains a hidden interval peak between stable endpoints");
+        state.require(
+            has_capacity(baseline.candidate->uncertainty_claims(), 10) &&
+                has_capacity(workload.candidate->uncertainty_claims(), 10) &&
+                has_capacity(release.candidate->uncertainty_claims(), 10) &&
+                has_capacity(baseline.candidate->safety_margin_claims(), 890) &&
+                has_capacity(workload.candidate->safety_margin_claims(), 490) &&
+                has_capacity(release.candidate->safety_margin_claims(), 890),
+            "phase attestations retain interval uncertainty and minimum safety slack");
+        state.require(
+            baseline.candidate->observation_generation() <
+                    workload.candidate->observation_generation() &&
+                workload.candidate->observation_generation() <
+                    release.candidate->observation_generation(),
+            "selected phase checkpoints remain strictly capture ordered");
+        state.require(
+            baseline.candidate->provenance_sha256().size() == 64 &&
+                workload.candidate->provenance_sha256().size() == 64 &&
+                release.candidate->provenance_sha256().size() == 64 &&
+                baseline.candidate->provenance_sha256() !=
+                    workload.candidate->provenance_sha256() &&
+                workload.candidate->provenance_sha256() !=
+                    release.candidate->provenance_sha256(),
+            "each phase binds its ordered interval transcript independently");
+    }
+
+    state.require(result.evidence.has_value() &&
+                      result.evidence->baseline().canonical_bytes() ==
+                          captured.baseline_attestation &&
+                      result.evidence->workload().canonical_bytes() ==
+                          captured.workload_attestation &&
+                      result.evidence->release().canonical_bytes() ==
+                          captured.release_attestation,
+                  "ProfilingTransaction retains the authority's canonical bytes");
+
+    state.require(driver.run_calls == 1 && driver.release_calls == 1 &&
+                      !driver.aborted_during_run && !driver.release_failed,
+                  "the owner drives one nonblocking workload and terminal release");
+    state.require(driver.run_router == &router &&
+                      driver.release_router == &router &&
+                      driver.transaction_id ==
+                          transaction_context.profiling_transaction_id &&
+                      driver.release_transaction_id ==
+                          transaction_context.profiling_transaction_id,
+                  "both driver calls receive the gated Router and transaction identity");
+
+    const auto observer_thread = source.workload_poll_thread();
+    const auto observer_thread_token = source.workload_poll_thread_token();
+    state.require(source.begin_thread() == owner_thread &&
+                      driver.run_thread == owner_thread &&
+                      driver.release_thread == owner_thread &&
+                      source.begin_thread_token() == owner_thread_token &&
+                      driver.run_thread_token == owner_thread_token &&
+                      driver.release_thread_token == owner_thread_token,
+                  "source registration and all Router work stay on the owner thread");
+    state.require(observer_thread != std::thread::id{} &&
+                      observer_thread != owner_thread &&
+                      source.release_poll_thread() == observer_thread &&
+                      source.finish_thread() == observer_thread &&
+                      observer_thread_token != 0 &&
+                      observer_thread_token != owner_thread_token &&
+                      source.release_poll_thread_token() ==
+                          observer_thread_token &&
+                      source.finish_thread_token() == observer_thread_token,
+                  "one distinct observer polls workload and release and performs the final drain");
+    state.require(source.begin_calls() == 1 && source.finish_calls() == 1 &&
+                      !source.active() && source.observer_thread_exited(),
+                  "capture returns only after the observer drains, unregisters, and exits");
+}
+
+void test_stability_windows_restart_after_retained_events(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    auto release_settle_probe = std::make_shared<ReleaseSettleProbe>();
+    DynamicIntervalScenario scenario;
+    scenario.baseline_stability_events = {{120, 120}};
+    scenario.release_settle_probe = release_settle_probe;
+    scenario.release_stability_event = DynamicFrameReading{105, 105};
+    DynamicIntervalSource source(derivation_contract, std::move(scenario));
+    CoordinatedDriver driver(source);
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule(release_settle_probe));
+
+    const auto captured = authority.capture(
+        router, transaction_context, driver, [] { return false; });
+    state.require(captured.diagnostic.empty(),
+                  "retained events restart both stability windows without rejecting a complete capture");
+    const auto baseline =
+        parse_profiling_phase_attestation(captured.baseline_attestation);
+    const auto release =
+        parse_profiling_phase_attestation(captured.release_attestation);
+    state.require(baseline.accepted() && release.accepted(),
+                  "stability-reset phase attestations remain canonical");
+    if (baseline.candidate && release.candidate) {
+        state.require(
+            has_capacity(baseline.candidate->observed_claims(), 120) &&
+                has_capacity(release.candidate->observed_claims(), 105),
+            "baseline and release seal only the stable checkpoints after retained movement");
+    }
+    state.require(
+        source.baseline_stability_event_observed() &&
+            source.release_stability_event_observed() &&
+            release_settle_probe->settle_checkpoint_started() &&
+            source.stage_read_calls(SourceStage::Baseline) >= 2 &&
+            release_settle_probe->completed_release_reads() >=
+                release_settle_probe->release_reads_at_settle_entry() + 2,
+        "each moved stability boundary requires a later unchanged checkpoint");
+}
+
+void test_transient_unattributed_demand_discards_every_phase(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+
+    DynamicIntervalScenario baseline_scenario;
+    baseline_scenario.baseline_stability_events = {
+        {300, 200},
+        {100, 100},
+    };
+    DynamicIntervalSource baseline_source(
+        derivation_contract, std::move(baseline_scenario));
+    CountingDriver baseline_driver;
+    ProfilingCaptureAuthority baseline_authority(
+        derivation_contract, baseline_source, schedule());
+    const auto baseline_capture = baseline_authority.capture(
+        router, transaction_context, baseline_driver,
+        [] { return false; });
+    require_empty_capture(
+        state,
+        baseline_capture,
+        "transient unattributed baseline demand discards all phases even when the following frame is clean");
+    state.require(baseline_driver.run_calls == 0 &&
+                      baseline_driver.release_calls == 0 &&
+                      baseline_source.finish_calls() == 1 &&
+                      !baseline_source.active(),
+                  "invalid baseline demand drains the source before any workload ownership begins");
+
+    DynamicIntervalScenario workload_scenario;
+    workload_scenario.workload_events = {
+        {300, 200},
+        {100, 100},
+    };
+    DynamicIntervalSource workload_source(
+        derivation_contract, std::move(workload_scenario));
+    AdversarialDriver workload_driver(
+        workload_source, DriverRunOutcome::Complete, false);
+    ProfilingCaptureAuthority workload_authority(
+        derivation_contract, workload_source, schedule());
+    const auto workload_capture = workload_authority.capture(
+        router, transaction_context, workload_driver,
+        [] { return false; });
+    require_empty_capture(
+        state,
+        workload_capture,
+        "transient unattributed workload demand discards all phases even when the following frame is clean");
+    state.require(workload_driver.run_calls == 1 &&
+                      workload_driver.release_calls == 1 &&
+                      workload_source.finish_calls() == 1 &&
+                      !workload_source.active() &&
+                      workload_source.observer_thread_exited(),
+                  "invalid workload demand releases once and drains the source token before returning");
+
+    DynamicIntervalScenario release_scenario;
+    release_scenario.release_events = {
+        {300, 200},
+        {100, 100},
+    };
+    DynamicIntervalSource release_source(
+        derivation_contract, std::move(release_scenario));
+    AdversarialDriver release_driver(
+        release_source, DriverRunOutcome::Complete, true);
+    ProfilingCaptureAuthority release_authority(
+        derivation_contract, release_source, schedule());
+    const auto release_capture = release_authority.capture(
+        router, transaction_context, release_driver,
+        [] { return false; });
+    require_empty_capture(
+        state,
+        release_capture,
+        "transient unattributed release demand discards all phases even when the following frame is clean");
+    state.require(release_driver.run_calls == 1 &&
+                      release_driver.release_calls == 1 &&
+                      release_source.finish_calls() == 1 &&
+                      !release_source.active() &&
+                      release_source.observer_thread_exited(),
+                  "invalid release demand drains the source token and joins the observer before returning");
+}
+
+void test_workload_failure_and_cancellation_close_the_interval(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+
+    DynamicIntervalSource throwing_source(derivation_contract);
+    AdversarialDriver throwing_driver(
+        throwing_source, DriverRunOutcome::Throw, true);
+    ProfilingCaptureAuthority throwing_authority(
+        derivation_contract, throwing_source, schedule());
+    const auto throwing_capture = throwing_authority.capture(
+        router, transaction_context, throwing_driver,
+        [] { return false; });
+    require_empty_capture(
+        state,
+        throwing_capture,
+        "a workload exception publishes no lifecycle attestations");
+    state.require(
+        throwing_driver.run_calls == 1 &&
+            throwing_driver.release_calls == 1 &&
+            !throwing_driver.release_failed &&
+            throwing_source.finish_calls() == 1 &&
+            !throwing_source.active() &&
+            throwing_source.observer_thread_exited(),
+        "a workload exception releases once, finishes once, joins the observer, and returns no live token");
+
+    std::atomic<bool> caller_cancelled{false};
+    DynamicIntervalSource cancelled_source(derivation_contract);
+    AdversarialDriver cancelled_driver(
+        cancelled_source, DriverRunOutcome::Cancel, false,
+        &caller_cancelled);
+    ProfilingCaptureAuthority cancelled_authority(
+        derivation_contract, cancelled_source, schedule());
+    const auto cancelled_capture = cancelled_authority.capture(
+        router, transaction_context, cancelled_driver, [&] {
+            return caller_cancelled.load(std::memory_order_acquire);
+        });
+    require_empty_capture(
+        state,
+        cancelled_capture,
+        "caller cancellation publishes no lifecycle attestations");
+    state.require(
+        caller_cancelled.load(std::memory_order_acquire) &&
+            cancelled_driver.run_calls == 1 &&
+            cancelled_driver.release_calls == 1 &&
+            !cancelled_driver.release_failed &&
+            cancelled_source.finish_calls() == 1 &&
+            !cancelled_source.active() &&
+            cancelled_source.observer_thread_exited(),
+        "caller cancellation releases once, finishes once, joins the observer, and returns no live token");
+}
+
+void test_predispatch_abort_never_enters_workload_ownership(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    PredispatchAbort abort;
+    DynamicIntervalScenario scenario;
+    scenario.after_first_baseline_read = [&abort] {
+        abort.arm_after_baseline_read();
+    };
+    DynamicIntervalSource source(derivation_contract, std::move(scenario));
+    CountingDriver driver;
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule());
+    const auto owner_thread = std::this_thread::get_id();
+    const auto owner_thread_token = current_thread_token();
+
+    const auto captured = authority.capture(
+        router, transaction_context, driver,
+        [&abort] { return abort.should_abort(); });
+
+    require_empty_capture(
+        state,
+        captured,
+        "a cancellation observed at the post-readiness dispatch boundary emits no phase bytes");
+    state.require(abort.aborted() && driver.run_calls == 0 &&
+                      driver.release_calls == 0,
+                  "pre-dispatch cancellation never enters workload or release ownership");
+    state.require(
+        source.begin_calls() == 1 && source.finish_calls() == 1 &&
+            !source.active() && source.finish_thread() != std::thread::id{} &&
+            source.finish_thread() != owner_thread &&
+            source.finish_thread_token() != 0 &&
+            source.finish_thread_token() != owner_thread_token &&
+            source.observer_thread_exited(),
+        "pre-dispatch cancellation joins the ready observer after one source finish");
+}
+
+void test_release_settling_abort_closes_owned_workload(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    std::atomic<bool> caller_cancelled{false};
+    auto release_settle_probe =
+        std::make_shared<ReleaseSettleProbe>(&caller_cancelled);
+    DynamicIntervalScenario scenario;
+    scenario.release_settle_probe = release_settle_probe;
+    DynamicIntervalSource source(derivation_contract, std::move(scenario));
+    CoordinatedDriver driver(source);
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule(release_settle_probe));
+    const auto owner_thread = std::this_thread::get_id();
+    const auto owner_thread_token = current_thread_token();
+
+    const auto captured = authority.capture(
+        router, transaction_context, driver, [&caller_cancelled] {
+            return caller_cancelled.load(std::memory_order_acquire);
+        });
+
+    require_empty_capture(
+        state,
+        captured,
+        "cancellation after the release boundary emits no phase bytes while release is settling");
+    state.require(caller_cancelled.load(std::memory_order_acquire) &&
+                      driver.run_calls == 1 && driver.release_calls == 1 &&
+                      !driver.release_failed &&
+                      release_settle_probe->settle_checkpoint_started() &&
+                      release_settle_probe->completed_release_reads() ==
+                          release_settle_probe->release_reads_at_settle_entry(),
+                  "release-settling cancellation occurs after one completed workload and release transition");
+    state.require(
+        source.begin_calls() == 1 && source.finish_calls() == 1 &&
+            !source.active() && source.finish_thread() != std::thread::id{} &&
+            source.finish_thread() != owner_thread &&
+            source.finish_thread_token() != 0 &&
+            source.finish_thread_token() != owner_thread_token &&
+            source.observer_thread_exited(),
+        "release-settling cancellation finishes once and joins the observer before returning");
+}
+
+void test_unverified_noop_release_discards_every_phase(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    DynamicIntervalScenario scenario;
+    scenario.workload_events = {
+        {500, 500},
+        {100, 100},
+    };
+    scenario.release_events.clear();
+    DynamicIntervalSource source(derivation_contract, std::move(scenario));
+    AdversarialDriver driver(
+        source, DriverRunOutcome::Complete, false);
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule());
+
+    const auto captured = authority.capture(
+        router, transaction_context, driver, [] { return false; });
+    require_empty_capture(
+        state,
+        captured,
+        "a no-op release without retained release evidence publishes no phase bytes");
+    state.require(driver.run_calls == 1 && driver.release_calls == 1 &&
+                      source.finish_calls() == 1 && !source.active() &&
+                      source.observer_thread_exited(),
+                  "an unverified no-op release still closes the driver, observer, and source exactly once");
+}
+
+void test_final_drain_movement_discards_every_phase(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    DynamicIntervalScenario scenario;
+    scenario.final_drain_event = DynamicFrameReading{101, 101};
+    DynamicIntervalSource source(derivation_contract, std::move(scenario));
+    CoordinatedDriver driver(source);
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule());
+
+    const auto captured = authority.capture(
+        router, transaction_context, driver, [] { return false; });
+    require_empty_capture(
+        state,
+        captured,
+        "watermark movement in the atomic final drain invalidates all phase bytes");
+    state.require(source.final_drain_event_observed() &&
+                      driver.release_calls == 1 &&
+                      source.finish_calls() == 1 && !source.active() &&
+                      source.observer_thread_exited(),
+                  "a moved final drain unregisters once and joins its observer before failing closed");
+}
+
+void test_ordered_below_peak_history_changes_workload_provenance(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    DynamicIntervalScenario first_scenario;
+    first_scenario.workload_events = {
+        {200, 200},
+        {500, 500},
+        {300, 300},
+        {100, 100},
+    };
+    DynamicIntervalScenario second_scenario;
+    second_scenario.workload_events = {
+        {300, 300},
+        {500, 500},
+        {200, 200},
+        {100, 100},
+    };
+
+    DynamicIntervalSource first_source(
+        derivation_contract, std::move(first_scenario));
+    CoordinatedDriver first_driver(first_source);
+    ProfilingCaptureAuthority first_authority(
+        derivation_contract, first_source, schedule());
+    const auto first = first_authority.capture(
+        router, transaction_context, first_driver, [] { return false; });
+
+    DynamicIntervalSource second_source(
+        derivation_contract, std::move(second_scenario));
+    CoordinatedDriver second_driver(second_source);
+    ProfilingCaptureAuthority second_authority(
+        derivation_contract, second_source, schedule());
+    const auto second = second_authority.capture(
+        router, transaction_context, second_driver, [] { return false; });
+
+    const auto first_workload =
+        parse_profiling_phase_attestation(first.workload_attestation);
+    const auto second_workload =
+        parse_profiling_phase_attestation(second.workload_attestation);
+    state.require(first.diagnostic.empty() && second.diagnostic.empty() &&
+                      first_workload.accepted() &&
+                      second_workload.accepted(),
+                  "both ordered-history captures seal canonical phase attestations");
+    if (first_workload.candidate && second_workload.candidate) {
+        state.require(
+            has_capacity(first_workload.candidate->observed_claims(), 500) &&
+                has_capacity(second_workload.candidate->observed_claims(),
+                             500) &&
+                first_workload.candidate->observation_generation() ==
+                    second_workload.candidate->observation_generation() &&
+                first_workload.candidate->observed_at() ==
+                    second_workload.candidate->observed_at(),
+            "reordered histories retain the same workload peak, endpoint generation, and observation time");
+        state.require(
+            first_workload.candidate->provenance_sha256() !=
+                second_workload.candidate->provenance_sha256(),
+            "workload provenance binds ordered below-peak history rather than only peaks and endpoints");
+    }
+    state.require(first.baseline_attestation == second.baseline_attestation &&
+                      first.release_attestation == second.release_attestation,
+                  "reordering only workload history leaves equal baseline and release phase bytes");
+}
+
+} // namespace
+
+int main() {
+    TestState state;
+    RuntimeConfig config = make_config();
+    RuntimeConfig::set_global(&config);
+    {
+        Router router(&config, nullptr, nullptr);
+        test_invalid_and_default_source_never_invoke_driver(state, router);
+        test_captures_canonical_phases_across_a_complete_interval(
+            state, router);
+        test_stability_windows_restart_after_retained_events(state, router);
+        test_transient_unattributed_demand_discards_every_phase(
+            state, router);
+        test_workload_failure_and_cancellation_close_the_interval(
+            state, router);
+        test_predispatch_abort_never_enters_workload_ownership(
+            state, router);
+        test_release_settling_abort_closes_owned_workload(state, router);
+        test_unverified_noop_release_discards_every_phase(state, router);
+        test_final_drain_movement_discards_every_phase(state, router);
+        test_ordered_below_peak_history_changes_workload_provenance(
+            state, router);
+    }
+    RuntimeConfig::set_global(nullptr);
+    return state.ok.load() ? 0 : 1;
+}

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -224,7 +224,11 @@ ProfilingDerivationContract contract() {
 }
 
 ProfilingTransactionContext context(
-    const ProfilingDerivationContract &derivation_contract = contract()) {
+    const ProfilingDerivationContract &derivation_contract = contract(),
+    std::vector<ConstraintKind> constraints = {
+        ConstraintKind::Ownership,
+        ConstraintKind::GpuSharedResidency,
+    }) {
     const auto contract_sha256 =
         profiling_derivation_contract_sha256(derivation_contract);
     if (!contract_sha256) throw std::runtime_error("invalid test contract");
@@ -234,6 +238,7 @@ ProfilingTransactionContext context(
     result.sequence = 1;
     result.profiling_transaction_id = "profile/capture-authority";
     result.selector = selector();
+    result.selector.catalog_selector.constraints = std::move(constraints);
     result.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
     result.observation_contract_sha256 = *contract_sha256;
     result.predictor_contract_sha256 = digest('0');
@@ -898,6 +903,31 @@ void test_invalid_and_default_source_never_invoke_driver(
     state.require(source.begin_calls() == 0 && invalid_driver.run_calls == 0 &&
                       invalid_driver.release_calls == 0,
                   "an invalid schedule is rejected before source or driver access");
+
+    DynamicIntervalSource incomplete_source(derivation_contract);
+    ProfilingCaptureAuthority incomplete(
+        derivation_contract, incomplete_source, schedule());
+    CountingDriver incomplete_driver;
+    const auto incomplete_context = context(
+        derivation_contract,
+        {
+            ConstraintKind::Ownership,
+            ConstraintKind::GpuSharedResidency,
+            ConstraintKind::ModelTypePool,
+            ConstraintKind::HostMemAvailableFloor,
+        });
+    const auto incomplete_capture = incomplete.capture(
+        router, incomplete_context, incomplete_driver,
+        [] { return false; });
+
+    require_empty_capture(
+        state,
+        incomplete_capture,
+        "a derivation contract that omits required selector families emits no phase attestations");
+    state.require(incomplete_source.begin_calls() == 0 &&
+                      incomplete_driver.run_calls == 0 &&
+                      incomplete_driver.release_calls == 0,
+                  "incomplete selector coverage is rejected before source or driver access");
 
     ProfilingCaptureAuthority unavailable(derivation_contract, schedule());
     CountingDriver unavailable_driver;

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -366,6 +366,7 @@ struct DynamicIntervalScenario {
     std::shared_ptr<ReleaseSettleProbe> release_settle_probe;
     std::optional<DynamicFrameReading> release_stability_event;
     std::optional<DynamicFrameReading> final_drain_event;
+    bool throw_on_finish = false;
 };
 
 class DynamicIntervalSource final : public ProfilingIntervalObservationSource {
@@ -508,39 +509,53 @@ public:
     ProfilingRawIntervalBatch finish(
         ProfilingRawIntervalToken token,
         ProfilingEventWatermark after_event_watermark) noexcept override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        ++finish_calls_;
-        finish_thread_ = std::this_thread::get_id();
-        finish_thread_token_ = current_thread_token();
-        finish_observer_lifetime_ = current_thread_lifetime();
-        if (!active_ || token.opaque_id != token_.opaque_id) {
-            return failure_batch(
+        try {
+            std::lock_guard<std::mutex> lock(mutex_);
+            ++finish_calls_;
+            finish_thread_ = std::this_thread::get_id();
+            if (!active_ || token.opaque_id != token_.opaque_id) {
+                return failure_batch(
+                    ProfilingIntervalSourceError::Failed,
+                    after_event_watermark,
+                    "dynamic finish token is inactive");
+            }
+            active_ = false;
+            finish_thread_token_ = current_thread_token();
+            finish_observer_lifetime_ = current_thread_lifetime();
+            if (scenario_.throw_on_finish) {
+                throw std::runtime_error("dynamic finish failure");
+            }
+
+            if (scenario_.final_drain_event) {
+                append_frame(*scenario_.final_drain_event);
+                final_drain_event_observed_ = true;
+            }
+
+            std::vector<ProfilingRawIntervalFrame> events;
+            for (const auto &candidate : frames_) {
+                if (candidate.event_watermark.value >
+                    after_event_watermark.value) {
+                    events.push_back(candidate);
+                }
+            }
+            return {
+                ProfilingIntervalSourceError::None,
+                after_event_watermark,
+                frames_.back().event_watermark,
+                std::move(events),
+                frames_.back(),
+                {},
+            };
+        } catch (...) {
+            return {
                 ProfilingIntervalSourceError::Failed,
                 after_event_watermark,
-                "dynamic finish token is inactive");
+                after_event_watermark,
+                {},
+                {},
+                {},
+            };
         }
-        active_ = false;
-
-        if (scenario_.final_drain_event) {
-            append_frame(*scenario_.final_drain_event);
-            final_drain_event_observed_ = true;
-        }
-
-        std::vector<ProfilingRawIntervalFrame> events;
-        for (const auto &candidate : frames_) {
-            if (candidate.event_watermark.value >
-                after_event_watermark.value) {
-                events.push_back(candidate);
-            }
-        }
-        return {
-            ProfilingIntervalSourceError::None,
-            after_event_watermark,
-            frames_.back().event_watermark,
-            std::move(events),
-            frames_.back(),
-            {},
-        };
     }
 
     void publish_workload() {
@@ -869,7 +884,7 @@ void test_invalid_and_default_source_never_invoke_driver(
 
     DynamicIntervalSource source(derivation_contract);
     auto invalid_schedule = schedule();
-    invalid_schedule.observation_poll_interval = 481ms;
+    invalid_schedule.observation_poll_interval = 480ms;
     ProfilingCaptureAuthority invalid(
         derivation_contract, source, std::move(invalid_schedule));
     CountingDriver invalid_driver;
@@ -879,7 +894,7 @@ void test_invalid_and_default_source_never_invoke_driver(
     require_empty_capture(
         state,
         invalid_capture,
-        "an impossible polling schedule emits no phase attestations");
+        "a zero-jitter polling boundary emits no phase attestations");
     state.require(source.begin_calls() == 0 && invalid_driver.run_calls == 0 &&
                       invalid_driver.release_calls == 0,
                   "an invalid schedule is rejected before source or driver access");
@@ -1318,7 +1333,7 @@ void test_unverified_noop_release_discards_every_phase(
                   "an unverified no-op release still closes the driver, observer, and source exactly once");
 }
 
-void test_final_drain_movement_discards_every_phase(
+void test_final_drain_failures_discard_every_phase(
     TestState &state,
     Router &router) {
     const auto derivation_contract = contract();
@@ -1341,6 +1356,26 @@ void test_final_drain_movement_discards_every_phase(
                       source.finish_calls() == 1 && !source.active() &&
                       source.observer_thread_exited(),
                   "a moved final drain unregisters once and joins its observer before failing closed");
+
+    DynamicIntervalScenario throwing_scenario;
+    throwing_scenario.throw_on_finish = true;
+    DynamicIntervalSource throwing_source(
+        derivation_contract, std::move(throwing_scenario));
+    CoordinatedDriver throwing_driver(throwing_source);
+    ProfilingCaptureAuthority throwing_authority(
+        derivation_contract, throwing_source, schedule());
+
+    const auto throwing_capture = throwing_authority.capture(
+        router, transaction_context, throwing_driver,
+        [] { return false; });
+    require_empty_capture(
+        state,
+        throwing_capture,
+        "a final-drain adapter exception is contained and publishes no phase bytes");
+    state.require(throwing_source.finish_calls() == 1 &&
+                      !throwing_source.active() &&
+                      throwing_source.observer_thread_exited(),
+                  "a throwing final drain unregisters once without terminating the test process");
 }
 
 void test_ordered_below_peak_history_changes_workload_provenance(
@@ -1427,7 +1462,7 @@ int main() {
             state, router);
         test_release_settling_abort_closes_owned_workload(state, router);
         test_unverified_noop_release_discards_every_phase(state, router);
-        test_final_drain_movement_discards_every_phase(state, router);
+        test_final_drain_failures_discard_every_phase(state, router);
         test_ordered_below_peak_history_changes_workload_provenance(
             state, router);
     }

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -295,6 +295,7 @@ ProfilingCaptureSchedule schedule(
     std::shared_ptr<ReleaseSettleProbe> release_settle_probe = {}) {
     ProfilingCaptureSchedule value;
     value.observation_poll_interval = 1ms;
+    value.poll_cycle_overhead_allowance = 10ms;
     value.clock = clock(std::move(release_settle_probe));
     return value;
 }
@@ -889,7 +890,7 @@ void test_invalid_and_default_source_never_invoke_driver(
 
     DynamicIntervalSource source(derivation_contract);
     auto invalid_schedule = schedule();
-    invalid_schedule.observation_poll_interval = 480ms;
+    invalid_schedule.observation_poll_interval = 471ms;
     ProfilingCaptureAuthority invalid(
         derivation_contract, source, std::move(invalid_schedule));
     CountingDriver invalid_driver;
@@ -899,10 +900,30 @@ void test_invalid_and_default_source_never_invoke_driver(
     require_empty_capture(
         state,
         invalid_capture,
-        "a zero-jitter polling boundary emits no phase attestations");
+        "a polling schedule without its reserved cycle-overhead budget emits no phase attestations");
     state.require(source.begin_calls() == 0 && invalid_driver.run_calls == 0 &&
                       invalid_driver.release_calls == 0,
                   "an invalid schedule is rejected before source or driver access");
+
+    DynamicIntervalSource no_allowance_source(derivation_contract);
+    auto no_allowance_schedule = schedule();
+    no_allowance_schedule.poll_cycle_overhead_allowance = 0ms;
+    ProfilingCaptureAuthority no_allowance(
+        derivation_contract, no_allowance_source,
+        std::move(no_allowance_schedule));
+    CountingDriver no_allowance_driver;
+    const auto no_allowance_capture = no_allowance.capture(
+        router, transaction_context, no_allowance_driver,
+        [] { return false; });
+
+    require_empty_capture(
+        state,
+        no_allowance_capture,
+        "a polling schedule without a defined cycle-overhead allowance emits no phase attestations");
+    state.require(no_allowance_source.begin_calls() == 0 &&
+                      no_allowance_driver.run_calls == 0 &&
+                      no_allowance_driver.release_calls == 0,
+                  "a missing cycle-overhead allowance is rejected before source or driver access");
 
     DynamicIntervalSource incomplete_source(derivation_contract);
     ProfilingCaptureAuthority incomplete(

--- a/test/cpp/test_residency_profiling_provider.cpp
+++ b/test/cpp/test_residency_profiling_provider.cpp
@@ -596,6 +596,62 @@ void test_freshness_is_anchored_before_read(TestState &state) {
 
 void test_collector_fails_closed(TestState &state) {
     {
+        auto invalid_cadence_contract = contract();
+        invalid_cadence_contract.max_source_skew =
+            invalid_cadence_contract.interval.max_observation_gap;
+        auto transaction_context = context();
+        const auto invalid_identity =
+            profiling_derivation_contract_sha256(invalid_cadence_contract);
+        state.require(!invalid_identity.has_value(),
+                      "observation cadence must strictly exceed source skew");
+        if (invalid_identity) {
+            transaction_context.observation_contract_sha256 =
+                *invalid_identity;
+        }
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            std::move(invalid_cadence_contract), source, clock());
+
+        const auto result =
+            collector.collect(transaction_context, [] { return false; });
+
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidContract &&
+                          !result.observation.has_value(),
+                      "equal source skew and observation cadence fail closed");
+        state.require(source.requests.empty(),
+                      "an impossible observation cadence cannot enter the source");
+    }
+
+    {
+        auto invalid_cadence_contract = contract();
+        invalid_cadence_contract.max_source_skew =
+            invalid_cadence_contract.interval.max_observation_gap + 1ms;
+        auto transaction_context = context();
+        const auto invalid_identity =
+            profiling_derivation_contract_sha256(invalid_cadence_contract);
+        state.require(!invalid_identity.has_value(),
+                      "observation cadence must exceed greater source skew");
+        if (invalid_identity) {
+            transaction_context.observation_contract_sha256 =
+                *invalid_identity;
+        }
+        ScriptedProfilingObservationSource source({successful_read()});
+        ProfilingObservationCollector collector(
+            std::move(invalid_cadence_contract), source, clock());
+
+        const auto result =
+            collector.collect(transaction_context, [] { return false; });
+
+        state.require(result.status ==
+                              ProfilingCollectionStatus::InvalidContract &&
+                          !result.observation.has_value(),
+                      "source skew above observation cadence fails closed");
+        state.require(source.requests.empty(),
+                      "a negative observation budget cannot enter the source");
+    }
+
+    {
         auto invalid_contract = contract();
         invalid_contract.sensors.front().safety_ceiling =
             invalid_contract.sensors.front().uncertainty_bound;

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -121,6 +121,16 @@ std::vector<ClaimFamilyClosure> claims(std::uint64_t bytes = 0) {
     };
 }
 
+void omit_required_selector_claim_families(
+    std::vector<ClaimFamilyClosure> &closure) {
+    for (auto &family : closure) {
+        if (family.family == ClaimFamily::SafetyFloor ||
+            family.family == ClaimFamily::CardinalityPool) {
+            family.completeness = ClaimCompleteness::NotApplicable;
+        }
+    }
+}
+
 bool claim_sets_equal(const std::vector<ClaimFamilyClosure> &left,
                       const std::vector<ClaimFamilyClosure> &right) {
     const auto checked_left = check_claim_closure(left);
@@ -588,6 +598,52 @@ void test_rejects_unsafe_evidence(TestState &state, Router &router) {
             value.workload_attestation = phase_bytes(std::move(phase));
         },
         ProfilingTransactionStatus::InvalidEvidence);
+    using ClosureMember = std::vector<ClaimFamilyClosure>
+        ProfilingPhaseAttestationDraft::*;
+    const std::array<std::pair<const char *, ClosureMember>, 6>
+        required_closure_members{{
+            {"observed", &ProfilingPhaseAttestationDraft::observed_claims},
+            {"attributed", &ProfilingPhaseAttestationDraft::attributed_claims},
+            {"external", &ProfilingPhaseAttestationDraft::external_change_claims},
+            {"unattributed", &ProfilingPhaseAttestationDraft::unattributed_claims},
+            {"uncertainty", &ProfilingPhaseAttestationDraft::uncertainty_claims},
+            {"safety", &ProfilingPhaseAttestationDraft::safety_margin_claims},
+        }};
+    const std::array<std::pair<const char *, ProfilingPhase>, 3> phases{{
+        {"baseline", ProfilingPhase::Baseline},
+        {"workload", ProfilingPhase::Workload},
+        {"release", ProfilingPhase::Release},
+    }};
+    for (const auto &phase_entry : phases) {
+        const auto phase_name = phase_entry.first;
+        const auto phase_kind = phase_entry.second;
+        for (const auto &closure_entry : required_closure_members) {
+            const auto closure_name = closure_entry.first;
+            const auto closure_member = closure_entry.second;
+            const auto label = std::string(phase_name) + " " + closure_name +
+                               " claims must cover required selector families";
+            expect_rejected(
+                label.c_str(),
+                [phase_kind, closure_member](auto &ctx, auto &value) {
+                    auto phase = phase_draft(ctx, phase_kind);
+                    omit_required_selector_claim_families(
+                        phase.*closure_member);
+                    auto bytes = phase_bytes(std::move(phase));
+                    switch (phase_kind) {
+                    case ProfilingPhase::Baseline:
+                        value.baseline_attestation = std::move(bytes);
+                        break;
+                    case ProfilingPhase::Workload:
+                        value.workload_attestation = std::move(bytes);
+                        break;
+                    case ProfilingPhase::Release:
+                        value.release_attestation = std::move(bytes);
+                        break;
+                    }
+                },
+                ProfilingTransactionStatus::InvalidEvidence);
+        }
+    }
 
     auto contaminated_phase = phase_draft(context(), ProfilingPhase::Workload);
     contaminated_phase.external_change_claims = claims(4096);

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -389,6 +389,43 @@ void test_accepts_and_releases_gate(TestState &state, Router &router) {
     if (reacquired) router.end_exclusive();
 }
 
+void test_accepts_same_second_phase_observations(TestState &state,
+                                                 Router &router) {
+    ProfilingTransaction transaction(router, options());
+    const auto transaction_context = context();
+    ProfilingTransactionCapture captured;
+    auto baseline = phase_draft(transaction_context, ProfilingPhase::Baseline);
+    auto workload = phase_draft(transaction_context, ProfilingPhase::Workload);
+    auto release = phase_draft(transaction_context, ProfilingPhase::Release);
+    baseline.observed_at = "2026-08-23T10:00:00Z";
+    workload.observed_at = baseline.observed_at;
+    release.observed_at = baseline.observed_at;
+    captured.baseline_attestation = phase_bytes(std::move(baseline));
+    captured.workload_attestation = phase_bytes(std::move(workload));
+    captured.release_attestation = phase_bytes(std::move(release));
+
+    auto result = transaction.run(
+        transaction_context,
+        [captured = std::move(captured)](
+            Router &, const ProfilingTransactionContext &,
+            const ProfilingCancellationCheck &) mutable {
+            return std::move(captured);
+        });
+
+    state.require(result.accepted(),
+                  "same-second phase observations are accepted");
+    state.require(result.evidence.has_value(),
+                  "same-second phase observations retain evidence");
+    if (result.evidence) {
+        state.require(
+            result.evidence->baseline().observation_generation() <
+                    result.evidence->workload().observation_generation() &&
+                result.evidence->workload().observation_generation() <
+                    result.evidence->release().observation_generation(),
+            "same-second phase observations retain strict generation order");
+    }
+}
+
 void test_rejects_incomplete_capture(TestState &state, Router &router) {
     ProfilingTransaction transaction(router, options());
     auto result = transaction.run(context(), [&](Router &, const ProfilingTransactionContext &ctx,
@@ -503,10 +540,10 @@ void test_rejects_unsafe_evidence(TestState &state, Router &router) {
         },
         ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
-        "observation times must advance",
+        "observation times must not regress",
         [](auto &ctx, auto &value) {
             auto phase = phase_draft(ctx, ProfilingPhase::Release);
-            phase.observed_at = "2026-08-23T10:01:00Z";
+            phase.observed_at = "2026-08-23T10:00:59Z";
             value.release_attestation = phase_bytes(std::move(phase));
         },
         ProfilingTransactionStatus::InvalidEvidence);
@@ -1161,6 +1198,7 @@ int main() {
         Router router(&config, nullptr, nullptr);
         test_cross_router_request_ownership(state, router, config);
         test_accepts_and_releases_gate(state, router);
+        test_accepts_same_second_phase_observations(state, router);
         test_rejects_incomplete_capture(state, router);
         test_rejects_unsafe_evidence(state, router);
         test_rejects_concurrent_run(state, router);

--- a/test/residency/recovery/claims_public_seam.cpp
+++ b/test/residency/recovery/claims_public_seam.cpp
@@ -122,6 +122,84 @@ void require_checked_arithmetic() {
             "maximum plausible closure did not preserve every alternative scope");
 }
 
+void require_constraint_evidence_mapping() {
+    struct ExpectedBinding {
+        ConstraintKind constraint;
+        ConstraintEvidenceKind evidence;
+        ClaimFamily family;
+    };
+    const std::vector<ExpectedBinding> expected{
+        {ConstraintKind::GpuSharedResidency,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::ConsumableCapacity},
+        {ConstraintKind::GpuProviderResolvedCapacity,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::ConsumableCapacity},
+        {ConstraintKind::HostMemAvailableFloor,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::SafetyFloor},
+        {ConstraintKind::HostEffectsProviderResolved,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::SafetyFloor},
+        {ConstraintKind::ModelTypePool,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::CardinalityPool},
+        {ConstraintKind::Ownership,
+         ConstraintEvidenceKind::OwnerCoverage,
+         ClaimFamily::ConsumableCapacity},
+        {ConstraintKind::FlmTypeSlot,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::CardinalityPool},
+        {ConstraintKind::NpuCrossFamily,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::CompatibilityExclusivity},
+        {ConstraintKind::NpuExclusive,
+         ConstraintEvidenceKind::ClaimFamily,
+         ClaimFamily::CompatibilityExclusivity},
+    };
+
+    for (const auto &entry : expected) {
+        const auto requirement = constraint_evidence_requirement(entry.constraint);
+        require(requirement.has_value(),
+                "known constraint omitted an evidence requirement");
+        require(requirement->kind == entry.evidence,
+                "constraint mapped to the wrong evidence kind");
+        if (entry.evidence == ConstraintEvidenceKind::ClaimFamily) {
+            require(requirement->family.has_value() &&
+                        *requirement->family == entry.family,
+                    "constraint mapped to the wrong claim family");
+        } else {
+            require(!requirement->family.has_value(),
+                    "owner coverage carried a dummy claim family");
+        }
+    }
+    require(!constraint_evidence_requirement(
+                 static_cast<ConstraintKind>(999))
+                 .has_value(),
+            "unknown constraint mapped to evidence");
+
+    auto capacity_only_closure = closure();
+    for (auto &family : capacity_only_closure) {
+        if (family.family != ClaimFamily::ConsumableCapacity) {
+            family.completeness = ClaimCompleteness::NotApplicable;
+        }
+    }
+    const auto capacity_only = checked(std::move(capacity_only_closure));
+    require(claim_families_cover_ordinary_constraints(
+                capacity_only,
+                {ConstraintKind::Ownership,
+                 ConstraintKind::GpuSharedResidency}),
+            "capacity evidence did not cover its ordinary selector constraint");
+    require(!claim_families_cover_ordinary_constraints(
+                capacity_only,
+                {ConstraintKind::Ownership,
+                 ConstraintKind::GpuSharedResidency,
+                 ConstraintKind::HostMemAvailableFloor}),
+            "capacity evidence covered an omitted safety-floor constraint");
+    require(!claim_families_cover_ordinary_constraints(capacity_only, {}),
+            "an empty selector was treated as covered");
+}
+
 std::vector<ClaimSource> worked_sources() {
     return {
         ClaimSource{"resident/current", ClaimViewKind::Current,
@@ -241,6 +319,7 @@ void require_checked_transfers_and_release() {
 
 int main() {
     require_checked_arithmetic();
+    require_constraint_evidence_mapping();
     require_worked_projection();
     require_checked_transfers_and_release();
     return 0;


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 1250 additions, 157 deletions" src="https://img.shields.io/badge/IMPL-%2B1250%20%E2%88%92157-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 1764 additions, 2 deletions" src="https://img.shields.io/badge/TEST-%2B1764%20%E2%88%922-6F5F9A?style=flat" height="16"></picture> <picture><img alt="DOC: 2 additions, 2 deletions" src="https://img.shields.io/badge/DOC-%2B2%20%E2%88%922-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 16 touched" src="https://img.shields.io/badge/FILES-16-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 1250 additions, 157 deletions" src="https://img.shields.io/badge/IMPL-%2B1250%20%E2%88%92157-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 10 implementation files" src="https://img.shields.io/badge/FILES-10-5F6B78?style=flat" height="16"></picture>
  - [`CMakeLists.txt`](https://github.com/nisavid/lemonade/pull/134/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a) <picture><img alt="23 additions, 0 deletions" title="23 additions, 0 deletions" src="https://img.shields.io/badge/%2B23-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/claims.h`](https://github.com/nisavid/lemonade/pull/134/files#diff-5299f5ed66d8ecba4573b7699c7839576780b8bd13781edb4462fdf71a4bd62b) <picture><img alt="16 additions, 0 deletions" title="16 additions, 0 deletions" src="https://img.shields.io/badge/%2B16-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/include/lemon/residency/profiling_capture_authority.h`](https://github.com/nisavid/lemonade/pull/134/files#diff-617192056e27f076873c0e13dc040302fbe930c339c58412aed1a7c3eaa2d61c) <picture><img alt="68 additions, 0 deletions" title="68 additions, 0 deletions" src="https://img.shields.io/badge/%2B68-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/claims.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-f0feb75094928b52eaeeff9539264af43584cae73f7fb9e3cbe8296c2b56cbe9) <picture><img alt="57 additions, 0 deletions" title="57 additions, 0 deletions" src="https://img.shields.io/badge/%2B57-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/local_overlay.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-68ad1eed125cb7d2b6ccafbb17b09939654a829e96526fb5a6570313c2d304c1) <picture><img alt="5 additions, 0 deletions" title="5 additions, 0 deletions" src="https://img.shields.io/badge/%2B5-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_capture_authority.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-f0ac99c0765754cbc9f5840c333b8a67227585342d46ee4181d3fc6c326237de) <picture><img alt="891 additions, 0 deletions" title="891 additions, 0 deletions" src="https://img.shields.io/badge/%2B891-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_common.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-6c5a6b92d5030d19fe3299a28d1697eca084d7a71e4c948f60c27f6fb7c817f3) <picture><img alt="115 additions, 0 deletions" title="115 additions, 0 deletions" src="https://img.shields.io/badge/%2B115-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_common.h`](https://github.com/nisavid/lemonade/pull/134/files#diff-614beb390b281316a6676fe8f0cc5c8df3be1a7346634bd650076ea0e6405658) <picture><img alt="29 additions, 0 deletions" title="29 additions, 0 deletions" src="https://img.shields.io/badge/%2B29-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_provider.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-5212fed0ccb231b81eceebeb55bdd403330258d266ced17520b5b58cd6758614) <picture><img alt="10 additions, 112 deletions" title="10 additions, 112 deletions" src="https://img.shields.io/badge/%2B10-%E2%88%92112-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-ea5131019f6fd33b90980405887b634fb161b5fd8367c8acf451c849fa3f24a5) <picture><img alt="36 additions, 45 deletions" title="36 additions, 45 deletions" src="https://img.shields.io/badge/%2B36-%E2%88%9245-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 1764 additions, 2 deletions" src="https://img.shields.io/badge/TEST-%2B1764%20%E2%88%922-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 5 test files" src="https://img.shields.io/badge/FILES-5-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_local_overlay.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-8330e2dd29f45944fb75e4d564ee4bf90752ab8cbd20d17f4b6bda120ebd1e79) <picture><img alt="11 additions, 0 deletions" title="11 additions, 0 deletions" src="https://img.shields.io/badge/%2B11-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_residency_profiling_capture_authority.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-10b4b46d03d885bcf37b6c5b8997561a96a3506bf11a1df56f0cc1c5a89dc966) <picture><img alt="1522 additions, 0 deletions" title="1522 additions, 0 deletions" src="https://img.shields.io/badge/%2B1522-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_residency_profiling_provider.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-71a96f8621cd1ed5320380d5f561f9454e172ce0f8f9eedcc02c4e737d0ff422) <picture><img alt="56 additions, 0 deletions" title="56 additions, 0 deletions" src="https://img.shields.io/badge/%2B56-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/cpp/test_residency_profiling_transaction.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-6eccc8288ec167c7e83b3691fca7a50b36c196c464b41e557e3303ecbd1c2004) <picture><img alt="96 additions, 2 deletions" title="96 additions, 2 deletions" src="https://img.shields.io/badge/%2B96-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`test/residency/recovery/claims_public_seam.cpp`](https://github.com/nisavid/lemonade/pull/134/files#diff-e883a6ce6ec60c093ff3342b27126fef62970723b5724abd20501cb8ae20bc6c) <picture><img alt="79 additions, 0 deletions" title="79 additions, 0 deletions" src="https://img.shields.io/badge/%2B79-%E2%88%920-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="DOC: 2 additions, 2 deletions" src="https://img.shields.io/badge/DOC-%2B2%20%E2%88%922-3F7770?style=flat" height="16"></picture> <picture><img alt="FILES: 1 documentation file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`CONTEXT.md`](https://github.com/nisavid/lemonade/pull/134/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14) <picture><img alt="2 additions, 2 deletions" title="2 additions, 2 deletions" src="https://img.shields.io/badge/%2B2-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Adds an inactive capture authority that emits baseline, workload, and release attestations only after one continuous interval proves a stable baseline, completed workload, retained release transition, stable release window, and unchanged final drain. The current authority is explicitly capacity-only: selectors requiring unobserved host-floor, pool, or compatibility families fail before source or workload access, and capture schedules reserve source, polling, and cycle-overhead time inside the start-to-start cadence budget. Missing history, attribution gaps, contamination, cancellation, or lifecycle failure discard the whole capture. Refs #120.

## Review path

1. Start with the [public authority and workload-driver contract](https://github.com/nisavid/lemonade/pull/134/files#diff-617192056e27f076873c0e13dc040302fbe930c339c58412aed1a7c3eaa2d61c).
2. Check the [selector-to-evidence mapping](https://github.com/nisavid/lemonade/pull/134/files#diff-f0feb75094928b52eaeeff9539264af43584cae73f7fb9e3cbe8296c2b56cbe9) and [canonical input fence](https://github.com/nisavid/lemonade/pull/134/files#diff-68ad1eed125cb7d2b6ccafbb17b09939654a829e96526fb5a6570313c2d304c1) that prevent absent claim families from becoming accepted evidence.
3. Follow the [owner/observer lifecycle, cleanup, provenance, pre-effect selector fence, and atomic sealing](https://github.com/nisavid/lemonade/pull/134/files#diff-f0ac99c0765754cbc9f5840c333b8a67227585342d46ee4181d3fc6c326237de).
4. Verify the [all-phase claim-closure and same-second timestamp checks](https://github.com/nisavid/lemonade/pull/134/files#diff-ea5131019f6fd33b90980405887b634fb161b5fd8367c8acf451c849fa3f24a5), then use the [authority](https://github.com/nisavid/lemonade/pull/134/files#diff-10b4b46d03d885bcf37b6c5b8997561a96a3506bf11a1df56f0cc1c5a89dc966) and [transaction](https://github.com/nisavid/lemonade/pull/134/files#diff-6eccc8288ec167c7e83b3691fca7a50b36c196c464b41e557e3303ecbd1c2004) matrices to check completeness, contamination, cancellation, release verification, final drain, and exact-once cleanup.
5. Finish with the [shared profiling evidence helpers](https://github.com/nisavid/lemonade/pull/134/files#diff-6c5a6b92d5030d19fe3299a28d1697eca084d7a71e4c948f60c27f6fb7c817f3) and the small [cadence-contract prerequisite](https://github.com/nisavid/lemonade/pull/134/files#diff-5212fed0ccb231b81eceebeb55bdd403330258d266ced17520b5b58cd6758614).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

This slice does not add a live observation source, production workload driver, Server invocation, overlay activation, evidence export, publication, or signing. Issue #120 remains open for the live integration.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build "$BUILD_DIR" --target cpp-ci-tests -j2` — passed.
- `ctest --test-dir "$BUILD_DIR" -R '^(ResidencyClaims|ResidencyLocalOverlay|ResidencyProfilingTransaction|ResidencyProfilingCaptureAuthority)$' --repeat until-fail:10 --output-on-failure` — all four focused tests passed 10 consecutive runs each in 220.38 seconds.
- `ctest --test-dir "$BUILD_DIR" -R '^ResidencyProfilingCaptureAuthority$' --repeat until-fail:5 --output-on-failure` — the reviewed cadence-budget revision passed five consecutive runs in 30.06 seconds.
- `ctest --test-dir "$BUILD_DIR" -L cpp-ci --output-on-failure` — 67/67 passed on the reviewed revision in 78.35 seconds.
- Strict Clang 22 C++17 warning-as-error checks passed for all eight affected production and test translation units.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added residency profiling capture with baseline, workload, release, and final-drain validation.
  * Added cancellation handling, failure detection, provenance verification, and workload cleanup.
  * Added support for stable phase observations, including equal timestamps across phases.

* **Bug Fixes**
  * Rejects profiling contracts with unsafe observation timing.
  * Rejects captures with unattributed external demand or regressing timestamps.

* **Tests**
  * Added comprehensive coverage for successful captures, cancellation, failures, cleanup, stability resets, and provenance validation.
  * Added automated test execution for profiling capture scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
