### PR TITLE
feat(residency/profiling): split evidence input contract

### DIFF
--- a/docs/api/schemas/residency/deployment_local_overlay_object.schema.json
+++ b/docs/api/schemas/residency/deployment_local_overlay_object.schema.json
@@ -23,7 +23,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -118,7 +119,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -213,7 +215,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -307,7 +310,8 @@
                     "properties": {
                       "amount": {
                         "const": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -586,10 +590,14 @@
       "additionalProperties": false,
       "properties": {
         "major": {
-          "const": 1
+          "const": 1,
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "minor": {
-          "const": 0
+          "const": 0,
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1065,37 +1073,44 @@
         "backend": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "configuration": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "device": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "driver": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "model": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "topology": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "workload": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1149,7 +1164,8 @@
     "confidence_basis_points": {
       "maximum": 10000,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "decision_trace_sha256": {
       "$ref": "#/$defs/decision_trace_reference"
@@ -1185,7 +1201,8 @@
     "sequence": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "status": {
       "$ref": "#/$defs/object_status"
@@ -1215,6 +1232,7 @@
   "type": "object",
   "x-residency-required-keywords": [
     "x-max-utf8-bytes",
-    "x-residency-assert"
+    "x-residency-assert",
+    "x-residency-json-integer"
   ]
 }

--- a/docs/api/schemas/residency/overlay_activation_root.schema.json
+++ b/docs/api/schemas/residency/overlay_activation_root.schema.json
@@ -23,7 +23,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -118,7 +119,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -213,7 +215,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -307,7 +310,8 @@
                     "properties": {
                       "amount": {
                         "const": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -586,10 +590,14 @@
       "additionalProperties": false,
       "properties": {
         "major": {
-          "const": 1
+          "const": 1,
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "minor": {
-          "const": 0
+          "const": 0,
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1065,37 +1073,44 @@
         "backend": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "configuration": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "device": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "driver": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "model": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "topology": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "workload": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1283,7 +1298,8 @@
     "generation": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "previous_root_sha256": {
       "$ref": "#/$defs/previous_root_reference"
@@ -1301,7 +1317,8 @@
     "selected_overlay_sequence": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "selected_overlay_sha256": {
       "maxLength": 64,
@@ -1320,7 +1337,8 @@
     "sequence_high_water": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "transition": {
       "$ref": "#/$defs/root_transition"
@@ -1347,6 +1365,7 @@
   "type": "object",
   "x-residency-required-keywords": [
     "x-max-utf8-bytes",
-    "x-residency-assert"
+    "x-residency-assert",
+    "x-residency-json-integer"
   ]
 }

--- a/docs/api/schemas/residency/profiling_input_envelope.schema.json
+++ b/docs/api/schemas/residency/profiling_input_envelope.schema.json
@@ -586,7 +586,7 @@
       "additionalProperties": false,
       "properties": {
         "major": {
-          "const": 1
+          "const": 2
         },
         "minor": {
           "const": 0
@@ -1118,7 +1118,7 @@
       "x-max-utf8-bytes": 20
     }
   },
-  "$id": "residency.profiling_input_envelope/1.0",
+  "$id": "residency.profiling_input_envelope/2.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "allOf": [
@@ -1130,19 +1130,6 @@
     }
   ],
   "properties": {
-    "attributed_claims": {
-      "$ref": "#/$defs/claim_closure"
-    },
-    "attribution_complete": {
-      "const": true
-    },
-    "baseline_observation_sha256": {
-      "maxLength": 64,
-      "minLength": 64,
-      "pattern": "^[0-9a-f]{64}$",
-      "type": "string",
-      "x-max-utf8-bytes": 64
-    },
     "checksum_sha256": {
       "maxLength": 64,
       "minLength": 64,
@@ -1150,11 +1137,39 @@
       "type": "string",
       "x-max-utf8-bytes": 64
     },
+    "completion": {
+      "additionalProperties": false,
+      "properties": {
+        "action_lease_closure_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        },
+        "manifest_claims": {
+          "$ref": "#/$defs/claim_closure"
+        },
+        "ownership_recovery_evidence_sha256": {
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string",
+          "x-max-utf8-bytes": 64
+        }
+      },
+      "required": [
+        "action_lease_closure_sha256",
+        "manifest_claims",
+        "ownership_recovery_evidence_sha256"
+      ],
+      "type": "object"
+    },
+    "confidence": {
+      "const": "calibrated_instance"
+    },
     "deployment_id": {
       "$ref": "#/$defs/deployment_identity"
-    },
-    "external_demand_absent": {
-      "const": true
     },
     "fresh_until": {
       "$ref": "#/$defs/expiry"
@@ -1162,13 +1177,136 @@
     "generations": {
       "$ref": "#/$defs/source_generations"
     },
-    "lifecycle_release_verified": {
-      "const": true
-    },
     "max_clock_skew_milliseconds": {
       "maximum": 18446744073709551615,
       "minimum": 1,
       "type": "integer"
+    },
+    "method_evidence": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "baseline_observation_sha256": {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string",
+              "x-max-utf8-bytes": 64
+            },
+            "covered_effect": {
+              "const": "complete_lifecycle"
+            },
+            "external_change_absent": {
+              "const": true
+            },
+            "lifecycle_envelope_complete": {
+              "const": true
+            },
+            "method": {
+              "const": "mutation_complete_interval"
+            },
+            "owner_projection_coverage": {
+              "const": "complete"
+            },
+            "release_observation_sha256": {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string",
+              "x-max-utf8-bytes": 64
+            },
+            "workload_observation_sha256": {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string",
+              "x-max-utf8-bytes": 64
+            }
+          },
+          "required": [
+            "baseline_observation_sha256",
+            "covered_effect",
+            "external_change_absent",
+            "lifecycle_envelope_complete",
+            "method",
+            "owner_projection_coverage",
+            "release_observation_sha256",
+            "workload_observation_sha256"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "calibration_evidence_sha256": {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string",
+              "x-max-utf8-bytes": 64
+            },
+            "covered_effect": {
+              "const": "retained_gtt"
+            },
+            "method": {
+              "const": "differential_retained_gtt"
+            },
+            "owner_projection_coverage": {
+              "enum": [
+                "complete",
+                "incomplete",
+                "unknown"
+              ],
+              "maxLength": 10,
+              "minLength": 1,
+              "type": "string"
+            },
+            "retained_gtt_claim": {
+              "additionalProperties": false,
+              "properties": {
+                "amount": {
+                  "maximum": 18446744073709551615,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "constraint_id": {
+                  "maxLength": 128,
+                  "minLength": 1,
+                  "pattern": "^[\\u0021-\\u007e]+$",
+                  "type": "string",
+                  "x-max-utf8-bytes": 128
+                },
+                "unit": {
+                  "const": "bytes"
+                }
+              },
+              "required": [
+                "amount",
+                "constraint_id",
+                "unit"
+              ],
+              "type": "object"
+            },
+            "transient_envelope_sha256": {
+              "maxLength": 64,
+              "minLength": 64,
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string",
+              "x-max-utf8-bytes": 64
+            }
+          },
+          "required": [
+            "calibration_evidence_sha256",
+            "covered_effect",
+            "method",
+            "owner_projection_coverage",
+            "retained_gtt_claim",
+            "transient_envelope_sha256"
+          ],
+          "type": "object"
+        }
+      ]
     },
     "observation_contract_sha256": {
       "maxLength": 64,
@@ -1194,13 +1332,6 @@
       "type": "string",
       "x-max-utf8-bytes": 128
     },
-    "release_observation_sha256": {
-      "maxLength": 64,
-      "minLength": 64,
-      "pattern": "^[0-9a-f]{64}$",
-      "type": "string",
-      "x-max-utf8-bytes": 64
-    },
     "schema": {
       "$ref": "#/$defs/schema_version"
     },
@@ -1211,13 +1342,6 @@
       "maximum": 18446744073709551615,
       "minimum": 1,
       "type": "integer"
-    },
-    "workload_observation_sha256": {
-      "maxLength": 64,
-      "minLength": 64,
-      "pattern": "^[0-9a-f]{64}$",
-      "type": "string",
-      "x-max-utf8-bytes": 64
     }
   },
   "required": [
@@ -1227,18 +1351,14 @@
     "profiling_transaction_id",
     "selector",
     "generations",
-    "attributed_claims",
-    "baseline_observation_sha256",
-    "workload_observation_sha256",
-    "release_observation_sha256",
+    "method_evidence",
+    "completion",
+    "confidence",
     "observation_contract_sha256",
     "predictor_contract_sha256",
     "observed_at",
     "fresh_until",
     "max_clock_skew_milliseconds",
-    "attribution_complete",
-    "external_demand_absent",
-    "lifecycle_release_verified",
     "checksum_sha256"
   ],
   "title": "Profiling Input Envelope",

--- a/docs/api/schemas/residency/profiling_input_envelope.schema.json
+++ b/docs/api/schemas/residency/profiling_input_envelope.schema.json
@@ -23,7 +23,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -118,7 +119,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -213,7 +215,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -307,7 +310,8 @@
                     "properties": {
                       "amount": {
                         "const": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -586,10 +590,14 @@
       "additionalProperties": false,
       "properties": {
         "major": {
-          "const": 2
+          "const": 2,
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "minor": {
-          "const": 0
+          "const": 0,
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1065,37 +1073,44 @@
         "backend": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "configuration": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "device": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "driver": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "model": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "topology": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "workload": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1165,9 +1180,6 @@
       ],
       "type": "object"
     },
-    "confidence": {
-      "const": "calibrated_instance"
-    },
     "deployment_id": {
       "$ref": "#/$defs/deployment_identity"
     },
@@ -1180,7 +1192,8 @@
     "max_clock_skew_milliseconds": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "method_evidence": {
       "oneOf": [
@@ -1268,7 +1281,8 @@
                 "amount": {
                   "maximum": 18446744073709551615,
                   "minimum": 1,
-                  "type": "integer"
+                  "type": "integer",
+                  "x-residency-json-integer": true
                 },
                 "constraint_id": {
                   "maxLength": 128,
@@ -1341,7 +1355,8 @@
     "sequence": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     }
   },
   "required": [
@@ -1353,7 +1368,6 @@
     "generations",
     "method_evidence",
     "completion",
-    "confidence",
     "observation_contract_sha256",
     "predictor_contract_sha256",
     "observed_at",
@@ -1365,6 +1379,7 @@
   "type": "object",
   "x-residency-required-keywords": [
     "x-max-utf8-bytes",
-    "x-residency-assert"
+    "x-residency-assert",
+    "x-residency-json-integer"
   ]
 }

--- a/docs/api/schemas/residency/profiling_phase_attestation.schema.json
+++ b/docs/api/schemas/residency/profiling_phase_attestation.schema.json
@@ -23,7 +23,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -118,7 +119,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -213,7 +215,8 @@
                       "amount": {
                         "maximum": 18446744073709551615,
                         "minimum": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -307,7 +310,8 @@
                     "properties": {
                       "amount": {
                         "const": 1,
-                        "type": "integer"
+                        "type": "integer",
+                        "x-residency-json-integer": true
                       },
                       "constraint_id": {
                         "maxLength": 128,
@@ -586,10 +590,14 @@
       "additionalProperties": false,
       "properties": {
         "major": {
-          "const": 1
+          "const": 1,
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "minor": {
-          "const": 0
+          "const": 0,
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1065,37 +1073,44 @@
         "backend": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "configuration": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "device": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "driver": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "model": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "topology": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         },
         "workload": {
           "maximum": 18446744073709551615,
           "minimum": 1,
-          "type": "integer"
+          "type": "integer",
+          "x-residency-json-integer": true
         }
       },
       "required": [
@@ -1259,7 +1274,8 @@
     "max_source_skew_milliseconds": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "observation_contract_sha256": {
       "maxLength": 64,
@@ -1271,7 +1287,8 @@
     "observation_generation": {
       "maximum": 18446744073709551615,
       "minimum": 1,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "observed_at": {
       "$ref": "#/$defs/timestamp"
@@ -1343,7 +1360,8 @@
     "source_skew_milliseconds": {
       "maximum": 18446744073709551615,
       "minimum": 0,
-      "type": "integer"
+      "type": "integer",
+      "x-residency-json-integer": true
     },
     "unattributed_claims": {
       "allOf": [
@@ -1403,6 +1421,7 @@
   "type": "object",
   "x-residency-required-keywords": [
     "x-max-utf8-bytes",
-    "x-residency-assert"
+    "x-residency-assert",
+    "x-residency-json-integer"
   ]
 }

--- a/docs/research/portable-residency-capability-inventory.json
+++ b/docs/research/portable-residency-capability-inventory.json
@@ -4929,11 +4929,6 @@
             "type": "local_overlay_profiling_completion",
             "required": true
           },
-          "confidence": {
-            "type": "literal",
-            "required": true,
-            "value": "calibrated_instance"
-          },
           "observation_contract_sha256": {
             "type": "sha256",
             "required": true

--- a/docs/research/portable-residency-capability-inventory.json
+++ b/docs/research/portable-residency-capability-inventory.json
@@ -4890,11 +4890,11 @@
       },
       "profiling_input_envelope": {
         "version": {
-          "major": 1,
+          "major": 2,
           "minor": 0
         },
         "output": "docs/api/schemas/residency/profiling_input_envelope.schema.json",
-        "schema_type": "residency.profiling_input_envelope/1.0",
+        "schema_type": "residency.profiling_input_envelope/2.0",
         "fields": {
           "schema": {
             "type": "local_overlay_schema_version",
@@ -4921,21 +4921,18 @@
             "type": "local_overlay_source_generations",
             "required": true
           },
-          "attributed_claims": {
-            "type": "local_overlay_claim_closure",
+          "method_evidence": {
+            "type": "local_overlay_profiling_method_evidence",
             "required": true
           },
-          "baseline_observation_sha256": {
-            "type": "sha256",
+          "completion": {
+            "type": "local_overlay_profiling_completion",
             "required": true
           },
-          "workload_observation_sha256": {
-            "type": "sha256",
-            "required": true
-          },
-          "release_observation_sha256": {
-            "type": "sha256",
-            "required": true
+          "confidence": {
+            "type": "literal",
+            "required": true,
+            "value": "calibrated_instance"
           },
           "observation_contract_sha256": {
             "type": "sha256",
@@ -4955,18 +4952,6 @@
           },
           "max_clock_skew_milliseconds": {
             "type": "local_overlay_positive_uint64",
-            "required": true
-          },
-          "attribution_complete": {
-            "type": "local_overlay_required_true",
-            "required": true
-          },
-          "external_demand_absent": {
-            "type": "local_overlay_required_true",
-            "required": true
-          },
-          "lifecycle_release_verified": {
-            "type": "local_overlay_required_true",
             "required": true
           },
           "checksum_sha256": {

--- a/src/cpp/include/lemon/residency/durable_local_overlay.h
+++ b/src/cpp/include/lemon/residency/durable_local_overlay.h
@@ -52,6 +52,12 @@ private:
 
 enum class LocalOverlayActivationKind { Qualification, Rollback };
 
+namespace detail {
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+class LocalOverlayStoreTestFactory;
+#endif
+} // namespace detail
+
 class LocalOverlayActivation {
 public:
     LocalOverlayActivation() = delete;
@@ -61,13 +67,13 @@ public:
     LocalOverlayActivation &operator=(LocalOverlayActivation &&) noexcept = default;
 
     static LocalOverlayActivation
-    qualification(ParsedProfilingInputEnvelope profiling_input,
-                  ParsedLocalOverlayObject overlay,
-                  std::string baseline_observation_bytes,
-                  std::string workload_observation_bytes,
-                  std::string release_observation_bytes,
-                  std::string decision_trace_sha256,
-                  std::string activated_at);
+    unresolved_qualification(ParsedProfilingInputEnvelope profiling_input,
+                             ParsedLocalOverlayObject overlay,
+                             std::string baseline_observation_bytes,
+                             std::string workload_observation_bytes,
+                             std::string release_observation_bytes,
+                             std::string decision_trace_sha256,
+                             std::string activated_at);
     static LocalOverlayActivation rollback(std::string overlay_sha256,
                                            std::string decision_trace_sha256,
                                            std::string activated_at);
@@ -94,17 +100,20 @@ private:
     std::optional<std::string> release_observation_bytes_;
     std::string decision_trace_sha256_;
     std::string activated_at_;
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    bool qualification_resolved_for_test_ = false;
+#endif
 
     friend class LocalOverlayStore;
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    friend class detail::LocalOverlayStoreTestFactory;
+#endif
 };
 
 class LocalOverlayStore;
 
 namespace detail {
 class DurableFileAdapter;
-#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
-class LocalOverlayStoreTestFactory;
-#endif
 } // namespace detail
 
 class PublishedLocalOverlay {

--- a/src/cpp/include/lemon/residency/generated_contract.h
+++ b/src/cpp/include/lemon/residency/generated_contract.h
@@ -9,7 +9,7 @@
 
 namespace lemon::residency {
 
-inline constexpr std::string_view packaged_catalog_sha256 = "c3b8fcd06079c8733515b04a8082c164562636681c197e7ee686406a95f2bd55";
+inline constexpr std::string_view packaged_catalog_sha256 = "6bccfe672b0531ce9be71aaf7eeeaa2136ae170b0c965bc01acf1a5a4236f2a5";
 inline constexpr std::string_view explanation_schema_id = "residency.explanation/1.0";
 inline constexpr SchemaVersion explanation_schema_version{1, 0};
 inline constexpr std::size_t max_explanation_reasons = 16;

--- a/src/cpp/include/lemon/residency/generated_contract.h
+++ b/src/cpp/include/lemon/residency/generated_contract.h
@@ -9,7 +9,7 @@
 
 namespace lemon::residency {
 
-inline constexpr std::string_view packaged_catalog_sha256 = "6bccfe672b0531ce9be71aaf7eeeaa2136ae170b0c965bc01acf1a5a4236f2a5";
+inline constexpr std::string_view packaged_catalog_sha256 = "745ef80ee43157cca3b94edfc4d2f26bb76356e631defde98c83efd8215fb1c1";
 inline constexpr std::string_view explanation_schema_id = "residency.explanation/1.0";
 inline constexpr SchemaVersion explanation_schema_version{1, 0};
 inline constexpr std::size_t max_explanation_reasons = 16;

--- a/src/cpp/include/lemon/residency/local_overlay.h
+++ b/src/cpp/include/lemon/residency/local_overlay.h
@@ -160,6 +160,7 @@ using ProfilingMethodEvidenceDraft =
 
 struct ProfilingCompletionDraft {
     std::vector<ClaimFamilyClosure> manifest_claims;
+    // These content references require Server-owned resolution before activation.
     std::string ownership_recovery_evidence_sha256;
     std::string action_lease_closure_sha256;
 };
@@ -459,6 +460,7 @@ struct ParsedOverlayActivationRootResult {
     bool accepted() const noexcept;
 };
 
+// Profiling inputs remain inert until every referenced closure is resolved.
 ParsedProfilingInputEnvelopeResult
 seal_profiling_input(ProfilingInputEnvelopeDraft draft);
 ParsedProfilingInputEnvelopeResult

--- a/src/cpp/include/lemon/residency/local_overlay.h
+++ b/src/cpp/include/lemon/residency/local_overlay.h
@@ -8,10 +8,12 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 namespace lemon::residency {
 
+inline constexpr SchemaVersion supported_profiling_input_schema{2, 0};
 inline constexpr SchemaVersion supported_local_overlay_schema{1, 0};
 inline constexpr std::size_t max_local_overlay_input_bytes = 64 * 1024;
 inline constexpr std::size_t max_local_overlay_identifier_bytes = 128;
@@ -138,25 +140,44 @@ struct ProfilingPhaseAttestationDraft {
         ProfilingLifecycleState::BaselineQuiescent;
 };
 
+struct MutationCompleteIntervalEvidenceDraft {
+    std::string baseline_observation_sha256;
+    std::string workload_observation_sha256;
+    std::string release_observation_sha256;
+};
+
+struct DifferentialRetainedGttEvidenceDraft {
+    ClaimAmount retained_gtt_claim;
+    std::string calibration_evidence_sha256;
+    std::string transient_envelope_sha256;
+    ProfilingOwnerCoverage owner_projection_coverage =
+        ProfilingOwnerCoverage::Unknown;
+};
+
+using ProfilingMethodEvidenceDraft =
+    std::variant<MutationCompleteIntervalEvidenceDraft,
+                 DifferentialRetainedGttEvidenceDraft>;
+
+struct ProfilingCompletionDraft {
+    std::vector<ClaimFamilyClosure> manifest_claims;
+    std::string ownership_recovery_evidence_sha256;
+    std::string action_lease_closure_sha256;
+};
+
 struct ProfilingInputEnvelopeDraft {
-    SchemaVersion schema = supported_local_overlay_schema;
+    SchemaVersion schema = supported_profiling_input_schema;
     std::string deployment_id;
     std::uint64_t sequence = 0;
     std::string profiling_transaction_id;
     LocalOverlaySelectorIdentity selector;
     OverlaySourceGenerations generations;
-    std::vector<ClaimFamilyClosure> attributed_claims;
-    std::string baseline_observation_sha256;
-    std::string workload_observation_sha256;
-    std::string release_observation_sha256;
+    ProfilingMethodEvidenceDraft method_evidence;
+    ProfilingCompletionDraft completion;
     std::string observation_contract_sha256;
     std::string predictor_contract_sha256;
     std::string observed_at;
     std::string fresh_until;
     std::uint64_t max_clock_skew_milliseconds = 0;
-    bool attribution_complete = false;
-    bool external_demand_absent = false;
-    bool lifecycle_release_verified = false;
 };
 
 struct LocalOverlayMethodIdentity {
@@ -230,18 +251,19 @@ public:
     const LocalOverlaySelectorIdentity &selector() const noexcept;
     std::string_view selector_sha256() const noexcept;
     const OverlaySourceGenerations &generations() const noexcept;
-    const std::vector<ClaimFamilyClosure> &attributed_claims() const noexcept;
-    std::string_view baseline_observation_sha256() const noexcept;
-    std::string_view workload_observation_sha256() const noexcept;
-    std::string_view release_observation_sha256() const noexcept;
+    const ProfilingMethodEvidenceDraft &method_evidence() const noexcept;
+    const MutationCompleteIntervalEvidenceDraft *
+    mutation_complete_interval() const noexcept;
+    const DifferentialRetainedGttEvidenceDraft *
+    differential_retained_gtt() const noexcept;
+    const std::vector<ClaimFamilyClosure> &manifest_claims() const noexcept;
+    std::string_view ownership_recovery_evidence_sha256() const noexcept;
+    std::string_view action_lease_closure_sha256() const noexcept;
     std::string_view observation_contract_sha256() const noexcept;
     std::string_view predictor_contract_sha256() const noexcept;
     std::string_view observed_at() const noexcept;
     std::string_view fresh_until() const noexcept;
     std::uint64_t max_clock_skew_milliseconds() const noexcept;
-    bool attribution_complete() const noexcept;
-    bool external_demand_absent() const noexcept;
-    bool lifecycle_release_verified() const noexcept;
     std::string_view checksum_sha256() const noexcept;
     std::string_view canonical_bytes() const noexcept;
 

--- a/src/cpp/include/lemon/residency/profiling_transaction.h
+++ b/src/cpp/include/lemon/residency/profiling_transaction.h
@@ -47,6 +47,8 @@ struct ProfilingTransactionContext {
     OverlaySourceGenerations generations;
     std::string observation_contract_sha256;
     std::string predictor_contract_sha256;
+    std::string ownership_recovery_evidence_sha256;
+    std::string action_lease_closure_sha256;
 };
 
 struct ProfilingTransactionCapture {

--- a/src/cpp/resources/residency_profiles.json
+++ b/src/cpp/resources/residency_profiles.json
@@ -4905,11 +4905,6 @@
             "required": true,
             "type": "local_overlay_profiling_completion"
           },
-          "confidence": {
-            "required": true,
-            "type": "literal",
-            "value": "calibrated_instance"
-          },
           "deployment_id": {
             "required": true,
             "type": "local_overlay_deployment_identity"
@@ -7409,6 +7404,6 @@
     }
   ],
   "schema": "residency.profiles/1.0",
-  "selection_registry_sha256": "f3ccfe7c931b00898349233e313169100e33ff22b06f2d94a60db1b9835f22ca",
+  "selection_registry_sha256": "d1309cc70a9d291739c0a5bf46d45f40fe813aacff88c112af3f0b9944cd0ac5",
   "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
 }

--- a/src/cpp/resources/residency_profiles.json
+++ b/src/cpp/resources/residency_profiles.json
@@ -4897,29 +4897,22 @@
           }
         ],
         "fields": {
-          "attributed_claims": {
-            "required": true,
-            "type": "local_overlay_claim_closure"
-          },
-          "attribution_complete": {
-            "required": true,
-            "type": "local_overlay_required_true"
-          },
-          "baseline_observation_sha256": {
-            "required": true,
-            "type": "sha256"
-          },
           "checksum_sha256": {
             "required": true,
             "type": "sha256"
           },
+          "completion": {
+            "required": true,
+            "type": "local_overlay_profiling_completion"
+          },
+          "confidence": {
+            "required": true,
+            "type": "literal",
+            "value": "calibrated_instance"
+          },
           "deployment_id": {
             "required": true,
             "type": "local_overlay_deployment_identity"
-          },
-          "external_demand_absent": {
-            "required": true,
-            "type": "local_overlay_required_true"
           },
           "fresh_until": {
             "required": true,
@@ -4929,13 +4922,13 @@
             "required": true,
             "type": "local_overlay_source_generations"
           },
-          "lifecycle_release_verified": {
-            "required": true,
-            "type": "local_overlay_required_true"
-          },
           "max_clock_skew_milliseconds": {
             "required": true,
             "type": "local_overlay_positive_uint64"
+          },
+          "method_evidence": {
+            "required": true,
+            "type": "local_overlay_profiling_method_evidence"
           },
           "observation_contract_sha256": {
             "required": true,
@@ -4954,10 +4947,6 @@
             "required": true,
             "type": "opaque"
           },
-          "release_observation_sha256": {
-            "required": true,
-            "type": "sha256"
-          },
           "schema": {
             "required": true,
             "type": "local_overlay_schema_version"
@@ -4969,16 +4958,12 @@
           "sequence": {
             "required": true,
             "type": "local_overlay_positive_uint64"
-          },
-          "workload_observation_sha256": {
-            "required": true,
-            "type": "sha256"
           }
         },
         "output": "docs/api/schemas/residency/profiling_input_envelope.schema.json",
-        "schema_type": "residency.profiling_input_envelope/1.0",
+        "schema_type": "residency.profiling_input_envelope/2.0",
         "version": {
-          "major": 1,
+          "major": 2,
           "minor": 0
         }
       },
@@ -7424,6 +7409,6 @@
     }
   ],
   "schema": "residency.profiles/1.0",
-  "selection_registry_sha256": "9dbdfad20160c82f3905493d2d5c4bdcf40f2249b25ad919c57fd4462a51b4b7",
+  "selection_registry_sha256": "f3ccfe7c931b00898349233e313169100e33ff22b06f2d94a60db1b9835f22ca",
   "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
 }

--- a/src/cpp/server/residency/durable_local_overlay.cpp
+++ b/src/cpp/server/residency/durable_local_overlay.cpp
@@ -220,10 +220,10 @@ bool rollback_target_was_reachable(
 bool qualification_claims_are_safe(
     const ParsedProfilingInputEnvelope &input,
     const ParsedLocalOverlayObject &overlay) {
-    auto attributed = check_claim_closure(input.attributed_claims());
+    auto manifest = check_claim_closure(input.manifest_claims());
     auto conservative = check_claim_closure(overlay.conservative_claims());
-    if (!attributed.accepted() || !conservative.accepted() ||
-        !checked_subtract(*conservative.claims, *attributed.claims)
+    if (!manifest.accepted() || !conservative.accepted() ||
+        !checked_subtract(*conservative.claims, *manifest.claims)
              .accepted()) {
         return false;
     }
@@ -235,30 +235,30 @@ bool qualification_claims_are_safe(
         ClaimFamily::CompatibilityExclusivity,
     };
     for (const auto family : families) {
-        const auto attributed_completeness =
-            attributed.claims->completeness(family);
+        const auto manifest_completeness =
+            manifest.claims->completeness(family);
         const auto conservative_completeness =
             conservative.claims->completeness(family);
-        if ((attributed_completeness == ClaimCompleteness::KnownZero &&
+        if ((manifest_completeness == ClaimCompleteness::KnownZero &&
              conservative_completeness == ClaimCompleteness::NotApplicable) ||
-            (attributed_completeness == ClaimCompleteness::Bounded &&
+            (manifest_completeness == ClaimCompleteness::Bounded &&
              conservative_completeness != ClaimCompleteness::Bounded)) {
             return false;
         }
     }
 
-    for (const auto &attributed_family : input.attributed_claims()) {
-        if (attributed_family.completeness != ClaimCompleteness::Bounded) {
+    for (const auto &manifest_family : input.manifest_claims()) {
+        if (manifest_family.completeness != ClaimCompleteness::Bounded) {
             continue;
         }
         for (const auto &safety_family : overlay.safety_margin_claims()) {
-            if (safety_family.family != attributed_family.family) {
+            if (safety_family.family != manifest_family.family) {
                 continue;
             }
-            for (const auto &attributed_entry : attributed_family.entries) {
+            for (const auto &manifest_entry : manifest_family.entries) {
                 for (const auto &safety_entry : safety_family.entries) {
                     if (safety_entry.constraint_id ==
-                        attributed_entry.constraint_id) {
+                        manifest_entry.constraint_id) {
                         return true;
                     }
                 }
@@ -498,6 +498,17 @@ public:
                 parsed_overlay.candidate->profiling_input_sha256()) {
                 return {LocalOverlayStoreStatus::DigestMismatch, std::nullopt};
             }
+            if (parsed_input.candidate->differential_retained_gtt() !=
+                nullptr) {
+                return {LocalOverlayStoreStatus::UnsupportedStorage,
+                        std::nullopt};
+            }
+            const auto *interval =
+                parsed_input.candidate->mutation_complete_interval();
+            if (interval == nullptr) {
+                return {LocalOverlayStoreStatus::CorruptOrRollback,
+                        std::nullopt};
+            }
 
             auto read_observation = [&](std::string_view sha256,
                                         std::string &bytes)
@@ -531,11 +542,11 @@ public:
             for (const auto &[sha256, bytes] :
                  std::array<std::pair<std::string_view, std::string *>, 3>{
                      std::pair<std::string_view, std::string *>{
-                         parsed_input.candidate->baseline_observation_sha256(),
+                         interval->baseline_observation_sha256,
                          &baseline_observation_bytes},
-                     {parsed_input.candidate->workload_observation_sha256(),
+                     {interval->workload_observation_sha256,
                       &workload_observation_bytes},
-                     {parsed_input.candidate->release_observation_sha256(),
+                     {interval->release_observation_sha256,
                       &release_observation_bytes}}) {
                 const auto observation_status =
                     read_observation(sha256, *bytes);
@@ -1014,6 +1025,7 @@ LocalOverlayStore::activate(PublishedLocalOverlay &&expected,
 
     const ParsedProfilingInputEnvelope *selected_input = nullptr;
     const ParsedLocalOverlayObject *selected_overlay = nullptr;
+    const MutationCompleteIntervalEvidenceDraft *selected_interval = nullptr;
     const std::string *selected_baseline_observation_bytes = nullptr;
     const std::string *selected_workload_observation_bytes = nullptr;
     const std::string *selected_release_observation_bytes = nullptr;
@@ -1036,6 +1048,15 @@ LocalOverlayStore::activate(PublishedLocalOverlay &&expected,
         }
         selected_input = &*activation.profiling_input_;
         selected_overlay = &*activation.overlay_;
+        if (selected_input->differential_retained_gtt() != nullptr) {
+            return release_with_status(
+                LocalOverlayStoreStatus::UnsupportedStorage);
+        }
+        selected_interval = selected_input->mutation_complete_interval();
+        if (selected_interval == nullptr) {
+            return release_with_status(
+                LocalOverlayStoreStatus::CorruptOrRollback);
+        }
         selected_baseline_observation_bytes =
             &*activation.baseline_observation_bytes_;
         selected_workload_observation_bytes =
@@ -1090,10 +1111,10 @@ LocalOverlayStore::activate(PublishedLocalOverlay &&expected,
                 LocalOverlayStoreStatus::UnsupportedStorage);
         }
         if (*baseline_sha256 !=
-                selected_input->baseline_observation_sha256() ||
+                selected_interval->baseline_observation_sha256 ||
             *workload_sha256 !=
-                selected_input->workload_observation_sha256() ||
-            *release_sha256 != selected_input->release_observation_sha256()) {
+                selected_interval->workload_observation_sha256 ||
+            *release_sha256 != selected_interval->release_observation_sha256) {
             return release_with_status(LocalOverlayStoreStatus::DigestMismatch);
         }
     } else {
@@ -1130,6 +1151,11 @@ LocalOverlayStore::activate(PublishedLocalOverlay &&expected,
         if (selected_overlay == nullptr || selected_input == nullptr ||
             activation.activated_at_ < selected_overlay->qualified_at() ||
             activation.activated_at_ >= selected_overlay->expires_at()) {
+            return release_with_status(
+                LocalOverlayStoreStatus::CorruptOrRollback);
+        }
+        selected_interval = selected_input->mutation_complete_interval();
+        if (selected_interval == nullptr) {
             return release_with_status(
                 LocalOverlayStoreStatus::CorruptOrRollback);
         }
@@ -1220,17 +1246,17 @@ LocalOverlayStore::activate(PublishedLocalOverlay &&expected,
 
     if (activation.kind_ == LocalOverlayActivationKind::Qualification) {
         if (auto failed = publish_object(
-                selected_input->baseline_observation_sha256(),
+                selected_interval->baseline_observation_sha256,
                 *selected_baseline_observation_bytes)) {
             return std::move(*failed);
         }
         if (auto failed = publish_object(
-                selected_input->workload_observation_sha256(),
+                selected_interval->workload_observation_sha256,
                 *selected_workload_observation_bytes)) {
             return std::move(*failed);
         }
         if (auto failed = publish_object(
-                selected_input->release_observation_sha256(),
+                selected_interval->release_observation_sha256,
                 *selected_release_observation_bytes)) {
             return std::move(*failed);
         }

--- a/src/cpp/server/residency/durable_local_overlay.cpp
+++ b/src/cpp/server/residency/durable_local_overlay.cpp
@@ -688,7 +688,7 @@ LocalOverlayActivation::LocalOverlayActivation(
       decision_trace_sha256_(std::move(decision_trace_sha256)),
       activated_at_(std::move(activated_at)) {}
 
-LocalOverlayActivation LocalOverlayActivation::qualification(
+LocalOverlayActivation LocalOverlayActivation::unresolved_qualification(
     ParsedProfilingInputEnvelope profiling_input,
     ParsedLocalOverlayObject overlay, std::string baseline_observation_bytes,
     std::string workload_observation_bytes,
@@ -936,6 +936,17 @@ LocalOverlayStore::activate(PublishedLocalOverlay &&expected,
     }
     if (!expected_state) {
         return store_result(LocalOverlayStoreStatus::CorruptOrRollback);
+    }
+#ifdef LEMONADE_RESIDENCY_DURABLE_TESTING
+    const bool qualification_is_unresolved =
+        activation.kind_ == LocalOverlayActivationKind::Qualification &&
+        !activation.qualification_resolved_for_test_;
+#else
+    const bool qualification_is_unresolved =
+        activation.kind_ == LocalOverlayActivationKind::Qualification;
+#endif
+    if (qualification_is_unresolved) {
+        return store_result(LocalOverlayStoreStatus::UnsupportedStorage);
     }
     if (!impl_->limits_are_usable()) {
         return store_result(LocalOverlayStoreStatus::LimitExceeded);
@@ -1317,6 +1328,12 @@ LocalOverlayStore LocalOverlayStoreTestFactory::make(
     std::unique_ptr<DurableFileAdapter> adapter,
     LocalOverlayStoreLimits limits) {
     return LocalOverlayStore(std::move(adapter), limits);
+}
+
+LocalOverlayActivation LocalOverlayStoreTestFactory::resolve_qualification(
+    LocalOverlayActivation activation) {
+    activation.qualification_resolved_for_test_ = true;
+    return activation;
 }
 
 LocalOverlayStore make_local_overlay_store_for_test(

--- a/src/cpp/server/residency/durable_local_overlay_test_factory.h
+++ b/src/cpp/server/residency/durable_local_overlay_test_factory.h
@@ -17,6 +17,8 @@ public:
     static LocalOverlayStore
     make(std::unique_ptr<DurableFileAdapter> adapter,
          LocalOverlayStoreLimits limits);
+    static LocalOverlayActivation
+    resolve_qualification(LocalOverlayActivation activation);
 };
 
 LocalOverlayStore

--- a/src/cpp/server/residency/generated_contract.cpp
+++ b/src/cpp/server/residency/generated_contract.cpp
@@ -94,7 +94,7 @@ constexpr std::array<std::string_view, 16> schema_types{{
     "residency.deployment_local_overlay_object/1.0",
     "residency.operation_revision/1.0",
     "residency.overlay_activation_root/1.0",
-    "residency.profiling_input_envelope/1.0",
+    "residency.profiling_input_envelope/2.0",
     "residency.profiling_phase_attestation/1.0",
     "residency.reason/1.0",
     "residency.request_error/1.0",

--- a/src/cpp/server/residency/local_overlay.cpp
+++ b/src/cpp/server/residency/local_overlay.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace lemon::residency {
@@ -25,7 +26,7 @@ namespace {
 using json = nlohmann::json;
 
 constexpr char profiling_input_domain[] =
-    "lemonade.residency.local-overlay-profiling-input/v1\0";
+    "lemonade.residency.local-overlay-profiling-input/v2\0";
 constexpr char profiling_phase_attestation_domain[] =
     "lemonade.residency.profiling-phase-attestation/v1\0";
 constexpr char local_overlay_domain[] =
@@ -67,6 +68,11 @@ std::string bounded_diagnostic(std::string message) {
 bool schema_is_supported(SchemaVersion schema) noexcept {
     return schema.major == supported_local_overlay_schema.major &&
            schema.minor == supported_local_overlay_schema.minor;
+}
+
+bool profiling_input_schema_is_supported(SchemaVersion schema) noexcept {
+    return schema.major == supported_profiling_input_schema.major &&
+           schema.minor == supported_profiling_input_schema.minor;
 }
 
 bool is_lower_hex(std::string_view value, std::size_t size) noexcept {
@@ -303,20 +309,36 @@ json parse_json(std::string_view bytes) {
     }
 }
 
-SchemaVersion parse_schema(const json &value) {
+SchemaVersion parse_schema_value(const json &value,
+                                 std::string_view diagnostic) {
     require_exact_keys(value, {"major", "minor"}, "schema");
     const auto major = require_u64(required(value, "major"), "schema major");
     const auto minor = require_u64(required(value, "minor"), "schema minor");
     if (major > std::numeric_limits<std::uint32_t>::max() ||
         minor > std::numeric_limits<std::uint32_t>::max()) {
         reject(OverlayContractStatus::UnsupportedSchema,
-               "overlay schema is unsupported");
+               std::string(diagnostic));
     }
-    const SchemaVersion schema{static_cast<std::uint32_t>(major),
-                               static_cast<std::uint32_t>(minor)};
+    return SchemaVersion{static_cast<std::uint32_t>(major),
+                         static_cast<std::uint32_t>(minor)};
+}
+
+SchemaVersion parse_schema(const json &value) {
+    const auto schema =
+        parse_schema_value(value, "overlay schema is unsupported");
     if (!schema_is_supported(schema)) {
         reject(OverlayContractStatus::UnsupportedSchema,
                "overlay schema is unsupported");
+    }
+    return schema;
+}
+
+SchemaVersion parse_profiling_input_schema(const json &value) {
+    const auto schema = parse_schema_value(
+        value, "profiling input schema is unsupported");
+    if (!profiling_input_schema_is_supported(schema)) {
+        reject(OverlayContractStatus::UnsupportedSchema,
+               "profiling input schema is unsupported");
     }
     return schema;
 }
@@ -689,16 +711,30 @@ std::vector<ClaimFamilyClosure> claim_closure(const CheckedClaimSet &claims) {
     return result;
 }
 
+json claim_amount_document(const ClaimAmount &claim) {
+    return json{
+        {"amount", claim.amount},
+        {"constraint_id", claim.constraint_id},
+        {"unit", claim_unit_wire(claim.unit)},
+    };
+}
+
+ClaimAmount parse_claim_amount(const json &value, std::string_view label) {
+    require_exact_keys(value, {"amount", "constraint_id", "unit"}, label);
+    return ClaimAmount{
+        require_string(required(value, "constraint_id"), "constraint ID"),
+        parse_claim_unit(
+            require_string(required(value, "unit"), "claim unit")),
+        require_u64(required(value, "amount"), "claim amount"),
+    };
+}
+
 json claim_closure_document(const std::vector<ClaimFamilyClosure> &closure) {
     json result = json::array();
     for (const auto &family : closure) {
         json entries = json::array();
         for (const auto &entry : family.entries) {
-            entries.push_back(json{
-                {"amount", entry.amount},
-                {"constraint_id", entry.constraint_id},
-                {"unit", claim_unit_wire(entry.unit)},
-            });
+            entries.push_back(claim_amount_document(entry));
         }
         result.push_back(json{
             {"completeness", claim_completeness_wire(family.completeness)},
@@ -739,15 +775,8 @@ std::vector<ClaimFamilyClosure> parse_claim_closure(const json &value,
         family.completeness = parse_claim_completeness(require_string(
             required(family_value, "completeness"), "claim completeness"));
         for (const auto &entry_value : entry_values) {
-            require_exact_keys(entry_value, {"amount", "constraint_id", "unit"},
-                               "claim amount");
-            family.entries.push_back(ClaimAmount{
-                require_string(required(entry_value, "constraint_id"),
-                               "constraint ID"),
-                parse_claim_unit(require_string(required(entry_value, "unit"),
-                                                "claim unit")),
-                require_u64(required(entry_value, "amount"), "claim amount"),
-            });
+            family.entries.push_back(
+                parse_claim_amount(entry_value, "claim amount"));
         }
         closure.push_back(std::move(family));
     }
@@ -1258,10 +1287,77 @@ parse_profiling_phase_document(const json &document) {
     };
 }
 
+CheckedClaimSet normalize_profiling_completion(
+    ProfilingCompletionDraft &completion,
+    const std::vector<ConstraintKind> &constraints) {
+    auto manifest = checked_claims(std::move(completion.manifest_claims));
+    if (!claim_families_cover_ordinary_constraints(manifest, constraints)) {
+        reject(OverlayContractStatus::IncompleteClaimClosure,
+               "profiling manifest omits a required selector family");
+    }
+    completion.manifest_claims = claim_closure(manifest);
+    require_digest(completion.ownership_recovery_evidence_sha256,
+                   "ownership and recovery evidence digest");
+    require_digest(completion.action_lease_closure_sha256,
+                   "action-lease closure digest");
+    return manifest;
+}
+
+void normalize_method_evidence(ProfilingMethodEvidenceDraft &evidence,
+                               const CheckedClaimSet &manifest) {
+    if (evidence.valueless_by_exception()) {
+        reject(OverlayContractStatus::InvalidValue,
+               "profiling method evidence is unavailable");
+    }
+    if (auto *interval =
+            std::get_if<MutationCompleteIntervalEvidenceDraft>(&evidence)) {
+        require_digest(interval->baseline_observation_sha256,
+                       "baseline observation digest");
+        require_digest(interval->workload_observation_sha256,
+                       "workload observation digest");
+        require_digest(interval->release_observation_sha256,
+                       "release observation digest");
+        return;
+    }
+
+    auto &differential =
+        std::get<DifferentialRetainedGttEvidenceDraft>(evidence);
+    require_identifier(differential.retained_gtt_claim.constraint_id,
+                       "retained-GTT constraint ID");
+    if (differential.retained_gtt_claim.unit != ClaimUnit::Bytes ||
+        differential.retained_gtt_claim.amount == 0) {
+        reject(OverlayContractStatus::InvalidClaimClosure,
+               "retained-GTT evidence must be a positive byte claim");
+    }
+    require_digest(differential.calibration_evidence_sha256,
+                   "calibration evidence digest");
+    require_digest(differential.transient_envelope_sha256,
+                   "transient envelope digest");
+    if (profiling_owner_coverage_wire(
+            differential.owner_projection_coverage)
+            .empty()) {
+        reject(OverlayContractStatus::UnknownValue,
+               "owner projection coverage is unknown");
+    }
+
+    const auto &capacity = manifest.entries(ClaimFamily::ConsumableCapacity);
+    const auto covering = std::find_if(
+        capacity.begin(), capacity.end(), [&](const ClaimTotal &claim) {
+            return claim.constraint_id ==
+                       differential.retained_gtt_claim.constraint_id &&
+                   claim.unit == differential.retained_gtt_claim.unit &&
+                   claim.amount >= differential.retained_gtt_claim.amount;
+        });
+    if (covering == capacity.end()) {
+        reject(OverlayContractStatus::IncompleteClaimClosure,
+               "profiling manifest does not cover the retained-GTT claim");
+    }
+}
+
 void normalize_profiling_draft(ProfilingInputEnvelopeDraft &draft) {
-    if (!schema_is_supported(draft.schema)) {
+    if (!profiling_input_schema_is_supported(draft.schema)) {
         reject(OverlayContractStatus::UnsupportedSchema,
-               "overlay schema is unsupported");
+               "profiling input schema is unsupported");
     }
     require_digest(draft.deployment_id, "deployment ID");
     if (draft.sequence == 0) {
@@ -1272,19 +1368,9 @@ void normalize_profiling_draft(ProfilingInputEnvelopeDraft &draft) {
                        "profiling transaction ID");
     normalize_selector(draft.selector);
     normalize_generations(draft.generations);
-    const auto checked = checked_claims(std::move(draft.attributed_claims));
-    if (!claim_families_cover_ordinary_constraints(
-            checked, draft.selector.catalog_selector.constraints)) {
-        reject(OverlayContractStatus::IncompleteClaimClosure,
-               "attributed claims omit a required selector family");
-    }
-    draft.attributed_claims = claim_closure(checked);
-    require_digest(draft.baseline_observation_sha256,
-                   "baseline observation digest");
-    require_digest(draft.workload_observation_sha256,
-                   "workload observation digest");
-    require_digest(draft.release_observation_sha256,
-                   "release observation digest");
+    const auto manifest = normalize_profiling_completion(
+        draft.completion, draft.selector.catalog_selector.constraints);
+    normalize_method_evidence(draft.method_evidence, manifest);
     require_digest(draft.observation_contract_sha256,
                    "observation contract digest");
     require_digest(draft.predictor_contract_sha256,
@@ -1295,34 +1381,70 @@ void normalize_profiling_draft(ProfilingInputEnvelopeDraft &draft) {
         reject(OverlayContractStatus::InvalidValue,
                "maximum clock skew must be nonzero");
     }
-    if (!draft.attribution_complete || !draft.external_demand_absent ||
-        !draft.lifecycle_release_verified) {
-        reject(OverlayContractStatus::IncompleteIdentity,
-               "profiling input does not close attribution and lifecycle "
-               "evidence");
+}
+
+json method_evidence_document(const ProfilingMethodEvidenceDraft &evidence) {
+    if (const auto *interval =
+            std::get_if<MutationCompleteIntervalEvidenceDraft>(&evidence)) {
+        return json{
+            {"baseline_observation_sha256",
+             interval->baseline_observation_sha256},
+            {"covered_effect", "complete_lifecycle"},
+            {"external_change_absent", true},
+            {"lifecycle_envelope_complete", true},
+            {"method", "mutation_complete_interval"},
+            {"owner_projection_coverage", "complete"},
+            {"release_observation_sha256",
+             interval->release_observation_sha256},
+            {"workload_observation_sha256",
+             interval->workload_observation_sha256},
+        };
     }
+
+    const auto &differential =
+        std::get<DifferentialRetainedGttEvidenceDraft>(evidence);
+    return json{
+        {"calibration_evidence_sha256",
+         differential.calibration_evidence_sha256},
+        {"covered_effect", "retained_gtt"},
+        {"method", "differential_retained_gtt"},
+        {"owner_projection_coverage",
+         profiling_owner_coverage_wire(
+             differential.owner_projection_coverage)},
+        {"retained_gtt_claim",
+         claim_amount_document(differential.retained_gtt_claim)},
+        {"transient_envelope_sha256",
+         differential.transient_envelope_sha256},
+    };
+}
+
+json completion_document(const ProfilingCompletionDraft &completion) {
+    return json{
+        {"action_lease_closure_sha256",
+         completion.action_lease_closure_sha256},
+        {"manifest_claims",
+         claim_closure_document(completion.manifest_claims)},
+        {"ownership_recovery_evidence_sha256",
+         completion.ownership_recovery_evidence_sha256},
+    };
 }
 
 json profiling_payload(const ProfilingInputEnvelopeDraft &draft) {
     return json{
-        {"attributed_claims", claim_closure_document(draft.attributed_claims)},
-        {"attribution_complete", draft.attribution_complete},
-        {"baseline_observation_sha256", draft.baseline_observation_sha256},
+        {"completion", completion_document(draft.completion)},
+        {"confidence", "calibrated_instance"},
         {"deployment_id", draft.deployment_id},
-        {"external_demand_absent", draft.external_demand_absent},
         {"fresh_until", draft.fresh_until},
         {"generations", generations_document(draft.generations)},
-        {"lifecycle_release_verified", draft.lifecycle_release_verified},
         {"max_clock_skew_milliseconds", draft.max_clock_skew_milliseconds},
+        {"method_evidence", method_evidence_document(draft.method_evidence)},
         {"observation_contract_sha256", draft.observation_contract_sha256},
         {"observed_at", draft.observed_at},
         {"predictor_contract_sha256", draft.predictor_contract_sha256},
         {"profiling_transaction_id", draft.profiling_transaction_id},
-        {"release_observation_sha256", draft.release_observation_sha256},
         {"schema", schema_document(draft.schema)},
         {"selector", selector_document(draft.selector)},
         {"sequence", draft.sequence},
-        {"workload_observation_sha256", draft.workload_observation_sha256},
     };
 }
 
@@ -1361,20 +1483,94 @@ struct ParsedProfilingDocument {
     std::string checksum;
 };
 
+ProfilingMethodEvidenceDraft parse_method_evidence(const json &value) {
+    const auto method = require_string(required(value, "method"),
+                                       "profiling evidence method");
+    if (method == "mutation_complete_interval") {
+        require_exact_keys(
+            value,
+            {"baseline_observation_sha256", "covered_effect",
+             "external_change_absent", "lifecycle_envelope_complete",
+             "method", "owner_projection_coverage",
+             "release_observation_sha256", "workload_observation_sha256"},
+            "mutation-complete interval evidence");
+        if (require_string(required(value, "covered_effect"),
+                           "covered effect") != "complete_lifecycle" ||
+            parse_profiling_owner_coverage(require_string(
+                required(value, "owner_projection_coverage"),
+                "owner projection coverage")) !=
+                ProfilingOwnerCoverage::Complete ||
+            !require_bool(required(value, "external_change_absent"),
+                          "external-change absence") ||
+            !require_bool(required(value, "lifecycle_envelope_complete"),
+                          "lifecycle envelope completeness")) {
+            reject(OverlayContractStatus::InvalidValue,
+                   "mutation-complete interval evidence has invalid closed "
+                   "semantics");
+        }
+        return MutationCompleteIntervalEvidenceDraft{
+            require_string(required(value, "baseline_observation_sha256"),
+                           "baseline observation digest"),
+            require_string(required(value, "workload_observation_sha256"),
+                           "workload observation digest"),
+            require_string(required(value, "release_observation_sha256"),
+                           "release observation digest"),
+        };
+    }
+    if (method == "differential_retained_gtt") {
+        require_exact_keys(
+            value,
+            {"calibration_evidence_sha256", "covered_effect", "method",
+             "owner_projection_coverage", "retained_gtt_claim",
+             "transient_envelope_sha256"},
+            "differential retained-GTT evidence");
+        if (require_string(required(value, "covered_effect"),
+                           "covered effect") != "retained_gtt") {
+            reject(OverlayContractStatus::InvalidValue,
+                   "differential evidence has an invalid covered effect");
+        }
+        return DifferentialRetainedGttEvidenceDraft{
+            parse_claim_amount(required(value, "retained_gtt_claim"),
+                               "retained-GTT claim"),
+            require_string(required(value, "calibration_evidence_sha256"),
+                           "calibration evidence digest"),
+            require_string(required(value, "transient_envelope_sha256"),
+                           "transient envelope digest"),
+            parse_profiling_owner_coverage(require_string(
+                required(value, "owner_projection_coverage"),
+                "owner projection coverage")),
+        };
+    }
+    reject(OverlayContractStatus::UnknownValue,
+           "profiling evidence method is unknown");
+}
+
+ProfilingCompletionDraft parse_completion(const json &value) {
+    require_exact_keys(value,
+                       {"action_lease_closure_sha256", "manifest_claims",
+                        "ownership_recovery_evidence_sha256"},
+                       "profiling completion");
+    return ProfilingCompletionDraft{
+        parse_claim_closure(required(value, "manifest_claims"),
+                            "profiling manifest claims"),
+        require_string(required(value, "ownership_recovery_evidence_sha256"),
+                       "ownership and recovery evidence digest"),
+        require_string(required(value, "action_lease_closure_sha256"),
+                       "action-lease closure digest"),
+    };
+}
+
 ParsedProfilingDocument parse_profiling_document(const json &document) {
     require_exact_keys(
         document,
-        {"attributed_claims", "attribution_complete",
-         "baseline_observation_sha256", "checksum_sha256", "deployment_id",
-         "external_demand_absent", "fresh_until", "generations",
-         "lifecycle_release_verified", "max_clock_skew_milliseconds",
-         "observation_contract_sha256", "observed_at",
-         "predictor_contract_sha256", "profiling_transaction_id",
-         "release_observation_sha256", "schema", "selector", "sequence",
-         "workload_observation_sha256"},
+        {"checksum_sha256", "completion", "confidence", "deployment_id",
+         "fresh_until", "generations", "max_clock_skew_milliseconds",
+         "method_evidence", "observation_contract_sha256", "observed_at",
+         "predictor_contract_sha256", "profiling_transaction_id", "schema",
+         "selector", "sequence"},
         "profiling input");
     ProfilingInputEnvelopeDraft draft;
-    draft.schema = parse_schema(required(document, "schema"));
+    draft.schema = parse_profiling_input_schema(required(document, "schema"));
     draft.deployment_id =
         require_string(required(document, "deployment_id"), "deployment ID");
     draft.sequence =
@@ -1384,17 +1580,14 @@ ParsedProfilingDocument parse_profiling_document(const json &document) {
                        "profiling transaction ID");
     draft.selector = parse_selector(required(document, "selector"));
     draft.generations = parse_generations(required(document, "generations"));
-    draft.attributed_claims = parse_claim_closure(
-        required(document, "attributed_claims"), "attributed claims");
-    draft.baseline_observation_sha256 =
-        require_string(required(document, "baseline_observation_sha256"),
-                       "baseline observation digest");
-    draft.workload_observation_sha256 =
-        require_string(required(document, "workload_observation_sha256"),
-                       "workload observation digest");
-    draft.release_observation_sha256 =
-        require_string(required(document, "release_observation_sha256"),
-                       "release observation digest");
+    draft.method_evidence =
+        parse_method_evidence(required(document, "method_evidence"));
+    draft.completion = parse_completion(required(document, "completion"));
+    if (require_string(required(document, "confidence"),
+                       "profiling confidence") != "calibrated_instance") {
+        reject(OverlayContractStatus::UnknownValue,
+               "profiling confidence is unknown");
+    }
     draft.observation_contract_sha256 =
         require_string(required(document, "observation_contract_sha256"),
                        "observation contract digest");
@@ -1408,14 +1601,6 @@ ParsedProfilingDocument parse_profiling_document(const json &document) {
     draft.max_clock_skew_milliseconds =
         require_u64(required(document, "max_clock_skew_milliseconds"),
                     "maximum clock skew");
-    draft.attribution_complete = require_bool(
-        required(document, "attribution_complete"), "attribution completeness");
-    draft.external_demand_absent =
-        require_bool(required(document, "external_demand_absent"),
-                     "external-demand absence");
-    draft.lifecycle_release_verified =
-        require_bool(required(document, "lifecycle_release_verified"),
-                     "lifecycle release verification");
     return ParsedProfilingDocument{
         std::move(draft),
         require_string(required(document, "checksum_sha256"),
@@ -1894,24 +2079,36 @@ ParsedProfilingInputEnvelope::generations() const noexcept {
     return draft_.generations;
 }
 
+const ProfilingMethodEvidenceDraft &
+ParsedProfilingInputEnvelope::method_evidence() const noexcept {
+    return draft_.method_evidence;
+}
+
+const MutationCompleteIntervalEvidenceDraft *
+ParsedProfilingInputEnvelope::mutation_complete_interval() const noexcept {
+    return std::get_if<MutationCompleteIntervalEvidenceDraft>(
+        &draft_.method_evidence);
+}
+
+const DifferentialRetainedGttEvidenceDraft *
+ParsedProfilingInputEnvelope::differential_retained_gtt() const noexcept {
+    return std::get_if<DifferentialRetainedGttEvidenceDraft>(
+        &draft_.method_evidence);
+}
+
 const std::vector<ClaimFamilyClosure> &
-ParsedProfilingInputEnvelope::attributed_claims() const noexcept {
-    return draft_.attributed_claims;
+ParsedProfilingInputEnvelope::manifest_claims() const noexcept {
+    return draft_.completion.manifest_claims;
+}
+
+std::string_view ParsedProfilingInputEnvelope::
+    ownership_recovery_evidence_sha256() const noexcept {
+    return draft_.completion.ownership_recovery_evidence_sha256;
 }
 
 std::string_view
-ParsedProfilingInputEnvelope::baseline_observation_sha256() const noexcept {
-    return draft_.baseline_observation_sha256;
-}
-
-std::string_view
-ParsedProfilingInputEnvelope::workload_observation_sha256() const noexcept {
-    return draft_.workload_observation_sha256;
-}
-
-std::string_view
-ParsedProfilingInputEnvelope::release_observation_sha256() const noexcept {
-    return draft_.release_observation_sha256;
+ParsedProfilingInputEnvelope::action_lease_closure_sha256() const noexcept {
+    return draft_.completion.action_lease_closure_sha256;
 }
 
 std::string_view
@@ -1935,18 +2132,6 @@ std::string_view ParsedProfilingInputEnvelope::fresh_until() const noexcept {
 std::uint64_t
 ParsedProfilingInputEnvelope::max_clock_skew_milliseconds() const noexcept {
     return draft_.max_clock_skew_milliseconds;
-}
-
-bool ParsedProfilingInputEnvelope::attribution_complete() const noexcept {
-    return draft_.attribution_complete;
-}
-
-bool ParsedProfilingInputEnvelope::external_demand_absent() const noexcept {
-    return draft_.external_demand_absent;
-}
-
-bool ParsedProfilingInputEnvelope::lifecycle_release_verified() const noexcept {
-    return draft_.lifecycle_release_verified;
 }
 
 std::string_view

--- a/src/cpp/server/residency/local_overlay.cpp
+++ b/src/cpp/server/residency/local_overlay.cpp
@@ -256,11 +256,14 @@ std::string require_string(const json &value, std::string_view label) {
 }
 
 std::uint64_t require_u64(const json &value, std::string_view label) {
-    if (!value.is_number_unsigned()) {
-        reject(OverlayContractStatus::InvalidValue,
-               std::string(label) + " must be an unsigned integer");
+    if (value.is_number_unsigned()) {
+        return value.get<std::uint64_t>();
     }
-    return value.get<std::uint64_t>();
+    if (value.is_number_integer() && value.get<std::int64_t>() == 0) {
+        return 0;
+    }
+    reject(OverlayContractStatus::InvalidValue,
+           std::string(label) + " must be an unsigned integer");
 }
 
 bool require_bool(const json &value, std::string_view label) {

--- a/src/cpp/server/residency/local_overlay.cpp
+++ b/src/cpp/server/residency/local_overlay.cpp
@@ -1432,7 +1432,6 @@ json completion_document(const ProfilingCompletionDraft &completion) {
 json profiling_payload(const ProfilingInputEnvelopeDraft &draft) {
     return json{
         {"completion", completion_document(draft.completion)},
-        {"confidence", "calibrated_instance"},
         {"deployment_id", draft.deployment_id},
         {"fresh_until", draft.fresh_until},
         {"generations", generations_document(draft.generations)},
@@ -1563,7 +1562,7 @@ ProfilingCompletionDraft parse_completion(const json &value) {
 ParsedProfilingDocument parse_profiling_document(const json &document) {
     require_exact_keys(
         document,
-        {"checksum_sha256", "completion", "confidence", "deployment_id",
+        {"checksum_sha256", "completion", "deployment_id",
          "fresh_until", "generations", "max_clock_skew_milliseconds",
          "method_evidence", "observation_contract_sha256", "observed_at",
          "predictor_contract_sha256", "profiling_transaction_id", "schema",
@@ -1583,11 +1582,6 @@ ParsedProfilingDocument parse_profiling_document(const json &document) {
     draft.method_evidence =
         parse_method_evidence(required(document, "method_evidence"));
     draft.completion = parse_completion(required(document, "completion"));
-    if (require_string(required(document, "confidence"),
-                       "profiling confidence") != "calibrated_instance") {
-        reject(OverlayContractStatus::UnknownValue,
-               "profiling confidence is unknown");
-    }
     draft.observation_contract_sha256 =
         require_string(required(document, "observation_contract_sha256"),
                        "observation contract digest");

--- a/src/cpp/server/residency/profiling_transaction.cpp
+++ b/src/cpp/server/residency/profiling_transaction.cpp
@@ -590,24 +590,27 @@ ProfilingTransactionResult ProfilingTransaction::run(ProfilingTransactionContext
         }
 
         ProfilingInputEnvelopeDraft input;
-        input.schema = supported_local_overlay_schema;
+        input.schema = supported_profiling_input_schema;
         input.deployment_id = std::move(context.deployment_id);
         input.sequence = context.sequence;
         input.profiling_transaction_id = std::move(context.profiling_transaction_id);
         input.selector = std::move(context.selector);
         input.generations = context.generations;
-        input.attributed_claims = workload_phase.attributed_claims();
-        input.baseline_observation_sha256 = *baseline_sha256;
-        input.workload_observation_sha256 = *workload_sha256;
-        input.release_observation_sha256 = *release_sha256;
+        MutationCompleteIntervalEvidenceDraft method_evidence;
+        method_evidence.baseline_observation_sha256 = *baseline_sha256;
+        method_evidence.workload_observation_sha256 = *workload_sha256;
+        method_evidence.release_observation_sha256 = *release_sha256;
+        input.method_evidence = std::move(method_evidence);
+        input.completion.manifest_claims = workload_phase.attributed_claims();
+        input.completion.ownership_recovery_evidence_sha256 =
+            std::move(context.ownership_recovery_evidence_sha256);
+        input.completion.action_lease_closure_sha256 =
+            std::move(context.action_lease_closure_sha256);
         input.observation_contract_sha256 = std::move(context.observation_contract_sha256);
         input.predictor_contract_sha256 = std::move(context.predictor_contract_sha256);
         input.observed_at = release_phase.observed_at();
         input.fresh_until = std::move(fresh_until);
         input.max_clock_skew_milliseconds = common_skew;
-        input.attribution_complete = true;
-        input.external_demand_absent = true;
-        input.lifecycle_release_verified = true;
 
         ParsedProfilingInputEnvelopeResult sealed;
         try {

--- a/test/cpp/test_durable_local_overlay.cpp
+++ b/test/cpp/test_durable_local_overlay.cpp
@@ -182,24 +182,58 @@ ParsedProfilingInputEnvelope profile_for(std::string deployment_id,
                                          std::string fresh_until =
                                              "2026-08-23T10:05:00Z") {
     ProfilingInputEnvelopeDraft draft;
+    draft.schema = supported_profiling_input_schema;
     draft.deployment_id = std::move(deployment_id);
     draft.sequence = sequence;
     draft.profiling_transaction_id =
         "profiling/" + std::to_string(sequence);
     draft.selector = selector();
     draft.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
-    draft.attributed_claims = claims(4096);
-    draft.baseline_observation_sha256 = observations.baseline_sha256;
-    draft.workload_observation_sha256 = observations.workload_sha256;
-    draft.release_observation_sha256 = observations.release_sha256;
+    MutationCompleteIntervalEvidenceDraft method_evidence;
+    method_evidence.baseline_observation_sha256 = observations.baseline_sha256;
+    method_evidence.workload_observation_sha256 = observations.workload_sha256;
+    method_evidence.release_observation_sha256 = observations.release_sha256;
+    draft.method_evidence = std::move(method_evidence);
+    draft.completion.manifest_claims = claims(4096);
+    draft.completion.ownership_recovery_evidence_sha256 = digest('c');
+    draft.completion.action_lease_closure_sha256 = digest('d');
     draft.observation_contract_sha256 = digest('e');
     draft.predictor_contract_sha256 = digest('f');
     draft.observed_at = "2026-08-23T10:00:00Z";
     draft.fresh_until = std::move(fresh_until);
     draft.max_clock_skew_milliseconds = 1000;
-    draft.attribution_complete = true;
-    draft.external_demand_absent = true;
-    draft.lifecycle_release_verified = true;
+    auto sealed = seal_profiling_input(std::move(draft));
+    require(sealed.accepted(), sealed.diagnostic);
+    return std::move(*sealed.candidate);
+}
+
+ParsedProfilingInputEnvelope differential_profile_for(
+    std::string deployment_id, std::uint64_t sequence,
+    std::string fresh_until = "2026-08-23T10:05:00Z") {
+    ProfilingInputEnvelopeDraft draft;
+    draft.schema = supported_profiling_input_schema;
+    draft.deployment_id = std::move(deployment_id);
+    draft.sequence = sequence;
+    draft.profiling_transaction_id =
+        "profiling/differential/" + std::to_string(sequence);
+    draft.selector = selector();
+    draft.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
+    DifferentialRetainedGttEvidenceDraft method_evidence;
+    method_evidence.retained_gtt_claim =
+        ClaimAmount{"gpu/gtt", ClaimUnit::Bytes, 4096};
+    method_evidence.calibration_evidence_sha256 = digest('a');
+    method_evidence.transient_envelope_sha256 = digest('b');
+    method_evidence.owner_projection_coverage =
+        ProfilingOwnerCoverage::Incomplete;
+    draft.method_evidence = std::move(method_evidence);
+    draft.completion.manifest_claims = claims(4096);
+    draft.completion.ownership_recovery_evidence_sha256 = digest('c');
+    draft.completion.action_lease_closure_sha256 = digest('d');
+    draft.observation_contract_sha256 = digest('e');
+    draft.predictor_contract_sha256 = digest('f');
+    draft.observed_at = "2026-08-23T10:00:00Z";
+    draft.fresh_until = std::move(fresh_until);
+    draft.max_clock_skew_milliseconds = 1000;
     auto sealed = seal_profiling_input(std::move(draft));
     require(sealed.accepted(), sealed.diagnostic);
     return std::move(*sealed.candidate);
@@ -689,6 +723,32 @@ void require_observation_admission_fails_before_writes() {
                     "write");
         }
     }
+}
+
+void require_differential_evidence_fails_before_writes() {
+    auto storage = JournalTestStorage::fresh();
+    auto store = storage.make_overlay_store(generous_limits());
+    auto empty = store.snapshot(TrustedLocalOverlayReplayFloor::uninitialized());
+    require(empty.status == LocalOverlayStoreStatus::Empty &&
+                empty.authority.has_value(),
+            "differential activation fixture did not start empty");
+
+    auto observations = observations_for(1);
+    auto profile = differential_profile_for(
+        std::string(empty.authority->deployment_id()), 1);
+    auto overlay = overlay_for(profile);
+
+    storage.reset_observations();
+    auto rejected = activate_qualification(
+        store, std::move(*empty.authority), std::move(profile),
+        std::move(overlay), std::move(observations), '4',
+        "2026-08-23T10:02:00Z");
+    const auto after = storage.snapshot();
+    require(rejected.status == LocalOverlayStoreStatus::UnsupportedStorage &&
+                !rejected.authority.has_value() &&
+                after.authority_root_bytes.empty() &&
+                !after.authority_mutation_attempted,
+            "differential evidence entered the three-observation store");
 }
 
 void require_claim_admission_fails_before_writes() {
@@ -1579,6 +1639,7 @@ int main() {
     require_full_history_rejects_qualification_before_writes();
     require_full_history_rejects_rollback_before_writes();
     require_observation_admission_fails_before_writes();
+    require_differential_evidence_fails_before_writes();
     require_claim_admission_fails_before_writes();
     require_qualification_at_fresh_until_fails_before_writes();
     require_historic_activation_freshness_boundary_fails_closed();

--- a/test/cpp/test_durable_local_overlay.cpp
+++ b/test/cpp/test_durable_local_overlay.cpp
@@ -1,9 +1,11 @@
+#include "durable_local_overlay_test_factory.h"
 #include "journal_persistence_test_support.h"
 #include "lemon/residency/durable_local_overlay.h"
 
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdlib>
 #include <filesystem>
 #include <iostream>
@@ -180,7 +182,9 @@ ParsedProfilingInputEnvelope profile_for(std::string deployment_id,
                                          std::uint64_t sequence,
                                          const ObservationBundle &observations,
                                          std::string fresh_until =
-                                             "2026-08-23T10:05:00Z") {
+                                             "2026-08-23T10:05:00Z",
+                                         char ownership_recovery_digest = 'c',
+                                         char action_lease_digest = 'd') {
     ProfilingInputEnvelopeDraft draft;
     draft.schema = supported_profiling_input_schema;
     draft.deployment_id = std::move(deployment_id);
@@ -195,8 +199,10 @@ ParsedProfilingInputEnvelope profile_for(std::string deployment_id,
     method_evidence.release_observation_sha256 = observations.release_sha256;
     draft.method_evidence = std::move(method_evidence);
     draft.completion.manifest_claims = claims(4096);
-    draft.completion.ownership_recovery_evidence_sha256 = digest('c');
-    draft.completion.action_lease_closure_sha256 = digest('d');
+    draft.completion.ownership_recovery_evidence_sha256 =
+        digest(ownership_recovery_digest);
+    draft.completion.action_lease_closure_sha256 =
+        digest(action_lease_digest);
     draft.observation_contract_sha256 = digest('e');
     draft.predictor_contract_sha256 = digest('f');
     draft.observed_at = "2026-08-23T10:00:00Z";
@@ -334,32 +340,50 @@ LocalOverlayStoreLimits generous_limits() {
     return LocalOverlayStoreLimits{64 * 1024, 128};
 }
 
-LocalOverlayStoreResult
-activate_qualification(LocalOverlayStore &store,
-                       PublishedLocalOverlay &&expected,
-                       ParsedProfilingInputEnvelope profile,
-                       ParsedLocalOverlayObject overlay,
-                       ObservationBundle observations, char decision_trace,
-                       std::string activated_at) {
-    return store.activate(
-        std::move(expected),
-        LocalOverlayActivation::qualification(
-            std::move(profile), std::move(overlay),
-            std::move(observations.baseline),
-            std::move(observations.workload),
-            std::move(observations.release), digest(decision_trace),
-            std::move(activated_at)));
+LocalOverlayActivation qualification_candidate(
+    ParsedProfilingInputEnvelope profile, ParsedLocalOverlayObject overlay,
+    ObservationBundle observations, char decision_trace,
+    std::string activated_at) {
+    return LocalOverlayActivation::unresolved_qualification(
+        std::move(profile), std::move(overlay),
+        std::move(observations.baseline), std::move(observations.workload),
+        std::move(observations.release), digest(decision_trace),
+        std::move(activated_at));
 }
 
-LocalOverlayStoreResult
-qualify(LocalOverlayStore &store, PublishedLocalOverlay &&expected,
-        std::uint64_t sequence, char decision_trace,
-        std::string activated_at) {
+LocalOverlayStoreResult activate_resolved_fixture_qualification(
+    LocalOverlayStore &store, PublishedLocalOverlay &&expected,
+    ParsedProfilingInputEnvelope profile, ParsedLocalOverlayObject overlay,
+    ObservationBundle observations, char decision_trace,
+    std::string activated_at) {
+    auto activation = qualification_candidate(
+        std::move(profile), std::move(overlay), std::move(observations),
+        decision_trace, std::move(activated_at));
+    activation = detail::LocalOverlayStoreTestFactory::resolve_qualification(
+        std::move(activation));
+    return store.activate(std::move(expected), std::move(activation));
+}
+
+LocalOverlayStoreResult activate_unresolved_qualification(
+    LocalOverlayStore &store, PublishedLocalOverlay &&expected,
+    ParsedProfilingInputEnvelope profile, ParsedLocalOverlayObject overlay,
+    ObservationBundle observations, char decision_trace,
+    std::string activated_at) {
+    return store.activate(
+        std::move(expected),
+        qualification_candidate(
+            std::move(profile), std::move(overlay), std::move(observations),
+            decision_trace, std::move(activated_at)));
+}
+
+LocalOverlayStoreResult qualify_resolved_storage_fixture(
+    LocalOverlayStore &store, PublishedLocalOverlay &&expected,
+    std::uint64_t sequence, char decision_trace, std::string activated_at) {
     const auto deployment_id = std::string(expected.deployment_id());
     auto observations = observations_for(sequence);
     auto profile = profile_for(deployment_id, sequence, observations);
     auto overlay = overlay_for(profile);
-    return activate_qualification(
+    return activate_resolved_fixture_qualification(
         store, std::move(expected), std::move(profile), std::move(overlay),
         std::move(observations), decision_trace, std::move(activated_at));
 }
@@ -382,8 +406,9 @@ published_fixture(PlatformContract platform = PlatformContract::Linux) {
     require(empty.status == LocalOverlayStoreStatus::Empty &&
                 empty.authority.has_value(),
             "published fixture did not start empty");
-    auto activated = qualify(store, std::move(*empty.authority), 1, '4',
-                             "2026-08-23T10:02:00Z");
+    auto activated = qualify_resolved_storage_fixture(
+        store, std::move(*empty.authority), 1, '4',
+        "2026-08-23T10:02:00Z");
     require(activated.status == LocalOverlayStoreStatus::Activated &&
                 activated.authority.has_value() &&
                 activated.authority->active_overlay() != nullptr,
@@ -414,10 +439,12 @@ void require_empty_activate_and_same_deployment_visibility() {
     auto profile = profile_for(deployment_id, 1, observations);
     auto overlay = overlay_for(profile);
     const auto overlay_sha256 = std::string(overlay.checksum_sha256());
-    auto activation = LocalOverlayActivation::qualification(
+    auto activation = LocalOverlayActivation::unresolved_qualification(
         std::move(profile), std::move(overlay), observations.baseline,
         observations.workload, observations.release, digest('4'),
         "2026-08-23T10:02:00Z");
+    activation = detail::LocalOverlayStoreTestFactory::resolve_qualification(
+        std::move(activation));
     auto activated = store.activate(std::move(*empty.authority),
                                     std::move(activation));
     require(activated.status == LocalOverlayStoreStatus::Activated &&
@@ -578,16 +605,18 @@ void require_stale_cas_conflicts_before_object_writes() {
                 second.authority.has_value(),
             "two empty readers did not receive CAS capabilities");
 
-    auto winner = qualify(first_store, std::move(*first.authority), 1, '4',
-                          "2026-08-23T10:02:00Z");
+    auto winner = qualify_resolved_storage_fixture(
+        first_store, std::move(*first.authority), 1, '4',
+        "2026-08-23T10:02:00Z");
     require(winner.status == LocalOverlayStoreStatus::Activated &&
                 winner.authority.has_value(),
             "first fake-store activation did not publish");
     const auto committed_root = std::string(winner.authority->root_bytes());
 
     storage.reset_observations();
-    auto loser = qualify(second_store, std::move(*second.authority), 1, '5',
-                         "2026-08-23T10:03:00Z");
+    auto loser = qualify_resolved_storage_fixture(
+        second_store, std::move(*second.authority), 1, '5',
+        "2026-08-23T10:03:00Z");
     const auto after = storage.snapshot();
     require(loser.status == LocalOverlayStoreStatus::ConflictBeforeWrite &&
                 !loser.authority.has_value() &&
@@ -605,16 +634,18 @@ void require_full_history_rejects_qualification_before_writes() {
                 empty.authority.has_value(),
             "history-limit fixture did not start empty");
 
-    auto first = qualify(store, std::move(*empty.authority), 1, '4',
-                         "2026-08-23T10:02:00Z");
+    auto first = qualify_resolved_storage_fixture(
+        store, std::move(*empty.authority), 1, '4',
+        "2026-08-23T10:02:00Z");
     require(first.status == LocalOverlayStoreStatus::Activated &&
                 first.authority.has_value(),
             "history-limit fixture did not publish its only root");
     const auto first_root = std::string(first.authority->root_bytes());
 
     storage.reset_observations();
-    auto rejected = qualify(store, std::move(*first.authority), 2, '5',
-                            "2026-08-23T10:04:00Z");
+    auto rejected = qualify_resolved_storage_fixture(
+        store, std::move(*first.authority), 2, '5',
+        "2026-08-23T10:04:00Z");
     const auto after = storage.snapshot();
     require(rejected.status == LocalOverlayStoreStatus::LimitExceeded &&
                 !rejected.authority.has_value() &&
@@ -640,16 +671,18 @@ void require_full_history_rejects_rollback_before_writes() {
                 empty.authority.has_value(),
             "rollback history-limit fixture did not start empty");
 
-    auto first = qualify(store, std::move(*empty.authority), 1, '4',
-                         "2026-08-23T10:02:00Z");
+    auto first = qualify_resolved_storage_fixture(
+        store, std::move(*empty.authority), 1, '4',
+        "2026-08-23T10:02:00Z");
     require(first.status == LocalOverlayStoreStatus::Activated &&
                 first.authority.has_value(),
             "rollback history-limit fixture did not publish sequence one");
     const auto first_root = std::string(first.authority->root_bytes());
     const auto first_overlay =
         std::string(first.authority->active_overlay()->checksum_sha256());
-    auto second = qualify(store, std::move(*first.authority), 2, '5',
-                          "2026-08-23T10:04:00Z");
+    auto second = qualify_resolved_storage_fixture(
+        store, std::move(*first.authority), 2, '5',
+        "2026-08-23T10:04:00Z");
     require(second.status == LocalOverlayStoreStatus::Activated &&
                 second.authority.has_value(),
             "rollback history-limit fixture did not fill its history");
@@ -681,7 +714,8 @@ void require_observation_admission_fails_before_writes() {
     for (const auto failure : {LocalOverlayStoreStatus::MissingObject,
                                LocalOverlayStoreStatus::DigestMismatch,
                                LocalOverlayStoreStatus::LimitExceeded}) {
-        for (const auto observation_index : {0, 1, 2}) {
+        for (const std::size_t observation_index :
+             std::array<std::size_t, 3>{0, 1, 2}) {
             auto storage = JournalTestStorage::fresh();
             auto store = storage.make_overlay_store(generous_limits());
             auto empty = store.snapshot(
@@ -710,7 +744,7 @@ void require_observation_admission_fails_before_writes() {
             }
 
             storage.reset_observations();
-            auto rejected = activate_qualification(
+            auto rejected = activate_resolved_fixture_qualification(
                 store, std::move(*empty.authority), std::move(profile),
                 std::move(overlay), std::move(observations), '4',
                 "2026-08-23T10:02:00Z");
@@ -739,7 +773,7 @@ void require_differential_evidence_fails_before_writes() {
     auto overlay = overlay_for(profile);
 
     storage.reset_observations();
-    auto rejected = activate_qualification(
+    auto rejected = activate_unresolved_qualification(
         store, std::move(*empty.authority), std::move(profile),
         std::move(overlay), std::move(observations), '4',
         "2026-08-23T10:02:00Z");
@@ -749,6 +783,62 @@ void require_differential_evidence_fails_before_writes() {
                 after.authority_root_bytes.empty() &&
                 !after.authority_mutation_attempted,
             "differential evidence entered the three-observation store");
+}
+
+void require_unresolved_mutation_evidence_fails_before_writes() {
+    auto storage = JournalTestStorage::fresh();
+    auto store = storage.make_overlay_store(generous_limits());
+    auto empty = store.snapshot(TrustedLocalOverlayReplayFloor::uninitialized());
+    require(empty.status == LocalOverlayStoreStatus::Empty &&
+                empty.authority.has_value(),
+            "unresolved mutation-evidence fixture did not start empty");
+
+    auto observations = observations_for(1);
+    auto profile = profile_for(
+        std::string(empty.authority->deployment_id()), 1, observations);
+    auto overlay = overlay_for(profile);
+
+    storage.reset_observations();
+    auto rejected = activate_unresolved_qualification(
+        store, std::move(*empty.authority), std::move(profile),
+        std::move(overlay), std::move(observations), '4',
+        "2026-08-23T10:02:00Z");
+    const auto after = storage.snapshot();
+    require(rejected.status == LocalOverlayStoreStatus::UnsupportedStorage &&
+                !rejected.authority.has_value() &&
+                after.authority_root_bytes.empty() &&
+                !after.authority_mutation_attempted,
+            "literal mutation observations authorized durable activation");
+}
+
+void require_completion_digest_references_do_not_authorize_activation() {
+    auto storage = JournalTestStorage::fresh();
+    auto store = storage.make_overlay_store(generous_limits());
+    auto empty = store.snapshot(TrustedLocalOverlayReplayFloor::uninitialized());
+    require(empty.status == LocalOverlayStoreStatus::Empty &&
+                empty.authority.has_value(),
+            "completion-reference fixture did not start empty");
+
+    auto observations = observations_for(1);
+    auto profile = profile_for(
+        std::string(empty.authority->deployment_id()), 1, observations,
+        "2026-08-23T10:05:00Z", '0', '9');
+    require(profile.ownership_recovery_evidence_sha256() == digest('0') &&
+                profile.action_lease_closure_sha256() == digest('9'),
+            "completion-reference fixture did not preserve its opaque refs");
+    auto overlay = overlay_for(profile);
+
+    storage.reset_observations();
+    auto rejected = activate_unresolved_qualification(
+        store, std::move(*empty.authority), std::move(profile),
+        std::move(overlay), std::move(observations), '4',
+        "2026-08-23T10:02:00Z");
+    const auto after = storage.snapshot();
+    require(rejected.status == LocalOverlayStoreStatus::UnsupportedStorage &&
+                !rejected.authority.has_value() &&
+                after.authority_root_bytes.empty() &&
+                !after.authority_mutation_attempted,
+            "opaque completion references authorized durable activation");
 }
 
 void require_claim_admission_fails_before_writes() {
@@ -773,7 +863,7 @@ void require_claim_admission_fails_before_writes() {
                                  claims(200));
 
         storage.reset_observations();
-        auto rejected = activate_qualification(
+        auto rejected = activate_resolved_fixture_qualification(
             store, std::move(*empty.authority), std::move(profile),
             std::move(overlay), std::move(observations), '4',
             "2026-08-23T10:02:00Z");
@@ -805,7 +895,7 @@ void require_claim_admission_fails_before_writes() {
         profile, std::move(bound), std::move(uncertainty),
         std::move(safety_margin));
     storage.reset_observations();
-    auto rejected = activate_qualification(
+    auto rejected = activate_resolved_fixture_qualification(
         store, std::move(*empty.authority), std::move(profile),
         std::move(overlay), std::move(observations), '4',
         "2026-08-23T10:02:00Z");
@@ -837,7 +927,7 @@ void require_qualification_at_fresh_until_fails_before_writes() {
             "freshness-boundary overlay was not canonical");
 
     storage.reset_observations();
-    auto rejected = activate_qualification(
+    auto rejected = activate_resolved_fixture_qualification(
         store, std::move(*empty.authority), std::move(profile),
         std::move(*sealed_overlay.candidate), std::move(observations), '4',
         freshness_boundary);
@@ -867,7 +957,7 @@ void require_activation_at_fresh_until_fails_before_writes() {
             "the input was fresh");
 
     storage.reset_observations();
-    auto rejected = activate_qualification(
+    auto rejected = activate_resolved_fixture_qualification(
         store, std::move(*empty.authority), std::move(profile),
         std::move(overlay), std::move(observations), '4', freshness_boundary);
     const auto after = storage.snapshot();
@@ -921,7 +1011,7 @@ void require_same_observation_digest_is_deduplicated() {
         std::string(empty.authority->deployment_id()), 1, observations);
     auto overlay = overlay_for(profile);
     storage.reset_observations();
-    auto activated = activate_qualification(
+    auto activated = activate_resolved_fixture_qualification(
         store, std::move(*empty.authority), std::move(profile),
         std::move(overlay), observations, '4', "2026-08-23T10:02:00Z");
     require(activated.status == LocalOverlayStoreStatus::Activated &&
@@ -944,8 +1034,9 @@ void require_rollback_advances_generation_and_preserves_history() {
                 empty.authority.has_value(),
             "rollback fixture did not start empty");
 
-    auto first = qualify(store, std::move(*empty.authority), 1, '4',
-                         "2026-08-23T10:02:00Z");
+    auto first = qualify_resolved_storage_fixture(
+        store, std::move(*empty.authority), 1, '4',
+        "2026-08-23T10:02:00Z");
     require(first.status == LocalOverlayStoreStatus::Activated &&
                 first.authority.has_value(),
             "rollback fixture did not publish sequence one");
@@ -954,8 +1045,9 @@ void require_rollback_advances_generation_and_preserves_history() {
         std::string(first.authority->active_overlay()->checksum_sha256());
     const auto first_observations = observations_for(1);
 
-    auto second = qualify(store, std::move(*first.authority), 2, '5',
-                          "2026-08-23T10:04:00Z");
+    auto second = qualify_resolved_storage_fixture(
+        store, std::move(*first.authority), 2, '5',
+        "2026-08-23T10:04:00Z");
     require(second.status == LocalOverlayStoreStatus::Activated &&
                 second.authority.has_value() &&
                 second.authority->generation() == 2 &&
@@ -1017,22 +1109,25 @@ void require_rollback_can_select_another_prior_overlay() {
                 empty.authority.has_value(),
             "rollback-of-rollback fixture did not start empty");
 
-    auto first = qualify(store, std::move(*empty.authority), 1, '4',
-                         "2026-08-23T10:02:00Z");
+    auto first = qualify_resolved_storage_fixture(
+        store, std::move(*empty.authority), 1, '4',
+        "2026-08-23T10:02:00Z");
     require(first.status == LocalOverlayStoreStatus::Activated &&
                 first.authority.has_value(),
             "rollback-of-rollback fixture did not publish sequence one");
     const auto first_overlay =
         std::string(first.authority->active_overlay()->checksum_sha256());
-    auto second = qualify(store, std::move(*first.authority), 2, '5',
-                          "2026-08-23T10:03:00Z");
+    auto second = qualify_resolved_storage_fixture(
+        store, std::move(*first.authority), 2, '5',
+        "2026-08-23T10:03:00Z");
     require(second.status == LocalOverlayStoreStatus::Activated &&
                 second.authority.has_value(),
             "rollback-of-rollback fixture did not publish sequence two");
     const auto second_overlay =
         std::string(second.authority->active_overlay()->checksum_sha256());
-    auto third = qualify(store, std::move(*second.authority), 3, '6',
-                         "2026-08-23T10:04:00Z");
+    auto third = qualify_resolved_storage_fixture(
+        store, std::move(*second.authority), 3, '6',
+        "2026-08-23T10:04:00Z");
     require(third.status == LocalOverlayStoreStatus::Activated &&
                 third.authority.has_value(),
             "rollback-of-rollback fixture did not publish sequence three");
@@ -1123,7 +1218,8 @@ void require_copied_store_and_object_corruption_fail_closed() {
                 "same-address overlay corruption was not distinguished");
     }
 
-    for (const auto missing_observation : {0, 1, 2}) {
+    for (const std::size_t missing_observation :
+         std::array<std::size_t, 3>{0, 1, 2}) {
         auto fixture = published_fixture();
         const std::array<std::string, 3> observation_sha256{
             fixture.observations.baseline_sha256,
@@ -1140,7 +1236,8 @@ void require_copied_store_and_object_corruption_fail_closed() {
                 "missing observation did not fail closed");
     }
 
-    for (const auto corrupt_observation : {0, 1, 2}) {
+    for (const std::size_t corrupt_observation :
+         std::array<std::size_t, 3>{0, 1, 2}) {
         auto fixture = published_fixture();
         const std::array<std::string, 3> observation_sha256{
             fixture.observations.baseline_sha256,
@@ -1190,14 +1287,16 @@ void require_historic_observation_corruption_fails_closed() {
         require(empty.status == LocalOverlayStoreStatus::Empty &&
                     empty.authority.has_value(),
                 "historic observation fixture did not start empty");
-        auto first = qualify(store, std::move(*empty.authority), 1, '4',
-                             "2026-08-23T10:02:00Z");
+        auto first = qualify_resolved_storage_fixture(
+            store, std::move(*empty.authority), 1, '4',
+            "2026-08-23T10:02:00Z");
         require(first.status == LocalOverlayStoreStatus::Activated &&
                     first.authority.has_value(),
                 "historic observation fixture did not publish generation one");
         const auto first_root = std::string(first.authority->root_bytes());
-        auto second = qualify(store, std::move(*first.authority), 2, '5',
-                              "2026-08-23T10:04:00Z");
+        auto second = qualify_resolved_storage_fixture(
+            store, std::move(*first.authority), 2, '5',
+            "2026-08-23T10:04:00Z");
         require(second.status == LocalOverlayStoreStatus::Activated &&
                     second.authority.has_value() &&
                     second.authority->generation() == 2,
@@ -1414,16 +1513,16 @@ void require_concurrent_activators_share_one_owner_lock() {
     storage.pause_after(
         lemon::residency::testing::FaultOperation::ObjectPublish);
     std::thread first_thread([&] {
-        first_result.emplace(
-            qualify(first_store, std::move(*first.authority), 1, '4',
-                    "2026-08-23T10:02:00Z"));
+        first_result.emplace(qualify_resolved_storage_fixture(
+            first_store, std::move(*first.authority), 1, '4',
+            "2026-08-23T10:02:00Z"));
     });
     require(storage.wait_until_paused(5000),
             "first activator did not pause while holding authority");
     std::thread second_thread([&] {
-        second_result.emplace(
-            qualify(second_store, std::move(*second.authority), 1, '5',
-                    "2026-08-23T10:03:00Z"));
+        second_result.emplace(qualify_resolved_storage_fixture(
+            second_store, std::move(*second.authority), 1, '5',
+            "2026-08-23T10:03:00Z"));
     });
     require(storage.wait_until_lock_waiter(5000),
             "second activator did not wait on the shared owner lock");
@@ -1555,12 +1654,14 @@ void require_object_publication_crash_boundaries() {
                             std::string(overlay.checksum_sha256()),
                             std::string(overlay.canonical_bytes()));
                     }
-                    auto activation = LocalOverlayActivation::qualification(
+                    auto activation = LocalOverlayActivation::unresolved_qualification(
                         std::move(input), std::move(overlay),
                         std::move(observations.baseline),
                         std::move(observations.workload),
                         std::move(observations.release), digest('5'),
                         "2026-08-23T10:03:00Z");
+                    activation = detail::LocalOverlayStoreTestFactory::
+                        resolve_qualification(std::move(activation));
                     fixture.storage.reset_observations();
                     fixture.storage.arm_fault(operation, position,
                                               FaultAction::Crash);
@@ -1608,12 +1709,14 @@ void require_pointer_publication_crash_boundaries() {
                     std::string(expected.authority->deployment_id()), 2,
                     observations);
                 auto overlay = overlay_for(input);
-                auto activation = LocalOverlayActivation::qualification(
+                auto activation = LocalOverlayActivation::unresolved_qualification(
                     std::move(input), std::move(overlay),
                     std::move(observations.baseline),
                     std::move(observations.workload),
                     std::move(observations.release), digest('5'),
                     "2026-08-23T10:03:00Z");
+                activation = detail::LocalOverlayStoreTestFactory::
+                    resolve_qualification(std::move(activation));
                 fixture.storage.reset_observations();
                 fixture.storage.arm_fault(operation, position,
                                           FaultAction::Crash);
@@ -1640,6 +1743,8 @@ int main() {
     require_full_history_rejects_rollback_before_writes();
     require_observation_admission_fails_before_writes();
     require_differential_evidence_fails_before_writes();
+    require_unresolved_mutation_evidence_fails_before_writes();
+    require_completion_digest_references_do_not_authorize_activation();
     require_claim_admission_fails_before_writes();
     require_qualification_at_fresh_until_fails_before_writes();
     require_historic_activation_freshness_boundary_fails_closed();

--- a/test/cpp/test_residency_contract_matrix.cpp
+++ b/test/cpp/test_residency_contract_matrix.cpp
@@ -15,7 +15,7 @@ namespace {
 using namespace lemon::residency;
 
 constexpr std::string_view expected_catalog_sha256 =
-    "c3b8fcd06079c8733515b04a8082c164562636681c197e7ee686406a95f2bd55";
+    "6bccfe672b0531ce9be71aaf7eeeaa2136ae170b0c965bc01acf1a5a4236f2a5";
 
 template <typename T>
 T known_value(const DecodedValue<T> &decoded, std::string_view label) {

--- a/test/cpp/test_residency_contract_matrix.cpp
+++ b/test/cpp/test_residency_contract_matrix.cpp
@@ -15,7 +15,7 @@ namespace {
 using namespace lemon::residency;
 
 constexpr std::string_view expected_catalog_sha256 =
-    "6bccfe672b0531ce9be71aaf7eeeaa2136ae170b0c965bc01acf1a5a4236f2a5";
+    "745ef80ee43157cca3b94edfc4d2f26bb76356e631defde98c83efd8215fb1c1";
 
 template <typename T>
 T known_value(const DecodedValue<T> &decoded, std::string_view label) {

--- a/test/cpp/test_residency_local_overlay.cpp
+++ b/test/cpp/test_residency_local_overlay.cpp
@@ -603,15 +603,14 @@ void require_profiling_input_codec() {
                                       "manifest_claims",
                                       "ownership_recovery_evidence_sha256"},
             "profiling completion serialized an open or incomplete shape");
-    require(document.at("confidence") == "calibrated_instance",
-            "complete profiling evidence did not derive calibrated-instance "
-            "confidence");
-    require(!document.contains("attribution_complete") &&
+    require(!document.contains("confidence") &&
+                !document.contains("attribution_complete") &&
                 !document.contains("external_demand_absent") &&
                 !method_evidence.contains("owner_projection_claim") &&
                 canonical.find("\"selector_sha256\"") == std::string::npos,
             "profiling input serialized a legacy proof flag, a fabricated "
-            "owner projection, or a derived selector digest");
+            "owner projection, premature confidence, or a derived selector "
+            "digest");
     auto reparsed = parse_profiling_input(canonical);
     require(reparsed.accepted(), reparsed.diagnostic);
     require(reparsed.candidate->canonical_bytes() == canonical &&
@@ -630,6 +629,12 @@ void require_profiling_input_codec() {
     require_rejected(parse_profiling_input(with_unknown_root_field(canonical)),
                      OverlayContractStatus::UnknownField,
                      "profiling input accepted an unknown field");
+    require_rejected(
+        parse_profiling_input(tamper_once(
+            canonical, "\"completion\":",
+            "\"confidence\":\"calibrated_instance\",\"completion\":")),
+        OverlayContractStatus::UnknownField,
+        "profiling input accepted premature confidence");
     require_rejected(
         parse_profiling_input(tamper_once(
             canonical,

--- a/test/cpp/test_residency_local_overlay.cpp
+++ b/test/cpp/test_residency_local_overlay.cpp
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -114,24 +115,28 @@ LocalOverlaySelectorIdentity selector() {
 
 ProfilingInputEnvelopeDraft profiling_draft() {
     ProfilingInputEnvelopeDraft draft;
-    draft.schema = supported_local_overlay_schema;
+    draft.schema = supported_profiling_input_schema;
     draft.deployment_id = digest('b');
     draft.sequence = 1;
     draft.profiling_transaction_id = "profiling/1";
     draft.selector = selector();
     draft.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
-    draft.attributed_claims = claims(4096);
-    draft.baseline_observation_sha256 = digest('c');
-    draft.workload_observation_sha256 = digest('d');
-    draft.release_observation_sha256 = digest('e');
+    DifferentialRetainedGttEvidenceDraft method_evidence;
+    method_evidence.retained_gtt_claim =
+        ClaimAmount{"gpu/gtt", ClaimUnit::Bytes, 4096};
+    method_evidence.calibration_evidence_sha256 = digest('c');
+    method_evidence.transient_envelope_sha256 = digest('d');
+    method_evidence.owner_projection_coverage =
+        ProfilingOwnerCoverage::Incomplete;
+    draft.method_evidence = std::move(method_evidence);
+    draft.completion.manifest_claims = claims(6144);
+    draft.completion.ownership_recovery_evidence_sha256 = digest('e');
+    draft.completion.action_lease_closure_sha256 = digest('f');
     draft.observation_contract_sha256 = digest('f');
     draft.predictor_contract_sha256 = digest('0');
     draft.observed_at = "2026-08-23T10:00:00Z";
     draft.fresh_until = "2026-08-23T10:05:00Z";
     draft.max_clock_skew_milliseconds = 1000;
-    draft.attribution_complete = true;
-    draft.external_demand_absent = true;
-    draft.lifecycle_release_verified = true;
     return draft;
 }
 
@@ -236,6 +241,15 @@ void require_rejected(const Result &result, OverlayContractStatus status,
             "rejected codec result returned a candidate");
     require(result.status == status,
             "codec rejection returned the wrong status");
+    require(result.diagnostic.size() <= max_local_overlay_diagnostic_bytes,
+            "codec diagnostic exceeded its bound");
+}
+
+template <typename Result>
+void require_rejected(const Result &result, std::string_view message) {
+    require(!result.accepted(), message);
+    require(!result.candidate.has_value(),
+            "rejected codec result returned a candidate");
     require(result.diagnostic.size() <= max_local_overlay_diagnostic_bytes,
             "codec diagnostic exceeded its bound");
 }
@@ -433,6 +447,21 @@ std::string without_positive_safety_margin(std::string bytes) {
 }
 
 void require_public_shape() {
+    static_assert(supported_profiling_input_schema.major == 2 &&
+                  supported_profiling_input_schema.minor == 0);
+    using ProfilingMethodEvidenceDraft =
+        decltype(ProfilingInputEnvelopeDraft{}.method_evidence);
+    static_assert(std::variant_size_v<ProfilingMethodEvidenceDraft> == 2);
+    static_assert(std::is_same_v<
+                  std::remove_reference_t<decltype(
+                      ProfilingInputEnvelopeDraft{}.completion)>,
+                  ProfilingCompletionDraft>);
+    static_assert(
+        std::is_assignable_v<ProfilingMethodEvidenceDraft &,
+                             MutationCompleteIntervalEvidenceDraft>);
+    static_assert(
+        std::is_assignable_v<ProfilingMethodEvidenceDraft &,
+                             DifferentialRetainedGttEvidenceDraft>);
     static_assert(
         !std::is_default_constructible_v<ParsedProfilingInputEnvelope>);
     static_assert(
@@ -554,8 +583,35 @@ void require_profiling_input_codec() {
             "sealed profiling input lost its closed identity");
 
     const auto canonical = std::string(sealed.candidate->canonical_bytes());
-    require(canonical.find("\"selector_sha256\"") == std::string::npos,
-            "profiling input serialized a derived selector digest");
+    const auto document = json::parse(canonical);
+    const auto &method_evidence = document.at("method_evidence");
+    require(object_keys(method_evidence) ==
+                std::set<std::string>{"calibration_evidence_sha256",
+                                      "covered_effect", "method",
+                                      "owner_projection_coverage",
+                                      "retained_gtt_claim",
+                                      "transient_envelope_sha256"} &&
+                method_evidence.at("method") ==
+                    "differential_retained_gtt" &&
+                method_evidence.at("covered_effect") == "retained_gtt" &&
+                method_evidence.at("owner_projection_coverage") ==
+                    "incomplete",
+            "differential profiling input lost its method, covered effect, "
+            "or incomplete owner-projection state");
+    require(object_keys(document.at("completion")) ==
+                std::set<std::string>{"action_lease_closure_sha256",
+                                      "manifest_claims",
+                                      "ownership_recovery_evidence_sha256"},
+            "profiling completion serialized an open or incomplete shape");
+    require(document.at("confidence") == "calibrated_instance",
+            "complete profiling evidence did not derive calibrated-instance "
+            "confidence");
+    require(!document.contains("attribution_complete") &&
+                !document.contains("external_demand_absent") &&
+                !method_evidence.contains("owner_projection_claim") &&
+                canonical.find("\"selector_sha256\"") == std::string::npos,
+            "profiling input serialized a legacy proof flag, a fabricated "
+            "owner projection, or a derived selector digest");
     auto reparsed = parse_profiling_input(canonical);
     require(reparsed.accepted(), reparsed.diagnostic);
     require(reparsed.candidate->canonical_bytes() == canonical &&
@@ -574,6 +630,21 @@ void require_profiling_input_codec() {
     require_rejected(parse_profiling_input(with_unknown_root_field(canonical)),
                      OverlayContractStatus::UnknownField,
                      "profiling input accepted an unknown field");
+    require_rejected(
+        parse_profiling_input(tamper_once(
+            canonical,
+            "\"calibration_evidence_sha256\":\"" + digest('c') + "\"",
+            "\"baseline_observation_sha256\":\"" + digest('7') +
+                "\",\"calibration_evidence_sha256\":\"" + digest('c') +
+                "\"")),
+        OverlayContractStatus::UnknownField,
+        "differential profiling input accepted a mixed method arm");
+    require_rejected(
+        parse_profiling_input(tamper_once(
+            canonical, "\"method\":\"differential_retained_gtt\"",
+            "\"method\":\"future_method\"")),
+        OverlayContractStatus::UnknownValue,
+        "profiling input accepted an unknown evidence method");
     require_rejected(parse_profiling_input(tamper_once(
                          canonical, "\"deployment_id\":\"" + digest('b') + "\"",
                          "\"deployment_id\":\"" + digest('c') + "\"")),
@@ -585,31 +656,64 @@ void require_profiling_input_codec() {
                      OverlayContractStatus::Duplicate,
                      "profiling input accepted a duplicate key");
 
-    auto incomplete = profiling_draft();
-    incomplete.attribution_complete = false;
-    require_rejected(seal_profiling_input(std::move(incomplete)),
-                     OverlayContractStatus::IncompleteIdentity,
-                     "profiling input accepted incomplete attribution");
+    auto v1 = profiling_draft();
+    v1.schema = supported_local_overlay_schema;
+    require_rejected(seal_profiling_input(std::move(v1)),
+                     OverlayContractStatus::UnsupportedSchema,
+                     "profiling input accepted the legacy shared schema");
+
+    auto missing_transient = profiling_draft();
+    std::get<DifferentialRetainedGttEvidenceDraft>(
+        missing_transient.method_evidence)
+        .transient_envelope_sha256.clear();
+    require_rejected(seal_profiling_input(std::move(missing_transient)),
+                     "profiling input accepted missing transient evidence");
+
+    auto missing_ownership = profiling_draft();
+    missing_ownership.completion.ownership_recovery_evidence_sha256.clear();
+    require_rejected(seal_profiling_input(std::move(missing_ownership)),
+                     "profiling input accepted missing ownership and recovery "
+                     "evidence");
+
+    auto missing_action_lease = profiling_draft();
+    missing_action_lease.completion.action_lease_closure_sha256.clear();
+    require_rejected(seal_profiling_input(std::move(missing_action_lease)),
+                     "profiling input accepted missing action-lease closure");
 
     auto unknown_claims = profiling_draft();
-    unknown_claims.attributed_claims.front().completeness =
+    unknown_claims.completion.manifest_claims.front().completeness =
         ClaimCompleteness::Unknown;
-    unknown_claims.attributed_claims.front().entries.clear();
+    unknown_claims.completion.manifest_claims.front().entries.clear();
     require_rejected(seal_profiling_input(std::move(unknown_claims)),
-                     OverlayContractStatus::IncompleteClaimClosure,
                      "profiling input accepted an unknown claim family");
 
-    auto omitted_required_family = profiling_draft();
-    for (auto &family : omitted_required_family.attributed_claims) {
+    auto incomplete_host_floor = profiling_draft();
+    for (auto &family : incomplete_host_floor.completion.manifest_claims) {
         if (family.family == ClaimFamily::SafetyFloor) {
-            family.completeness = ClaimCompleteness::NotApplicable;
+            family.completeness = ClaimCompleteness::Unknown;
+            family.entries.clear();
         }
     }
-    require_rejected(
-        seal_profiling_input(std::move(omitted_required_family)),
-        OverlayContractStatus::IncompleteClaimClosure,
-        "profiling input accepted a required selector family as not applicable");
+    require_rejected(seal_profiling_input(std::move(incomplete_host_floor)),
+                     "profiling input accepted an incomplete host-memory "
+                     "safety floor");
 
+    auto incomplete_cardinality = profiling_draft();
+    for (auto &family : incomplete_cardinality.completion.manifest_claims) {
+        if (family.family == ClaimFamily::CardinalityPool) {
+            family.completeness = ClaimCompleteness::Unknown;
+            family.entries.clear();
+        }
+    }
+    require_rejected(seal_profiling_input(std::move(incomplete_cardinality)),
+                     "profiling input accepted an incomplete cardinality "
+                     "closure");
+
+    auto insufficient_manifest = profiling_draft();
+    insufficient_manifest.completion.manifest_claims = claims(2048);
+    require_rejected(seal_profiling_input(std::move(insufficient_manifest)),
+                     "profiling input accepted a manifest GTT bound below its "
+                     "retained-GTT evidence");
 }
 
 void require_overlay_object_codec() {

--- a/test/cpp/test_residency_local_overlay.cpp
+++ b/test/cpp/test_residency_local_overlay.cpp
@@ -623,6 +623,11 @@ void require_profiling_input_codec() {
     require_rejected(parse_profiling_input(" " + canonical),
                      OverlayContractStatus::NonCanonical,
                      "profiling input accepted noncanonical whitespace");
+    require_rejected(
+        parse_profiling_input(tamper_once(canonical, "\"minor\":0",
+                                          "\"minor\":-0")),
+        OverlayContractStatus::NonCanonical,
+        "profiling input did not defer signed zero to canonical-byte checking");
     require_rejected(parse_profiling_input("{"),
                      OverlayContractStatus::MalformedJson,
                      "profiling input accepted malformed JSON");

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -270,26 +270,31 @@ ProfilingTransactionContext context(
     result.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
     result.observation_contract_sha256 = *contract_sha256;
     result.predictor_contract_sha256 = digest('0');
+    result.ownership_recovery_evidence_sha256 = digest('7');
+    result.action_lease_closure_sha256 = digest('8');
 
     ProfilingInputEnvelopeDraft input;
-    input.schema = supported_local_overlay_schema;
+    input.schema = supported_profiling_input_schema;
     input.deployment_id = result.deployment_id;
     input.sequence = result.sequence;
     input.profiling_transaction_id = result.profiling_transaction_id;
     input.selector = result.selector;
     input.generations = result.generations;
-    input.attributed_claims = claims();
-    input.baseline_observation_sha256 = digest('c');
-    input.workload_observation_sha256 = digest('d');
-    input.release_observation_sha256 = digest('e');
+    MutationCompleteIntervalEvidenceDraft method_evidence;
+    method_evidence.baseline_observation_sha256 = digest('c');
+    method_evidence.workload_observation_sha256 = digest('d');
+    method_evidence.release_observation_sha256 = digest('e');
+    input.method_evidence = std::move(method_evidence);
+    input.completion.manifest_claims = claims();
+    input.completion.ownership_recovery_evidence_sha256 =
+        result.ownership_recovery_evidence_sha256;
+    input.completion.action_lease_closure_sha256 =
+        result.action_lease_closure_sha256;
     input.observation_contract_sha256 = result.observation_contract_sha256;
     input.predictor_contract_sha256 = result.predictor_contract_sha256;
     input.observed_at = "2026-08-23T10:00:00Z";
     input.fresh_until = "2026-08-23T10:10:00Z";
     input.max_clock_skew_milliseconds = 1000;
-    input.attribution_complete = true;
-    input.external_demand_absent = true;
-    input.lifecycle_release_verified = true;
     const auto sealed = seal_profiling_input(std::move(input));
     if (!sealed.accepted()) {
         throw std::runtime_error("profiling context selector could not seal");

--- a/test/cpp/test_residency_profiling_transaction.cpp
+++ b/test/cpp/test_residency_profiling_transaction.cpp
@@ -175,26 +175,31 @@ ProfilingTransactionContext context(std::string transaction_id = "profile/1") {
     result.generations = OverlaySourceGenerations{1, 2, 3, 4, 5, 6, 7};
     result.observation_contract_sha256 = digest('f');
     result.predictor_contract_sha256 = digest('0');
+    result.ownership_recovery_evidence_sha256 = digest('7');
+    result.action_lease_closure_sha256 = digest('8');
 
     ProfilingInputEnvelopeDraft value;
-    value.schema = supported_local_overlay_schema;
+    value.schema = supported_profiling_input_schema;
     value.deployment_id = result.deployment_id;
     value.sequence = result.sequence;
     value.profiling_transaction_id = result.profiling_transaction_id;
     value.selector = result.selector;
     value.generations = result.generations;
-    value.attributed_claims = claims();
-    value.baseline_observation_sha256 = digest('c');
-    value.workload_observation_sha256 = digest('d');
-    value.release_observation_sha256 = digest('e');
+    MutationCompleteIntervalEvidenceDraft method_evidence;
+    method_evidence.baseline_observation_sha256 = digest('c');
+    method_evidence.workload_observation_sha256 = digest('d');
+    method_evidence.release_observation_sha256 = digest('e');
+    value.method_evidence = std::move(method_evidence);
+    value.completion.manifest_claims = claims();
+    value.completion.ownership_recovery_evidence_sha256 =
+        result.ownership_recovery_evidence_sha256;
+    value.completion.action_lease_closure_sha256 =
+        result.action_lease_closure_sha256;
     value.observation_contract_sha256 = result.observation_contract_sha256;
     value.predictor_contract_sha256 = result.predictor_contract_sha256;
     value.observed_at = "2026-08-23T10:00:00Z";
     value.fresh_until = "2026-08-23T10:05:00Z";
     value.max_clock_skew_milliseconds = 1000;
-    value.attribution_complete = true;
-    value.external_demand_absent = true;
-    value.lifecycle_release_verified = true;
     auto sealed = seal_profiling_input(std::move(value));
     if (!sealed.accepted()) {
         throw std::runtime_error("profiling context selector could not seal");
@@ -372,21 +377,32 @@ void test_accepts_and_releases_gate(TestState &state, Router &router) {
         state.require(result.evidence->input().max_clock_skew_milliseconds() == 1000,
                       "profiling input retains the common skew contract");
         state.require(claim_sets_equal(
-                          result.evidence->input().attributed_claims(),
+                          result.evidence->input().manifest_claims(),
                           result.evidence->workload().attributed_claims()),
-                      "profiling input derives attributed workload claims");
+                      "profiling input derives the completed workload manifest");
+        state.require(
+            result.evidence->input().ownership_recovery_evidence_sha256() ==
+                    transaction_context.ownership_recovery_evidence_sha256 &&
+                result.evidence->input().action_lease_closure_sha256() ==
+                    transaction_context.action_lease_closure_sha256,
+            "profiling input binds ownership, recovery, and action-lease closure");
         state.require(
             result.evidence->baseline().canonical_bytes() == captured.baseline_attestation &&
                 result.evidence->workload().canonical_bytes() == captured.workload_attestation &&
                 result.evidence->release().canonical_bytes() == captured.release_attestation,
             "accepted evidence retains exact canonical phase bytes");
-        state.require(result.evidence->input().baseline_observation_sha256() ==
+        const auto *interval =
+            result.evidence->input().mutation_complete_interval();
+        state.require(interval != nullptr &&
+                          result.evidence->input().differential_retained_gtt() ==
+                              nullptr &&
+                          interval->baseline_observation_sha256 ==
                               raw_sha256(captured.baseline_attestation) &&
-                          result.evidence->input().workload_observation_sha256() ==
+                          interval->workload_observation_sha256 ==
                               raw_sha256(captured.workload_attestation) &&
-                          result.evidence->input().release_observation_sha256() ==
+                          interval->release_observation_sha256 ==
                               raw_sha256(captured.release_attestation),
-                      "profiling input binds raw phase-attestation digests");
+                      "profiling input binds the mutation-complete interval evidence");
     }
     try {
         auto preparation = queued.get();
@@ -492,6 +508,16 @@ void test_rejects_unsafe_evidence(TestState &state, Router &router) {
     expect_rejected(
         "selector identity must match its attested digest",
         [](auto &ctx, auto &) { ctx.selector.canonical_model_id = "model/other"; },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "ownership and recovery closure must be attested",
+        [](auto &ctx, auto &) {
+            ctx.ownership_recovery_evidence_sha256.clear();
+        },
+        ProfilingTransactionStatus::InvalidEvidence);
+    expect_rejected(
+        "action-lease closure must be attested",
+        [](auto &ctx, auto &) { ctx.action_lease_closure_sha256.clear(); },
         ProfilingTransactionStatus::InvalidEvidence);
     expect_rejected(
         "deployment identity must remain stable",

--- a/test/residency/contract/generated/catalog.json
+++ b/test/residency/contract/generated/catalog.json
@@ -4905,11 +4905,6 @@
             "required": true,
             "type": "local_overlay_profiling_completion"
           },
-          "confidence": {
-            "required": true,
-            "type": "literal",
-            "value": "calibrated_instance"
-          },
           "deployment_id": {
             "required": true,
             "type": "local_overlay_deployment_identity"
@@ -7409,6 +7404,6 @@
     }
   ],
   "schema": "residency.profiles/1.0",
-  "selection_registry_sha256": "f3ccfe7c931b00898349233e313169100e33ff22b06f2d94a60db1b9835f22ca",
+  "selection_registry_sha256": "d1309cc70a9d291739c0a5bf46d45f40fe813aacff88c112af3f0b9944cd0ac5",
   "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
 }

--- a/test/residency/contract/generated/catalog.json
+++ b/test/residency/contract/generated/catalog.json
@@ -4897,29 +4897,22 @@
           }
         ],
         "fields": {
-          "attributed_claims": {
-            "required": true,
-            "type": "local_overlay_claim_closure"
-          },
-          "attribution_complete": {
-            "required": true,
-            "type": "local_overlay_required_true"
-          },
-          "baseline_observation_sha256": {
-            "required": true,
-            "type": "sha256"
-          },
           "checksum_sha256": {
             "required": true,
             "type": "sha256"
           },
+          "completion": {
+            "required": true,
+            "type": "local_overlay_profiling_completion"
+          },
+          "confidence": {
+            "required": true,
+            "type": "literal",
+            "value": "calibrated_instance"
+          },
           "deployment_id": {
             "required": true,
             "type": "local_overlay_deployment_identity"
-          },
-          "external_demand_absent": {
-            "required": true,
-            "type": "local_overlay_required_true"
           },
           "fresh_until": {
             "required": true,
@@ -4929,13 +4922,13 @@
             "required": true,
             "type": "local_overlay_source_generations"
           },
-          "lifecycle_release_verified": {
-            "required": true,
-            "type": "local_overlay_required_true"
-          },
           "max_clock_skew_milliseconds": {
             "required": true,
             "type": "local_overlay_positive_uint64"
+          },
+          "method_evidence": {
+            "required": true,
+            "type": "local_overlay_profiling_method_evidence"
           },
           "observation_contract_sha256": {
             "required": true,
@@ -4954,10 +4947,6 @@
             "required": true,
             "type": "opaque"
           },
-          "release_observation_sha256": {
-            "required": true,
-            "type": "sha256"
-          },
           "schema": {
             "required": true,
             "type": "local_overlay_schema_version"
@@ -4969,16 +4958,12 @@
           "sequence": {
             "required": true,
             "type": "local_overlay_positive_uint64"
-          },
-          "workload_observation_sha256": {
-            "required": true,
-            "type": "sha256"
           }
         },
         "output": "docs/api/schemas/residency/profiling_input_envelope.schema.json",
-        "schema_type": "residency.profiling_input_envelope/1.0",
+        "schema_type": "residency.profiling_input_envelope/2.0",
         "version": {
-          "major": 1,
+          "major": 2,
           "minor": 0
         }
       },
@@ -7424,6 +7409,6 @@
     }
   ],
   "schema": "residency.profiles/1.0",
-  "selection_registry_sha256": "9dbdfad20160c82f3905493d2d5c4bdcf40f2249b25ad919c57fd4462a51b4b7",
+  "selection_registry_sha256": "f3ccfe7c931b00898349233e313169100e33ff22b06f2d94a60db1b9835f22ca",
   "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
 }

--- a/test/residency/contract/generated/schema_examples.json
+++ b/test/residency/contract/generated/schema_examples.json
@@ -292,7 +292,6 @@
         ],
         "ownership_recovery_evidence_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       },
-      "confidence": "calibrated_instance",
       "deployment_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       "fresh_until": "2026-09-23T10:01:00Z",
       "generations": {
@@ -5480,11 +5479,6 @@
                 "required": true,
                 "type": "local_overlay_profiling_completion"
               },
-              "confidence": {
-                "required": true,
-                "type": "literal",
-                "value": "calibrated_instance"
-              },
               "deployment_id": {
                 "required": true,
                 "type": "local_overlay_deployment_identity"
@@ -7984,7 +7978,7 @@
         }
       ],
       "schema": "residency.profiles/1.0",
-      "selection_registry_sha256": "f3ccfe7c931b00898349233e313169100e33ff22b06f2d94a60db1b9835f22ca",
+      "selection_registry_sha256": "d1309cc70a9d291739c0a5bf46d45f40fe813aacff88c112af3f0b9944cd0ac5",
       "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
     },
     "resource_diagnostic": {

--- a/test/residency/contract/generated/schema_examples.json
+++ b/test/residency/contract/generated/schema_examples.json
@@ -259,39 +259,41 @@
       "transition": "qualification"
     },
     "profiling_input_envelope": {
-      "attributed_claims": [
-        {
-          "completeness": "bounded",
-          "entries": [
-            {
-              "amount": 4096,
-              "constraint_id": "gpu/gtt",
-              "unit": "bytes"
-            }
-          ],
-          "family": "consumable_capacity"
-        },
-        {
-          "completeness": "known_zero",
-          "entries": [],
-          "family": "safety_floor"
-        },
-        {
-          "completeness": "known_zero",
-          "entries": [],
-          "family": "cardinality_pool"
-        },
-        {
-          "completeness": "not_applicable",
-          "entries": [],
-          "family": "compatibility_exclusivity"
-        }
-      ],
-      "attribution_complete": true,
-      "baseline_observation_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "checksum_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "completion": {
+        "action_lease_closure_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "manifest_claims": [
+          {
+            "completeness": "bounded",
+            "entries": [
+              {
+                "amount": 4096,
+                "constraint_id": "gpu/gtt",
+                "unit": "bytes"
+              }
+            ],
+            "family": "consumable_capacity"
+          },
+          {
+            "completeness": "known_zero",
+            "entries": [],
+            "family": "safety_floor"
+          },
+          {
+            "completeness": "known_zero",
+            "entries": [],
+            "family": "cardinality_pool"
+          },
+          {
+            "completeness": "not_applicable",
+            "entries": [],
+            "family": "compatibility_exclusivity"
+          }
+        ],
+        "ownership_recovery_evidence_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "confidence": "calibrated_instance",
       "deployment_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-      "external_demand_absent": true,
       "fresh_until": "2026-09-23T10:01:00Z",
       "generations": {
         "backend": 2,
@@ -302,15 +304,25 @@
         "topology": 4,
         "workload": 7
       },
-      "lifecycle_release_verified": true,
       "max_clock_skew_milliseconds": 1,
+      "method_evidence": {
+        "calibration_evidence_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "covered_effect": "retained_gtt",
+        "method": "differential_retained_gtt",
+        "owner_projection_coverage": "incomplete",
+        "retained_gtt_claim": {
+          "amount": 4096,
+          "constraint_id": "gpu/gtt",
+          "unit": "bytes"
+        },
+        "transient_envelope_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
       "observation_contract_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "observed_at": "2026-01-01T00:00:00Z",
       "predictor_contract_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "profiling_transaction_id": "profiling_transaction_id-1",
-      "release_observation_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
       "schema": {
-        "major": 1,
+        "major": 2,
         "minor": 0
       },
       "selector": {
@@ -344,8 +356,7 @@
         "topology_sha256": "4444444444444444444444444444444444444444444444444444444444444444",
         "workload_sha256": "7777777777777777777777777777777777777777777777777777777777777777"
       },
-      "sequence": 1,
-      "workload_observation_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+      "sequence": 1
     },
     "profiling_phase_attestation": {
       "attributed_claims": [
@@ -5461,29 +5472,22 @@
               }
             ],
             "fields": {
-              "attributed_claims": {
-                "required": true,
-                "type": "local_overlay_claim_closure"
-              },
-              "attribution_complete": {
-                "required": true,
-                "type": "local_overlay_required_true"
-              },
-              "baseline_observation_sha256": {
-                "required": true,
-                "type": "sha256"
-              },
               "checksum_sha256": {
                 "required": true,
                 "type": "sha256"
               },
+              "completion": {
+                "required": true,
+                "type": "local_overlay_profiling_completion"
+              },
+              "confidence": {
+                "required": true,
+                "type": "literal",
+                "value": "calibrated_instance"
+              },
               "deployment_id": {
                 "required": true,
                 "type": "local_overlay_deployment_identity"
-              },
-              "external_demand_absent": {
-                "required": true,
-                "type": "local_overlay_required_true"
               },
               "fresh_until": {
                 "required": true,
@@ -5493,13 +5497,13 @@
                 "required": true,
                 "type": "local_overlay_source_generations"
               },
-              "lifecycle_release_verified": {
-                "required": true,
-                "type": "local_overlay_required_true"
-              },
               "max_clock_skew_milliseconds": {
                 "required": true,
                 "type": "local_overlay_positive_uint64"
+              },
+              "method_evidence": {
+                "required": true,
+                "type": "local_overlay_profiling_method_evidence"
               },
               "observation_contract_sha256": {
                 "required": true,
@@ -5518,10 +5522,6 @@
                 "required": true,
                 "type": "opaque"
               },
-              "release_observation_sha256": {
-                "required": true,
-                "type": "sha256"
-              },
               "schema": {
                 "required": true,
                 "type": "local_overlay_schema_version"
@@ -5533,16 +5533,12 @@
               "sequence": {
                 "required": true,
                 "type": "local_overlay_positive_uint64"
-              },
-              "workload_observation_sha256": {
-                "required": true,
-                "type": "sha256"
               }
             },
             "output": "docs/api/schemas/residency/profiling_input_envelope.schema.json",
-            "schema_type": "residency.profiling_input_envelope/1.0",
+            "schema_type": "residency.profiling_input_envelope/2.0",
             "version": {
-              "major": 1,
+              "major": 2,
               "minor": 0
             }
           },
@@ -7988,7 +7984,7 @@
         }
       ],
       "schema": "residency.profiles/1.0",
-      "selection_registry_sha256": "9dbdfad20160c82f3905493d2d5c4bdcf40f2249b25ad919c57fd4462a51b4b7",
+      "selection_registry_sha256": "f3ccfe7c931b00898349233e313169100e33ff22b06f2d94a60db1b9835f22ca",
       "source_support_baseline": "a505bbc702cc1fcd44ef73c44defabc98c36d505"
     },
     "resource_diagnostic": {

--- a/test/residency/contract/test_cross_component_matrix_public_seam.py
+++ b/test/residency/contract/test_cross_component_matrix_public_seam.py
@@ -15,7 +15,7 @@ from typing import Any
 repo_root = Path(__file__).resolve().parents[3]
 failure = "TASK-013 residency cross-component matrix is unavailable\n"
 expected_catalog_sha256 = (
-    "6bccfe672b0531ce9be71aaf7eeeaa2136ae170b0c965bc01acf1a5a4236f2a5"
+    "745ef80ee43157cca3b94edfc4d2f26bb76356e631defde98c83efd8215fb1c1"
 )
 generated_paths = (
     "docs/api/schemas/residency/artifact_quarantine_record.schema.json",

--- a/test/residency/contract/test_cross_component_matrix_public_seam.py
+++ b/test/residency/contract/test_cross_component_matrix_public_seam.py
@@ -15,7 +15,7 @@ from typing import Any
 repo_root = Path(__file__).resolve().parents[3]
 failure = "TASK-013 residency cross-component matrix is unavailable\n"
 expected_catalog_sha256 = (
-    "c3b8fcd06079c8733515b04a8082c164562636681c197e7ee686406a95f2bd55"
+    "6bccfe672b0531ce9be71aaf7eeeaa2136ae170b0c965bc01acf1a5a4236f2a5"
 )
 generated_paths = (
     "docs/api/schemas/residency/artifact_quarantine_record.schema.json",
@@ -51,7 +51,7 @@ expected_schema_ids = (
     "residency.deployment_local_overlay_object/1.0",
     "residency.operation_revision/1.0",
     "residency.overlay_activation_root/1.0",
-    "residency.profiling_input_envelope/1.0",
+    "residency.profiling_input_envelope/2.0",
     "residency.profiling_phase_attestation/1.0",
     "residency.reason/1.0",
     "residency.request_error/1.0",

--- a/test/residency/contract/test_generated_contract.py
+++ b/test/residency/contract/test_generated_contract.py
@@ -1024,6 +1024,23 @@ def require_local_overlay_schemas(
             f"{name} contains optional top-level wire fields",
         )
 
+    require(
+        schemas["profiling_input_envelope"]["$id"]
+        == "residency.profiling_input_envelope/2.0"
+        and examples["profiling_input_envelope"]["schema"] == {"major": 2, "minor": 0},
+        "profiling-input schema version drifted",
+    )
+    for name in (
+        "profiling_phase_attestation",
+        "deployment_local_overlay_object",
+        "overlay_activation_root",
+    ):
+        require(
+            schemas[name]["$id"].endswith("/1.0")
+            and examples[name]["schema"] == {"major": 1, "minor": 0},
+            f"{name} schema version drifted",
+        )
+
     profiling = contract_validator(
         schemas["profiling_input_envelope"], registry=resources
     )
@@ -1042,18 +1059,14 @@ def require_local_overlay_schemas(
         "profiling_transaction_id",
         "selector",
         "generations",
-        "attributed_claims",
-        "baseline_observation_sha256",
-        "workload_observation_sha256",
-        "release_observation_sha256",
+        "method_evidence",
+        "completion",
+        "confidence",
         "observation_contract_sha256",
         "predictor_contract_sha256",
         "observed_at",
         "fresh_until",
         "max_clock_skew_milliseconds",
-        "attribution_complete",
-        "external_demand_absent",
-        "lifecycle_release_verified",
         "checksum_sha256",
     }
     require(
@@ -1189,12 +1202,99 @@ def require_local_overlay_schemas(
             "ordered assertion accepted incomparable values",
         )
 
-    incomplete = copy.deepcopy(examples["profiling_input_envelope"])
-    incomplete["attribution_complete"] = False
+    method_evidence = schemas["profiling_input_envelope"]["properties"][
+        "method_evidence"
+    ]
     require(
-        not profiling.is_valid(incomplete),
-        "profiling schema accepted incomplete attribution",
+        len(method_evidence.get("oneOf", [])) == 2,
+        "profiling schema does not close the two evidence methods",
     )
+
+    mutation_complete = copy.deepcopy(examples["profiling_input_envelope"])
+    mutation_complete["method_evidence"] = {
+        "method": "mutation_complete_interval",
+        "covered_effect": "complete_lifecycle",
+        "baseline_observation_sha256": "1" * 64,
+        "workload_observation_sha256": "2" * 64,
+        "release_observation_sha256": "3" * 64,
+        "owner_projection_coverage": "complete",
+        "external_change_absent": True,
+        "lifecycle_envelope_complete": True,
+    }
+    require(
+        profiling.is_valid(mutation_complete),
+        "profiling schema rejected mutation-complete interval evidence",
+    )
+
+    incomplete_mutation_owner = copy.deepcopy(mutation_complete)
+    incomplete_mutation_owner["method_evidence"][
+        "owner_projection_coverage"
+    ] = "incomplete"
+    require(
+        not profiling.is_valid(incomplete_mutation_owner),
+        "mutation-complete evidence accepted incomplete owner projection",
+    )
+
+    incomplete_differential = copy.deepcopy(examples["profiling_input_envelope"])
+    del incomplete_differential["method_evidence"]["transient_envelope_sha256"]
+    require(
+        not profiling.is_valid(incomplete_differential),
+        "differential evidence omitted its transient envelope",
+    )
+
+    for owner_coverage in ("complete", "incomplete", "unknown"):
+        differential_owner = copy.deepcopy(examples["profiling_input_envelope"])
+        differential_owner["method_evidence"][
+            "owner_projection_coverage"
+        ] = owner_coverage
+        require(
+            profiling.is_valid(differential_owner),
+            f"differential evidence rejected {owner_coverage} owner projection",
+        )
+    unknown_owner_coverage = copy.deepcopy(examples["profiling_input_envelope"])
+    unknown_owner_coverage["method_evidence"]["owner_projection_coverage"] = "future"
+    require(
+        not profiling.is_valid(unknown_owner_coverage),
+        "differential evidence accepted an open owner projection state",
+    )
+
+    open_method = copy.deepcopy(examples["profiling_input_envelope"])
+    open_method["method_evidence"]["future"] = True
+    require(
+        not profiling.is_valid(open_method),
+        "profiling schema accepted an open method-evidence object",
+    )
+
+    open_completion = copy.deepcopy(examples["profiling_input_envelope"])
+    open_completion["completion"]["future"] = True
+    require(
+        not profiling.is_valid(open_completion),
+        "profiling schema accepted an open completion object",
+    )
+
+    legacy_boolean = copy.deepcopy(examples["profiling_input_envelope"])
+    legacy_boolean["attribution_complete"] = True
+    require(
+        not profiling.is_valid(legacy_boolean),
+        "profiling schema accepted a legacy completeness boolean",
+    )
+
+    noncalibrated = copy.deepcopy(examples["profiling_input_envelope"])
+    noncalibrated["confidence"] = "validated_predictor"
+    require(
+        not profiling.is_valid(noncalibrated),
+        "profiling schema accepted non-calibrated confidence",
+    )
+
+    unknown_manifest_claim = copy.deepcopy(examples["profiling_input_envelope"])
+    unknown_manifest_claim["completion"]["manifest_claims"][0][
+        "completeness"
+    ] = "unknown"
+    require(
+        not profiling.is_valid(unknown_manifest_claim),
+        "profiling schema accepted an incomplete manifest claim closure",
+    )
+
     zero_clock_skew = copy.deepcopy(examples["profiling_input_envelope"])
     zero_clock_skew["max_clock_skew_milliseconds"] = 0
     require(
@@ -1213,13 +1313,6 @@ def require_local_overlay_schemas(
         not profiling.is_valid(mismatched_template),
         "profiling schema accepted a mismatched operation template and kind",
     )
-    unknown_claim = copy.deepcopy(examples["profiling_input_envelope"])
-    unknown_claim["attributed_claims"][0]["completeness"] = "unknown"
-    require(
-        not profiling.is_valid(unknown_claim),
-        "profiling schema accepted an incomplete claim closure",
-    )
-
     unhealthy_phase = copy.deepcopy(examples["profiling_phase_attestation"])
     unhealthy_phase["health"] = "stale"
     require(

--- a/test/residency/contract/test_generated_contract.py
+++ b/test/residency/contract/test_generated_contract.py
@@ -1052,6 +1052,29 @@ def require_local_overlay_schemas(
     )
     root = contract_validator(schemas["overlay_activation_root"], registry=resources)
 
+    for path, mutate in (
+        (
+            "schema.major",
+            lambda document: document["schema"].__setitem__("major", 2.0),
+        ),
+        (
+            "sequence",
+            lambda document: document.__setitem__("sequence", 2.0),
+        ),
+        (
+            "method_evidence.retained_gtt_claim.amount",
+            lambda document: document["method_evidence"][
+                "retained_gtt_claim"
+            ].__setitem__("amount", 4096.0),
+        ),
+    ):
+        integral_float = copy.deepcopy(examples["profiling_input_envelope"])
+        mutate(integral_float)
+        require(
+            not profiling.is_valid(integral_float),
+            f"profiling-input schema accepted integral float at {path}",
+        )
+
     profiling_input_fields = {
         "schema",
         "deployment_id",
@@ -1061,7 +1084,6 @@ def require_local_overlay_schemas(
         "generations",
         "method_evidence",
         "completion",
-        "confidence",
         "observation_contract_sha256",
         "predictor_contract_sha256",
         "observed_at",
@@ -1279,11 +1301,11 @@ def require_local_overlay_schemas(
         "profiling schema accepted a legacy completeness boolean",
     )
 
-    noncalibrated = copy.deepcopy(examples["profiling_input_envelope"])
-    noncalibrated["confidence"] = "validated_predictor"
+    premature_confidence = copy.deepcopy(examples["profiling_input_envelope"])
+    premature_confidence["confidence"] = "calibrated_instance"
     require(
-        not profiling.is_valid(noncalibrated),
-        "profiling schema accepted non-calibrated confidence",
+        not profiling.is_valid(premature_confidence),
+        "profiling schema accepted premature confidence",
     )
 
     unknown_manifest_claim = copy.deepcopy(examples["profiling_input_envelope"])

--- a/test/test_residency_capability_inventory_contract_registry.py
+++ b/test/test_residency_capability_inventory_contract_registry.py
@@ -34,6 +34,12 @@ class ResidencyCapabilityInventoryContractRegistryTest(
             local_overlay_schemas["profiling_input_envelope"]["schema_type"],
             "residency.profiling_input_envelope/2.0",
         )
+        profiling_fields = local_overlay_schemas["profiling_input_envelope"]["fields"]
+        for field in ("sequence", "max_clock_skew_milliseconds"):
+            self.assertEqual(
+                profiling_fields[field],
+                {"required": True, "type": "local_overlay_positive_uint64"},
+            )
         for schema_key in (
             "profiling_phase_attestation",
             "deployment_local_overlay_object",

--- a/test/test_residency_capability_inventory_contract_registry.py
+++ b/test/test_residency_capability_inventory_contract_registry.py
@@ -25,6 +25,24 @@ class ResidencyCapabilityInventoryContractRegistryTest(
         self.assertEqual(len(registry["presentation_registry"]), 27)
         self.assertEqual(len(registry["detail_schema_registry"]), 15)
         self.assertEqual(len(registry["schema_registry"]), 16)
+        local_overlay_schemas = registry["schema_registry"]
+        self.assertEqual(
+            local_overlay_schemas["profiling_input_envelope"]["version"],
+            {"major": 2, "minor": 0},
+        )
+        self.assertEqual(
+            local_overlay_schemas["profiling_input_envelope"]["schema_type"],
+            "residency.profiling_input_envelope/2.0",
+        )
+        for schema_key in (
+            "profiling_phase_attestation",
+            "deployment_local_overlay_object",
+            "overlay_activation_root",
+        ):
+            self.assertEqual(
+                local_overlay_schemas[schema_key]["version"],
+                {"major": 1, "minor": 0},
+            )
         catalog_fields = registry["schema_registry"]["residency_profiles"]["fields"]
         self.assertEqual(
             catalog_fields["source_support_baseline"],

--- a/tools/residency_contract/schemas.py
+++ b/tools/residency_contract/schemas.py
@@ -206,6 +206,79 @@ def _local_overlay_claim_closure() -> dict[str, Any]:
     }
 
 
+def _local_overlay_retained_gtt_claim() -> dict[str, Any]:
+    return _object(
+        {
+            "amount": {"type": "integer", "minimum": 1, "maximum": UINT64_MAX},
+            "constraint_id": _opaque(),
+            "unit": {"const": "bytes"},
+        },
+        ("amount", "constraint_id", "unit"),
+    )
+
+
+def _local_overlay_profiling_method_evidence() -> dict[str, Any]:
+    mutation_complete_interval = _object(
+        {
+            "baseline_observation_sha256": _fixed_lower_hex(64),
+            "covered_effect": {"const": "complete_lifecycle"},
+            "external_change_absent": {"const": True},
+            "lifecycle_envelope_complete": {"const": True},
+            "method": {"const": "mutation_complete_interval"},
+            "owner_projection_coverage": {"const": "complete"},
+            "release_observation_sha256": _fixed_lower_hex(64),
+            "workload_observation_sha256": _fixed_lower_hex(64),
+        },
+        (
+            "baseline_observation_sha256",
+            "covered_effect",
+            "external_change_absent",
+            "lifecycle_envelope_complete",
+            "method",
+            "owner_projection_coverage",
+            "release_observation_sha256",
+            "workload_observation_sha256",
+        ),
+    )
+    differential_retained_gtt = _object(
+        {
+            "calibration_evidence_sha256": _fixed_lower_hex(64),
+            "covered_effect": {"const": "retained_gtt"},
+            "method": {"const": "differential_retained_gtt"},
+            "owner_projection_coverage": _string_schema(
+                values=("complete", "incomplete", "unknown"),
+                max_length=len("incomplete"),
+            ),
+            "retained_gtt_claim": _local_overlay_retained_gtt_claim(),
+            "transient_envelope_sha256": _fixed_lower_hex(64),
+        },
+        (
+            "calibration_evidence_sha256",
+            "covered_effect",
+            "method",
+            "owner_projection_coverage",
+            "retained_gtt_claim",
+            "transient_envelope_sha256",
+        ),
+    )
+    return {"oneOf": [mutation_complete_interval, differential_retained_gtt]}
+
+
+def _local_overlay_profiling_completion() -> dict[str, Any]:
+    return _object(
+        {
+            "action_lease_closure_sha256": _fixed_lower_hex(64),
+            "manifest_claims": {"$ref": "#/$defs/claim_closure"},
+            "ownership_recovery_evidence_sha256": _fixed_lower_hex(64),
+        },
+        (
+            "action_lease_closure_sha256",
+            "manifest_claims",
+            "ownership_recovery_evidence_sha256",
+        ),
+    )
+
+
 def _local_overlay_safety_margin_claim_closure() -> dict[str, Any]:
     return {
         "allOf": [
@@ -408,7 +481,10 @@ def _local_overlay_method_identity(registry: Mapping[str, Any]) -> dict[str, Any
     return result
 
 
-def _local_overlay_definitions(registry: Mapping[str, Any]) -> dict[str, Any]:
+def _local_overlay_definitions(
+    registry: Mapping[str, Any], raw_version: Any
+) -> dict[str, Any]:
+    version = _mapping(raw_version, "local-overlay schema version")
     return {
         "authority_status": {"const": "active"},
         "claim_closure": _local_overlay_claim_closure(),
@@ -423,7 +499,10 @@ def _local_overlay_definitions(registry: Mapping[str, Any]) -> dict[str, Any]:
         ),
         "safety_margin_claim_closure": _local_overlay_safety_margin_claim_closure(),
         "schema_version": _object(
-            {"major": {"const": 1}, "minor": {"const": 0}},
+            {
+                "major": {"const": version.get("major")},
+                "minor": {"const": version.get("minor")},
+            },
             ("major", "minor"),
         ),
         "selector_identity": _local_overlay_selector_identity(registry),
@@ -457,6 +536,10 @@ def _local_overlay_field_schema(
     if spec["type"] == "local_overlay_profiling_lifecycle_state":
         values = ("baseline_quiescent", "workload_complete", "release_verified")
         return _string_schema(values=values, max_length=max(map(len, values)))
+    if spec["type"] == "local_overlay_profiling_method_evidence":
+        return _local_overlay_profiling_method_evidence()
+    if spec["type"] == "local_overlay_profiling_completion":
+        return _local_overlay_profiling_completion()
     if spec["type"] == "local_overlay_zero_claim_closure":
         return {
             "allOf": [
@@ -1277,7 +1360,9 @@ def _schema_document(
             {"reason": _reason_reference(registry, key)} if uses_reason else {}
         )
         if key in LOCAL_OVERLAY_SCHEMA_KEYS:
-            document_definitions.update(_local_overlay_definitions(registry))
+            document_definitions.update(
+                _local_overlay_definitions(registry, row.get("version"))
+            )
         if key == "request_error":
             root.setdefault("allOf", []).extend(
                 _request_error_http_conditionals(registry, reason_rows)
@@ -1464,8 +1549,24 @@ def _local_overlay_field_example(
         "local_overlay_profiling_lifecycle_state": "baseline_quiescent",
         "local_overlay_profiling_owner_coverage": "complete",
         "local_overlay_profiling_phase": "baseline",
+        "local_overlay_profiling_method_evidence": {
+            "calibration_evidence_sha256": "b" * 64,
+            "covered_effect": "retained_gtt",
+            "method": "differential_retained_gtt",
+            "owner_projection_coverage": "incomplete",
+            "retained_gtt_claim": {
+                "amount": 4096,
+                "constraint_id": "gpu/gtt",
+                "unit": "bytes",
+            },
+            "transient_envelope_sha256": "c" * 64,
+        },
+        "local_overlay_profiling_completion": {
+            "action_lease_closure_sha256": "e" * 64,
+            "manifest_claims": _local_overlay_claim_example(),
+            "ownership_recovery_evidence_sha256": "d" * 64,
+        },
         "local_overlay_safety_margin_claim_closure": _local_overlay_claim_example(),
-        "local_overlay_schema_version": {"major": 1, "minor": 0},
         "local_overlay_selector_identity": _local_overlay_selector_example(),
         "local_overlay_source_generations": {
             "backend": 2,
@@ -1607,12 +1708,18 @@ def _example(
     if key == "residency_profiles":
         return copy.deepcopy(catalog)
     fields = _mapping(row.get("fields"), f"schema_registry.{key}.fields")
-    result = {
-        name: _field_example(name, spec, registry, reason_rows)
-        for name, spec in fields.items()
-        if _mapping(spec, f"schema_registry.{key}.fields.{name}").get("required")
-        is True
-    }
+    result = {}
+    for name, spec in fields.items():
+        field = _mapping(spec, f"schema_registry.{key}.fields.{name}")
+        if field.get("required") is not True:
+            continue
+        result[name] = (
+            copy.deepcopy(row["version"])
+            if key in LOCAL_OVERLAY_SCHEMA_KEYS
+            and name == "schema"
+            and field.get("type") == "local_overlay_schema_version"
+            else _field_example(name, field, registry, reason_rows)
+        )
     if key == "coordinator_step_result":
         result["candidate_id"] = "candidate-1"
         result["artifact_scope_key"] = "artifact-scope-1"

--- a/tools/residency_contract/schemas.py
+++ b/tools/residency_contract/schemas.py
@@ -57,6 +57,7 @@ REQUIRED_SCHEMA_KEYWORDS = (
     "x-max-utf8-bytes",
     "x-nfc",
     "x-residency-assert",
+    "x-residency-json-integer",
 )
 
 
@@ -123,6 +124,14 @@ def _object(properties: Mapping[str, Any], required: Iterable[str]) -> dict[str,
     }
 
 
+def _json_integer(**keywords: Any) -> dict[str, Any]:
+    return {
+        "type": "integer",
+        "x-residency-json-integer": True,
+        **keywords,
+    }
+
+
 def _resolve(registry: Mapping[str, Any], reference: str) -> Any:
     value: Any = registry
     for part in reference.split("."):
@@ -148,9 +157,9 @@ def _enum_ref(registry: Mapping[str, Any], reference: str) -> dict[str, Any]:
 def _local_overlay_claim_family(
     family: str, unit: str, *, compatibility: bool = False
 ) -> dict[str, Any]:
-    amount = {"type": "integer", "minimum": 1, "maximum": UINT64_MAX}
+    amount = _json_integer(minimum=1, maximum=UINT64_MAX)
     if compatibility:
-        amount = {"const": 1, "type": "integer"}
+        amount = _json_integer(const=1)
     entry = _object(
         {
             "amount": amount,
@@ -209,7 +218,7 @@ def _local_overlay_claim_closure() -> dict[str, Any]:
 def _local_overlay_retained_gtt_claim() -> dict[str, Any]:
     return _object(
         {
-            "amount": {"type": "integer", "minimum": 1, "maximum": UINT64_MAX},
+            "amount": _json_integer(minimum=1, maximum=UINT64_MAX),
             "constraint_id": _opaque(),
             "unit": {"const": "bytes"},
         },
@@ -412,7 +421,7 @@ def _local_overlay_selector_identity(registry: Mapping[str, Any]) -> dict[str, A
 
 
 def _local_overlay_source_generations() -> dict[str, Any]:
-    generation = {"type": "integer", "minimum": 1, "maximum": UINT64_MAX}
+    generation = _json_integer(minimum=1, maximum=UINT64_MAX)
     fields = (
         "backend",
         "configuration",
@@ -500,8 +509,8 @@ def _local_overlay_definitions(
         "safety_margin_claim_closure": _local_overlay_safety_margin_claim_closure(),
         "schema_version": _object(
             {
-                "major": {"const": version.get("major")},
-                "minor": {"const": version.get("minor")},
+                "major": _json_integer(const=version.get("major")),
+                "minor": _json_integer(const=version.get("minor")),
             },
             ("major", "minor"),
         ),
@@ -519,11 +528,11 @@ def _local_overlay_field_schema(
 ) -> dict[str, Any] | None:
     del name, registry, catalog
     if spec["type"] == "local_overlay_positive_uint64":
-        return {"type": "integer", "minimum": 1, "maximum": UINT64_MAX}
+        return _json_integer(minimum=1, maximum=UINT64_MAX)
     if spec["type"] == "local_overlay_nonnegative_uint64":
-        return {"type": "integer", "minimum": 0, "maximum": UINT64_MAX}
+        return _json_integer(minimum=0, maximum=UINT64_MAX)
     if spec["type"] == "local_overlay_confidence_basis_points":
-        return {"type": "integer", "minimum": 1, "maximum": 10000}
+        return _json_integer(minimum=1, maximum=10000)
     if spec["type"] == "local_overlay_required_true":
         return {"const": True}
     if spec["type"] == "local_overlay_profiling_phase":

--- a/tools/residency_contract/validation.py
+++ b/tools/residency_contract/validation.py
@@ -17,7 +17,12 @@ from residency_inventory.path import _PATH_INDEX, _PATH_SEGMENT, _path_tokens
 
 REQUIRED_KEYWORDS_FIELD = "x-residency-required-keywords"
 SUPPORTED_REQUIRED_KEYWORDS = frozenset(
-    {"x-max-utf8-bytes", "x-nfc", "x-residency-assert"}
+    {
+        "x-max-utf8-bytes",
+        "x-nfc",
+        "x-residency-assert",
+        "x-residency-json-integer",
+    }
 )
 _MISSING = object()
 
@@ -56,6 +61,16 @@ def _validate_utf8_bytes(
         return
     if len(encoded) > maximum:
         yield from _validation_error(f"string exceeds {maximum} UTF-8 bytes")
+
+
+def _validate_json_integer(
+    validator: Any, expected: Any, instance: Any, schema: Any
+) -> Iterator[ValidationError]:
+    del validator, schema
+    if expected is not True:
+        return
+    if isinstance(instance, bool) or not isinstance(instance, int):
+        yield from _validation_error("value must use the JSON integer representation")
 
 
 def _resolve_path(instance: Any, path: str) -> Any:
@@ -132,6 +147,7 @@ ResidencyDraft202012Validator = validators.extend(
         "x-max-utf8-bytes": _validate_utf8_bytes,
         "x-nfc": _validate_nfc,
         "x-residency-assert": _validate_residency_assert,
+        "x-residency-json-integer": _validate_json_integer,
     },
 )
 
@@ -204,6 +220,8 @@ def _used_keywords(schema: Mapping[str, Any]) -> set[str]:
                 isinstance(value, bool) or not isinstance(value, int) or value < 0
             ):
                 _schema_error("x-max-utf8-bytes must be a nonnegative integer")
+            if keyword == "x-residency-json-integer" and value is not True:
+                _schema_error("x-residency-json-integer must be true")
             if keyword == "x-residency-assert":
                 _validate_assertion(value)
             used.add(keyword)

--- a/tools/residency_inventory/contract_registry.py
+++ b/tools/residency_inventory/contract_registry.py
@@ -21,7 +21,7 @@ from .contract import (
 from .path import _path_tokens
 
 EXPECTED_REGISTRY_DIGEST = (
-    "76dfa0d84a4367e242b536bc5edbaa12cb117280320674d7d5ac92f8ded1d481"
+    "344cea1742fb10f23b4a8c173315f76be8f735c95e5b145ef451cb58ed6289b3"
 )
 EXPECTED_REGISTRY_KEYS = [
     "schema",
@@ -344,8 +344,10 @@ SCHEMA_FIELD_TYPES = {
     "local_overlay_object_status",
     "local_overlay_previous_root_reference",
     "local_overlay_positive_uint64",
+    "local_overlay_profiling_completion",
     "local_overlay_profiling_health",
     "local_overlay_profiling_lifecycle_state",
+    "local_overlay_profiling_method_evidence",
     "local_overlay_profiling_owner_coverage",
     "local_overlay_profiling_phase",
     "local_overlay_required_true",
@@ -1327,15 +1329,24 @@ def _validate_schema_registry(registry: dict[str, Any]) -> None:
             schema.get("version"),
             f"contract_registry.schema_registry.{schema_key}.version",
         )
-        if version != {"major": 1, "minor": 0}:
-            fail(f"schema {schema_key} must remain at version 1.0")
+        expected_version = (
+            {"major": 2, "minor": 0}
+            if schema_key == "profiling_input_envelope"
+            else {"major": 1, "minor": 0}
+        )
+        if version != expected_version:
+            fail(
+                f"schema {schema_key} must remain at version "
+                f"{expected_version['major']}.{expected_version['minor']}"
+            )
         expected_output = f"docs/api/schemas/residency/{schema_key}.schema.json"
         if schema.get("output") != expected_output:
             fail(f"schema {schema_key} output path drifted")
         expected_type = (
             "residency.profiles/1.0"
             if schema_key == "residency_profiles"
-            else f"residency.{schema_key}/1.0"
+            else f"residency.{schema_key}/"
+            f"{expected_version['major']}.{expected_version['minor']}"
         )
         if schema.get("schema_type") != expected_type:
             fail(f"schema {schema_key} type drifted")

--- a/tools/residency_inventory/contract_registry.py
+++ b/tools/residency_inventory/contract_registry.py
@@ -21,7 +21,7 @@ from .contract import (
 from .path import _path_tokens
 
 EXPECTED_REGISTRY_DIGEST = (
-    "344cea1742fb10f23b4a8c173315f76be8f735c95e5b145ef451cb58ed6289b3"
+    "6f1ecdfe73bbfc0cf0443aad9033e7ac241931621c6f49e3589dbf1fbc0159cb"
 )
 EXPECTED_REGISTRY_KEYS = [
     "schema",


### PR DESCRIPTION
## Summary

Splits profiling-input v2 into closed mutation-complete and differential retained-GTT evidence methods while keeping phase, overlay, and activation-root schemas at v1. Inputs carry unresolved completion references and remain inert until a typed resolver exists; rollback and durable storage mechanics remain covered.

Refs #120

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Built `lemond` and the `cpp-ci-tests` aggregate.
- Ran all 70 `cpp-ci` CTests.
- Ran 188 residency inventory contract tests.
- Ran the generated-contract and cross-component public-seam tests.
- Verified generator and inventory drift checks, Black, and `git diff --check`.
- Compiled changed C++ translation units with GCC and Clang under C++17 strict warnings-as-errors.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [x] This PR introduces breaking changes.
- [ ] This PR does not introduce breaking changes.

The unpublished profiling-input wire and checksum domain move from v1 to v2; v1 inputs are rejected. Phase attestations, overlay objects, and activation roots remain at v1.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced profiling input schema version 2.0 with structured method evidence and completion details.
  * Added validation for mutation-complete evidence, manifest coverage, ownership recovery, and lease closure.
  * Added strict JSON integer validation for residency schema fields.
  * Qualification-based activations now require explicit resolution before use.

* **Breaking Changes**
  * Replaced legacy attribution, lifecycle, and observation fields with required evidence and completion objects.
  * Updated profiling-related contract and registry versions to reflect the new schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->