### PR TITLE
refactor(residency/profiling): report workload outcomes

### DIFF
--- a/src/cpp/include/lemon/residency/profiling_capture_authority.h
+++ b/src/cpp/include/lemon/residency/profiling_capture_authority.h
@@ -2,8 +2,10 @@
 
 #include "lemon/residency/profiling_provider.h"
 
+#include <array>
 #include <chrono>
-#include <string>
+#include <cstddef>
+#include <string_view>
 
 namespace lemon {
 
@@ -35,21 +37,25 @@ public:
     operator=(ProfilingWorkloadStepResult &&) noexcept = default;
 
     static ProfilingWorkloadStepResult success() noexcept;
-    static ProfilingWorkloadStepResult cancelled(std::string diagnostic);
-    static ProfilingWorkloadStepResult failed(std::string diagnostic);
-    static ProfilingWorkloadStepResult ambiguous(std::string diagnostic);
+    static ProfilingWorkloadStepResult
+    cancelled(std::string_view diagnostic) noexcept;
+    static ProfilingWorkloadStepResult
+    failed(std::string_view diagnostic) noexcept;
+    static ProfilingWorkloadStepResult
+    ambiguous(std::string_view diagnostic) noexcept;
 
     ProfilingWorkloadStepStatus status() const noexcept;
-    const std::string &diagnostic() const noexcept;
+    std::string_view diagnostic() const noexcept;
     bool succeeded() const noexcept;
 
 private:
     ProfilingWorkloadStepResult(ProfilingWorkloadStepStatus status,
-                                std::string diagnostic) noexcept;
+                                std::string_view diagnostic) noexcept;
 
     ProfilingWorkloadStepStatus status_ =
         ProfilingWorkloadStepStatus::Ambiguous;
-    std::string diagnostic_;
+    std::array<char, max_local_overlay_diagnostic_bytes> diagnostic_{};
+    std::size_t diagnostic_size_ = 0;
 };
 
 class ProfilingWorkloadDriver {

--- a/src/cpp/include/lemon/residency/profiling_capture_authority.h
+++ b/src/cpp/include/lemon/residency/profiling_capture_authority.h
@@ -3,6 +3,7 @@
 #include "lemon/residency/profiling_provider.h"
 
 #include <chrono>
+#include <string>
 
 namespace lemon {
 
@@ -17,6 +18,40 @@ struct ProfilingCaptureSchedule {
     ProfilingCollectionClock clock;
 };
 
+enum class ProfilingWorkloadStepStatus {
+    Succeeded,
+    Cancelled,
+    Failed,
+    Ambiguous,
+};
+
+class ProfilingWorkloadStepResult {
+public:
+    ProfilingWorkloadStepResult(const ProfilingWorkloadStepResult &) = default;
+    ProfilingWorkloadStepResult(ProfilingWorkloadStepResult &&) noexcept = default;
+    ProfilingWorkloadStepResult &
+    operator=(const ProfilingWorkloadStepResult &) = default;
+    ProfilingWorkloadStepResult &
+    operator=(ProfilingWorkloadStepResult &&) noexcept = default;
+
+    static ProfilingWorkloadStepResult success() noexcept;
+    static ProfilingWorkloadStepResult cancelled(std::string diagnostic);
+    static ProfilingWorkloadStepResult failed(std::string diagnostic);
+    static ProfilingWorkloadStepResult ambiguous(std::string diagnostic);
+
+    ProfilingWorkloadStepStatus status() const noexcept;
+    const std::string &diagnostic() const noexcept;
+    bool succeeded() const noexcept;
+
+private:
+    ProfilingWorkloadStepResult(ProfilingWorkloadStepStatus status,
+                                std::string diagnostic) noexcept;
+
+    ProfilingWorkloadStepStatus status_ =
+        ProfilingWorkloadStepStatus::Ambiguous;
+    std::string diagnostic_;
+};
+
 class ProfilingWorkloadDriver {
 public:
     virtual ~ProfilingWorkloadDriver() = default;
@@ -24,11 +59,11 @@ public:
     // Both calls are synchronous, run on the Router lease owner, retain no
     // references, and leave no unjoined work. Release is self-contained, does
     // not wait for observation progress, and safely completes a partial run.
-    virtual void run(
+    virtual ProfilingWorkloadStepResult run(
         Router &router,
         const ProfilingTransactionContext &context,
         const ProfilingCancellationCheck &should_abort) = 0;
-    virtual void release(
+    virtual ProfilingWorkloadStepResult release(
         Router &router,
         const ProfilingTransactionContext &context) noexcept = 0;
 };

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -17,6 +17,52 @@
 #include <vector>
 
 namespace lemon::residency {
+
+ProfilingWorkloadStepResult::ProfilingWorkloadStepResult(
+    ProfilingWorkloadStepStatus status,
+    std::string diagnostic) noexcept
+    : status_(status), diagnostic_(std::move(diagnostic)) {}
+
+ProfilingWorkloadStepResult ProfilingWorkloadStepResult::success() noexcept {
+    return ProfilingWorkloadStepResult{
+        ProfilingWorkloadStepStatus::Succeeded, {}};
+}
+
+ProfilingWorkloadStepResult ProfilingWorkloadStepResult::cancelled(
+    std::string diagnostic) {
+    return ProfilingWorkloadStepResult{
+        ProfilingWorkloadStepStatus::Cancelled,
+        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+}
+
+ProfilingWorkloadStepResult ProfilingWorkloadStepResult::failed(
+    std::string diagnostic) {
+    return ProfilingWorkloadStepResult{
+        ProfilingWorkloadStepStatus::Failed,
+        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+}
+
+ProfilingWorkloadStepResult ProfilingWorkloadStepResult::ambiguous(
+    std::string diagnostic) {
+    return ProfilingWorkloadStepResult{
+        ProfilingWorkloadStepStatus::Ambiguous,
+        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+}
+
+ProfilingWorkloadStepStatus
+ProfilingWorkloadStepResult::status() const noexcept {
+    return status_;
+}
+
+const std::string &
+ProfilingWorkloadStepResult::diagnostic() const noexcept {
+    return diagnostic_;
+}
+
+bool ProfilingWorkloadStepResult::succeeded() const noexcept {
+    return status_ == ProfilingWorkloadStepStatus::Succeeded;
+}
+
 namespace {
 
 using SteadyClock = std::chrono::steady_clock;
@@ -330,16 +376,19 @@ public:
 
     void enter() noexcept { entered_ = true; }
 
-    void release() noexcept {
-        if (!entered_ || released_) return;
+    const ProfilingWorkloadStepResult *release() noexcept {
+        if (!entered_) return nullptr;
+        if (released_) return result_ ? &*result_ : nullptr;
         released_ = true;
-        workload_.release(router_, context_);
+        result_.emplace(workload_.release(router_, context_));
+        return &*result_;
     }
 
 private:
     Router &router_;
     const ProfilingTransactionContext &context_;
     ProfilingWorkloadDriver &workload_;
+    std::optional<ProfilingWorkloadStepResult> result_;
     bool entered_ = false;
     bool released_ = false;
 };
@@ -393,15 +442,17 @@ public:
         }
 
         WorkloadReleaseGuard release_guard(router_, context_, workload_);
-        bool workload_completed = true;
+        auto workload_result = ProfilingWorkloadStepResult::ambiguous(
+            "profiling workload result was not reported");
         release_guard.enter();
         try {
-            workload_.run(router_, context_, [this] {
+            workload_result = workload_.run(router_, context_, [this] {
                 return observer_failed_.load(std::memory_order_acquire) ||
                        cancelled(should_abort_);
             });
         } catch (...) {
-            workload_completed = false;
+            workload_result = ProfilingWorkloadStepResult::ambiguous(
+                "profiling workload result was not reported");
         }
         const bool capture_cancelled = cancelled(should_abort_);
 
@@ -429,7 +480,7 @@ public:
             return finish_failed_capture();
         }
 
-        release_guard.release();
+        const auto *release_result = release_guard.release();
         {
             std::lock_guard<std::mutex> lock(mutex_);
             state_.release_done = true;
@@ -442,9 +493,21 @@ public:
         }
         join_observer();
 
-        if (!workload_completed || capture_cancelled ||
-            cancelled(should_abort_)) {
+        if (capture_cancelled || cancelled(should_abort_)) {
             return capture_failure("profiling workload did not complete");
+        }
+        if (!workload_result.succeeded()) {
+            return capture_failure(
+                workload_result.diagnostic().empty()
+                    ? "profiling workload did not complete"
+                    : workload_result.diagnostic());
+        }
+        if (release_result == nullptr || !release_result->succeeded()) {
+            return capture_failure(
+                release_result == nullptr ||
+                        release_result->diagnostic().empty()
+                    ? "profiling workload release was not verified"
+                    : release_result->diagnostic());
         }
         return seal_capture();
     }

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -542,12 +542,7 @@ public:
 
         const auto *release_result = release_guard.release();
         if (release_result == nullptr || !release_result->succeeded()) {
-            return finish_failed_capture(
-                select_capture_failure_diagnostic(
-                    workload_result, release_result,
-                    workload_observed_actionable_observer_failure.load(
-                        std::memory_order_acquire),
-                    {}));
+            return finish_after_release({});
         }
         {
             std::lock_guard<std::mutex> lock(mutex_);
@@ -701,6 +696,8 @@ private:
             }
             condition_.notify_all();
         } catch (...) {
+            actionable_observer_failed_.store(
+                true, std::memory_order_release);
             fail_observer("profiling observer failed");
         }
     }

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -496,7 +496,11 @@ public:
         const bool capture_cancelled = cancelled(should_abort_);
         if (capture_cancelled) {
             return finish_after_release(
-                "profiling interval capture cancelled");
+                actionable_observer_failed_.load(
+                    std::memory_order_acquire)
+                    ? std::string_view{}
+                    : std::string_view{
+                          "profiling interval capture cancelled"});
         }
         if (!workload_result.succeeded()) {
             return finish_after_release({});
@@ -706,6 +710,11 @@ private:
             const auto polled = recorder_.poll(
                 [this] { return observer_should_abort(); });
             if (!polled.ok()) {
+                if (polled.status !=
+                    ProfilingIntervalRecorderStatus::Cancelled) {
+                    actionable_observer_failed_.store(
+                        true, std::memory_order_release);
+                }
                 fail_observer(polled.diagnostic.empty()
                                   ? "profiling workload observation failed"
                                   : polled.diagnostic);
@@ -944,6 +953,7 @@ private:
     std::mutex mutex_;
     std::condition_variable condition_;
     SharedState state_;
+    std::atomic<bool> actionable_observer_failed_{false};
     std::atomic<bool> observer_failed_{false};
     bool stop_requested_ = false;
     std::string diagnostic_;

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -95,6 +95,28 @@ ProfilingTransactionCapture capture_failure(std::string_view diagnostic) {
         profiling_internal::bounded_diagnostic(std::string(diagnostic))};
 }
 
+std::string_view select_capture_failure_diagnostic(
+    const ProfilingWorkloadStepResult &workload_result,
+    const ProfilingWorkloadStepResult *release_result,
+    std::string_view fallback_diagnostic) noexcept {
+    if (release_result == nullptr) {
+        return "profiling workload release was not verified";
+    }
+    if (!release_result->succeeded()) {
+        return release_result->diagnostic().empty()
+                   ? std::string_view{
+                         "profiling workload release was not verified"}
+                   : release_result->diagnostic();
+    }
+    if (!workload_result.succeeded()) {
+        return workload_result.diagnostic().empty()
+                   ? std::string_view{
+                         "profiling workload did not complete"}
+                   : workload_result.diagnostic();
+    }
+    return fallback_diagnostic;
+}
+
 void initialize_clock(ProfilingCollectionClock &clock) {
     if (!clock.monotonic_now) {
         clock.monotonic_now = [] { return SteadyClock::now(); };
@@ -461,9 +483,24 @@ public:
             });
         } catch (...) {
             workload_result = ProfilingWorkloadStepResult::ambiguous(
-                "profiling workload result was not reported");
+                "profiling workload threw before reporting a result");
         }
+        const auto finish_after_release =
+            [&](std::string_view fallback_diagnostic) {
+                const auto *release_result = release_guard.release();
+                return finish_failed_capture(
+                    select_capture_failure_diagnostic(
+                        workload_result, release_result,
+                        fallback_diagnostic));
+            };
         const bool capture_cancelled = cancelled(should_abort_);
+        if (capture_cancelled) {
+            return finish_after_release(
+                "profiling interval capture cancelled");
+        }
+        if (!workload_result.succeeded()) {
+            return finish_after_release({});
+        }
 
         {
             std::lock_guard<std::mutex> lock(mutex_);
@@ -473,8 +510,7 @@ public:
         if (!wait_until([](const SharedState &state) {
                 return state.workload_boundary_ready || state.failed;
             })) {
-            release_guard.release();
-            return finish_failed_capture();
+            return finish_after_release({});
         }
 
         {
@@ -485,11 +521,15 @@ public:
         if (!wait_until([](const SharedState &state) {
                 return state.release_observer_ready || state.failed;
             })) {
-            release_guard.release();
-            return finish_failed_capture();
+            return finish_after_release({});
         }
 
         const auto *release_result = release_guard.release();
+        if (release_result == nullptr || !release_result->succeeded()) {
+            return finish_failed_capture(
+                select_capture_failure_diagnostic(
+                    workload_result, release_result, {}));
+        }
         {
             std::lock_guard<std::mutex> lock(mutex_);
             state_.release_done = true;
@@ -502,21 +542,8 @@ public:
         }
         join_observer();
 
-        if (capture_cancelled || cancelled(should_abort_)) {
-            return capture_failure("profiling workload did not complete");
-        }
-        if (!workload_result.succeeded()) {
-            return capture_failure(
-                workload_result.diagnostic().empty()
-                    ? "profiling workload did not complete"
-                    : workload_result.diagnostic());
-        }
-        if (release_result == nullptr || !release_result->succeeded()) {
-            return capture_failure(
-                release_result == nullptr ||
-                        release_result->diagnostic().empty()
-                    ? "profiling workload release was not verified"
-                    : release_result->diagnostic());
+        if (cancelled(should_abort_)) {
+            return capture_failure("profiling interval capture cancelled");
         }
         return seal_capture();
     }
@@ -797,14 +824,16 @@ private:
                 : result.diagnostic);
     }
 
-    ProfilingTransactionCapture finish_failed_capture() {
+    ProfilingTransactionCapture finish_failed_capture(
+        std::string_view diagnostic = {}) {
         {
             std::lock_guard<std::mutex> lock(mutex_);
             stop_requested_ = true;
         }
         condition_.notify_all();
         join_observer();
-        return capture_failure(diagnostic_);
+        return capture_failure(
+            diagnostic.empty() ? std::string_view{diagnostic_} : diagnostic);
     }
 
     void join_observer() {

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -20,8 +20,22 @@ namespace lemon::residency {
 
 ProfilingWorkloadStepResult::ProfilingWorkloadStepResult(
     ProfilingWorkloadStepStatus status,
-    std::string diagnostic) noexcept
-    : status_(status), diagnostic_(std::move(diagnostic)) {}
+    std::string_view diagnostic) noexcept
+    : status_(status) {
+    auto boundary = diagnostic.size();
+    if (boundary > diagnostic_.size()) {
+        boundary = diagnostic_.size();
+        while (boundary > 0 &&
+               (static_cast<unsigned char>(diagnostic[boundary]) & 0xc0u) ==
+                   0x80u) {
+            --boundary;
+        }
+    }
+    for (std::size_t index = 0; index < boundary; ++index) {
+        diagnostic_[index] = diagnostic[index];
+    }
+    diagnostic_size_ = boundary;
+}
 
 ProfilingWorkloadStepResult ProfilingWorkloadStepResult::success() noexcept {
     return ProfilingWorkloadStepResult{
@@ -29,24 +43,21 @@ ProfilingWorkloadStepResult ProfilingWorkloadStepResult::success() noexcept {
 }
 
 ProfilingWorkloadStepResult ProfilingWorkloadStepResult::cancelled(
-    std::string diagnostic) {
+    std::string_view diagnostic) noexcept {
     return ProfilingWorkloadStepResult{
-        ProfilingWorkloadStepStatus::Cancelled,
-        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+        ProfilingWorkloadStepStatus::Cancelled, diagnostic};
 }
 
 ProfilingWorkloadStepResult ProfilingWorkloadStepResult::failed(
-    std::string diagnostic) {
+    std::string_view diagnostic) noexcept {
     return ProfilingWorkloadStepResult{
-        ProfilingWorkloadStepStatus::Failed,
-        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+        ProfilingWorkloadStepStatus::Failed, diagnostic};
 }
 
 ProfilingWorkloadStepResult ProfilingWorkloadStepResult::ambiguous(
-    std::string diagnostic) {
+    std::string_view diagnostic) noexcept {
     return ProfilingWorkloadStepResult{
-        ProfilingWorkloadStepStatus::Ambiguous,
-        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+        ProfilingWorkloadStepStatus::Ambiguous, diagnostic};
 }
 
 ProfilingWorkloadStepStatus
@@ -54,9 +65,9 @@ ProfilingWorkloadStepResult::status() const noexcept {
     return status_;
 }
 
-const std::string &
+std::string_view
 ProfilingWorkloadStepResult::diagnostic() const noexcept {
-    return diagnostic_;
+    return {diagnostic_.data(), diagnostic_size_};
 }
 
 bool ProfilingWorkloadStepResult::succeeded() const noexcept {
@@ -77,13 +88,11 @@ using profiling_internal::sha256_hex;
 constexpr std::string_view phase_provenance_domain =
     "lemonade/profiling-phase-interval/v1";
 
-ProfilingTransactionCapture capture_failure(std::string diagnostic) {
-    if (diagnostic.empty()) {
-        diagnostic = "profiling interval capture failed";
-    }
+ProfilingTransactionCapture capture_failure(std::string_view diagnostic) {
+    if (diagnostic.empty()) diagnostic = "profiling interval capture failed";
     return ProfilingTransactionCapture{
         {}, {}, {},
-        profiling_internal::bounded_diagnostic(std::move(diagnostic))};
+        profiling_internal::bounded_diagnostic(std::string(diagnostic))};
 }
 
 void initialize_clock(ProfilingCollectionClock &clock) {

--- a/src/cpp/server/residency/profiling_capture_authority.cpp
+++ b/src/cpp/server/residency/profiling_capture_authority.cpp
@@ -98,6 +98,7 @@ ProfilingTransactionCapture capture_failure(std::string_view diagnostic) {
 std::string_view select_capture_failure_diagnostic(
     const ProfilingWorkloadStepResult &workload_result,
     const ProfilingWorkloadStepResult *release_result,
+    bool workload_observed_actionable_observer_failure,
     std::string_view fallback_diagnostic) noexcept {
     if (release_result == nullptr) {
         return "profiling workload release was not verified";
@@ -108,6 +109,7 @@ std::string_view select_capture_failure_diagnostic(
                          "profiling workload release was not verified"}
                    : release_result->diagnostic();
     }
+    if (workload_observed_actionable_observer_failure) return {};
     if (!workload_result.succeeded()) {
         return workload_result.diagnostic().empty()
                    ? std::string_view{
@@ -475,12 +477,24 @@ public:
         WorkloadReleaseGuard release_guard(router_, context_, workload_);
         auto workload_result = ProfilingWorkloadStepResult::ambiguous(
             "profiling workload result was not reported");
+        std::atomic<bool> workload_observed_actionable_observer_failure{
+            false};
         release_guard.enter();
         try {
-            workload_result = workload_.run(router_, context_, [this] {
-                return observer_failed_.load(std::memory_order_acquire) ||
-                       cancelled(should_abort_);
-            });
+            workload_result = workload_.run(
+                router_, context_,
+                [this,
+                 &workload_observed_actionable_observer_failure] {
+                    const bool observer_failed = observer_failed_.load(
+                        std::memory_order_acquire);
+                    if (observer_failed &&
+                        actionable_observer_failed_.load(
+                            std::memory_order_acquire)) {
+                        workload_observed_actionable_observer_failure.store(
+                            true, std::memory_order_release);
+                    }
+                    return observer_failed || cancelled(should_abort_);
+                });
         } catch (...) {
             workload_result = ProfilingWorkloadStepResult::ambiguous(
                 "profiling workload threw before reporting a result");
@@ -491,16 +505,14 @@ public:
                 return finish_failed_capture(
                     select_capture_failure_diagnostic(
                         workload_result, release_result,
+                        workload_observed_actionable_observer_failure.load(
+                            std::memory_order_acquire),
                         fallback_diagnostic));
             };
         const bool capture_cancelled = cancelled(should_abort_);
         if (capture_cancelled) {
             return finish_after_release(
-                actionable_observer_failed_.load(
-                    std::memory_order_acquire)
-                    ? std::string_view{}
-                    : std::string_view{
-                          "profiling interval capture cancelled"});
+                "profiling interval capture cancelled");
         }
         if (!workload_result.succeeded()) {
             return finish_after_release({});
@@ -532,7 +544,10 @@ public:
         if (release_result == nullptr || !release_result->succeeded()) {
             return finish_failed_capture(
                 select_capture_failure_diagnostic(
-                    workload_result, release_result, {}));
+                    workload_result, release_result,
+                    workload_observed_actionable_observer_failure.load(
+                        std::memory_order_acquire),
+                    {}));
         }
         {
             std::lock_guard<std::mutex> lock(mutex_);

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -426,6 +426,8 @@ struct DynamicIntervalScenario {
     std::shared_ptr<std::atomic<bool>> stall_reads_until_abort;
     std::optional<DynamicFrameReading> release_stability_event;
     std::optional<DynamicFrameReading> final_drain_event;
+    ProfilingIntervalSourceError workload_read_error =
+        ProfilingIntervalSourceError::None;
     bool throw_on_finish = false;
 };
 
@@ -522,6 +524,17 @@ public:
 
         auto &stage_read_calls = read_calls_by_stage_[stage_index(stage_)];
         ++stage_read_calls;
+        if (stage_ == SourceStage::Workload &&
+            scenario_.workload_read_error !=
+                ProfilingIntervalSourceError::None) {
+            return failure_batch(
+                scenario_.workload_read_error,
+                after_event_watermark,
+                scenario_.workload_read_error ==
+                        ProfilingIntervalSourceError::Cancelled
+                    ? "dynamic workload observation cancelled"
+                    : "dynamic workload observation failed");
+        }
         if (stage_ == SourceStage::Baseline && stage_read_calls == 1 &&
             !scenario_.baseline_stability_events.empty()) {
             for (const auto &reading :
@@ -1191,6 +1204,40 @@ public:
     std::string_view run_diagnostic_;
     ProfilingWorkloadStepStatus release_status_;
     std::string_view release_diagnostic_;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+};
+
+class ObserverFailureCancellationDriver final
+    : public ProfilingWorkloadDriver {
+public:
+    ObserverFailureCancellationDriver(
+        DynamicIntervalSource &source,
+        std::atomic<bool> &caller_cancelled)
+        : source_(source), caller_cancelled_(caller_cancelled) {}
+
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &should_abort) override {
+        ++run_calls;
+        source_.publish_workload();
+        while (!should_abort || !should_abort()) {
+            std::this_thread::yield();
+        }
+        caller_cancelled_.store(true, std::memory_order_release);
+        return ProfilingWorkloadStepResult::success();
+    }
+
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+        return ProfilingWorkloadStepResult::success();
+    }
+
+    DynamicIntervalSource &source_;
+    std::atomic<bool> &caller_cancelled_;
     std::size_t run_calls = 0;
     std::size_t release_calls = 0;
 };
@@ -1909,6 +1956,55 @@ void test_boundary_cancellation_preserves_release_ambiguity(
         "workload-boundary cancellation preserves release ambiguity and cleans up exactly once");
 }
 
+void test_observer_status_precedes_caller_cancellation(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    struct ObserverStatusCase {
+        ProfilingIntervalSourceError error;
+        std::string_view expected_diagnostic;
+        const char *message;
+    };
+    const std::array<ObserverStatusCase, 2> observer_status_cases{{
+        {ProfilingIntervalSourceError::Failed,
+         "dynamic workload observation failed",
+         "an actionable observer failure remains specific when cancellation follows"},
+        {ProfilingIntervalSourceError::Cancelled,
+         "profiling interval capture cancelled",
+         "an observer cancellation retains the canonical cancellation diagnostic"},
+    }};
+
+    for (const auto &observer_status_case : observer_status_cases) {
+        std::atomic<bool> caller_cancelled{false};
+        DynamicIntervalScenario scenario;
+        scenario.workload_read_error = observer_status_case.error;
+        auto shared_clock = std::make_shared<SharedCaptureClock>();
+        DynamicIntervalSource source(
+            derivation_contract, shared_clock, std::move(scenario));
+        ObserverFailureCancellationDriver driver(source, caller_cancelled);
+        ProfilingCaptureAuthority authority(
+            derivation_contract, source, schedule(shared_clock));
+
+        const auto captured = authority.capture(
+            router, transaction_context, driver, [&] {
+                return caller_cancelled.load(std::memory_order_acquire);
+            });
+
+        require_empty_capture(
+            state, captured,
+            "an observer rejection followed by cancellation publishes no phase-evidence candidate");
+        state.require(
+            caller_cancelled.load(std::memory_order_acquire) &&
+                captured.diagnostic ==
+                    observer_status_case.expected_diagnostic &&
+                driver.run_calls == 1 && driver.release_calls == 1 &&
+                source.finish_calls() == 1 && !source.active() &&
+                source.observer_thread_exited(),
+            observer_status_case.message);
+    }
+}
+
 void test_predispatch_abort_never_enters_workload_ownership(
     TestState &state,
     Router &router) {
@@ -2162,6 +2258,7 @@ int main() {
             state, router);
         test_boundary_cancellation_preserves_release_ambiguity(
             state, router);
+        test_observer_status_precedes_caller_cancellation(state, router);
         test_predispatch_abort_never_enters_workload_ownership(
             state, router);
         test_release_settling_abort_closes_owned_workload(state, router);

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -1540,72 +1540,72 @@ void test_reported_workload_results_gate_phase_evidence(
     Router &router) {
     const auto derivation_contract = contract();
     const auto transaction_context = context(derivation_contract);
-    const auto bounded_failure = ProfilingWorkloadStepResult::failed(
-        std::string(max_local_overlay_diagnostic_bytes + 64, 'x'));
+    auto long_diagnostic =
+        std::string(max_local_overlay_diagnostic_bytes - 1, 'x');
+    long_diagnostic += "\xe2\x82\xac";
+    const auto bounded_failure =
+        ProfilingWorkloadStepResult::failed(long_diagnostic);
     state.require(
         bounded_failure.status() == ProfilingWorkloadStepStatus::Failed &&
             !bounded_failure.succeeded() &&
             bounded_failure.diagnostic().size() <=
-                max_local_overlay_diagnostic_bytes,
+                max_local_overlay_diagnostic_bytes &&
+            bounded_failure.diagnostic() ==
+                std::string_view(long_diagnostic).substr(
+                    0, max_local_overlay_diagnostic_bytes - 1),
         "workload step results retain an explicit state and bounded diagnostic");
 
-    auto load_clock = std::make_shared<SharedCaptureClock>();
-    DynamicIntervalSource load_source(derivation_contract, load_clock);
-    ReportingDriver load_driver(
-        load_source, ProfilingWorkloadStepStatus::Failed,
-        ProfilingWorkloadStepStatus::Succeeded);
-    ProfilingCaptureAuthority load_authority(
-        derivation_contract, load_source, schedule(load_clock));
-    const auto load_capture = load_authority.capture(
-        router, transaction_context, load_driver, [] { return false; });
-    require_empty_capture(
-        state, load_capture,
-        "a reported load failure publishes no phase-evidence candidate");
-    state.require(
-        load_driver.run_calls == 1 && load_driver.release_calls == 1 &&
-            load_source.finish_calls() == 1 && !load_source.active() &&
-            load_source.observer_thread_exited(),
-        "a reported load failure still releases, drains, and joins exactly once");
+    struct ReportedResultCase {
+        ProfilingWorkloadStepStatus run_status;
+        ProfilingWorkloadStepStatus release_status;
+        const char *candidate_message;
+        const char *cleanup_message;
+    };
+    const std::array<ReportedResultCase, 6> reported_result_cases{{
+        {ProfilingWorkloadStepStatus::Failed,
+         ProfilingWorkloadStepStatus::Succeeded,
+         "a reported load failure publishes no phase-evidence candidate",
+         "a reported load failure still cleans up exactly once"},
+        {ProfilingWorkloadStepStatus::Cancelled,
+         ProfilingWorkloadStepStatus::Succeeded,
+         "a reported load cancellation publishes no phase-evidence candidate",
+         "a reported load cancellation still cleans up exactly once"},
+        {ProfilingWorkloadStepStatus::Ambiguous,
+         ProfilingWorkloadStepStatus::Succeeded,
+         "an ambiguous load publishes no phase-evidence candidate",
+         "an ambiguous load still cleans up exactly once"},
+        {ProfilingWorkloadStepStatus::Succeeded,
+         ProfilingWorkloadStepStatus::Ambiguous,
+         "an ambiguous release publishes no phase-evidence candidate",
+         "an ambiguous release still cleans up exactly once"},
+        {ProfilingWorkloadStepStatus::Succeeded,
+         ProfilingWorkloadStepStatus::Failed,
+         "a failed release publishes no phase-evidence candidate",
+         "a failed release still cleans up exactly once"},
+        {ProfilingWorkloadStepStatus::Succeeded,
+         ProfilingWorkloadStepStatus::Cancelled,
+         "a cancelled release publishes no phase-evidence candidate",
+         "a cancelled release still cleans up exactly once"},
+    }};
 
-    auto ambiguous_clock = std::make_shared<SharedCaptureClock>();
-    DynamicIntervalSource ambiguous_source(
-        derivation_contract, ambiguous_clock);
-    ReportingDriver ambiguous_driver(
-        ambiguous_source, ProfilingWorkloadStepStatus::Succeeded,
-        ProfilingWorkloadStepStatus::Ambiguous);
-    ProfilingCaptureAuthority ambiguous_authority(
-        derivation_contract, ambiguous_source, schedule(ambiguous_clock));
-    const auto ambiguous_capture = ambiguous_authority.capture(
-        router, transaction_context, ambiguous_driver,
-        [] { return false; });
-    require_empty_capture(
-        state, ambiguous_capture,
-        "an ambiguous release publishes no phase-evidence candidate");
-    state.require(
-        ambiguous_driver.run_calls == 1 &&
-            ambiguous_driver.release_calls == 1 &&
-            ambiguous_source.finish_calls() == 1 &&
-            !ambiguous_source.active() &&
-            ambiguous_source.observer_thread_exited(),
-        "an ambiguous release still drains and joins exactly once");
-
-    auto failed_clock = std::make_shared<SharedCaptureClock>();
-    DynamicIntervalSource failed_source(derivation_contract, failed_clock);
-    ReportingDriver failed_driver(
-        failed_source, ProfilingWorkloadStepStatus::Succeeded,
-        ProfilingWorkloadStepStatus::Failed);
-    ProfilingCaptureAuthority failed_authority(
-        derivation_contract, failed_source, schedule(failed_clock));
-    const auto failed_capture = failed_authority.capture(
-        router, transaction_context, failed_driver, [] { return false; });
-    require_empty_capture(
-        state, failed_capture,
-        "a failed release publishes no phase-evidence candidate");
-    state.require(
-        failed_driver.run_calls == 1 && failed_driver.release_calls == 1 &&
-            failed_source.finish_calls() == 1 && !failed_source.active() &&
-            failed_source.observer_thread_exited(),
-        "a failed release still drains and joins exactly once");
+    for (const auto &reported_result_case : reported_result_cases) {
+        auto shared_clock = std::make_shared<SharedCaptureClock>();
+        DynamicIntervalSource source(derivation_contract, shared_clock);
+        ReportingDriver driver(
+            source, reported_result_case.run_status,
+            reported_result_case.release_status);
+        ProfilingCaptureAuthority authority(
+            derivation_contract, source, schedule(shared_clock));
+        const auto captured = authority.capture(
+            router, transaction_context, driver, [] { return false; });
+        require_empty_capture(
+            state, captured, reported_result_case.candidate_message);
+        state.require(
+            driver.run_calls == 1 && driver.release_calls == 1 &&
+                source.finish_calls() == 1 && !source.active() &&
+                source.observer_thread_exited(),
+            reported_result_case.cleanup_message);
+    }
 }
 
 void test_predispatch_abort_never_enters_workload_ownership(

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -27,6 +27,17 @@ using namespace lemon::residency;
 using namespace std::chrono_literals;
 
 static_assert(std::has_virtual_destructor_v<ProfilingWorkloadDriver>);
+static_assert(std::is_same_v<
+              decltype(std::declval<ProfilingWorkloadDriver &>().run(
+                  std::declval<Router &>(),
+                  std::declval<const ProfilingTransactionContext &>(),
+                  std::declval<const ProfilingCancellationCheck &>())),
+              ProfilingWorkloadStepResult>);
+static_assert(std::is_same_v<
+              decltype(std::declval<ProfilingWorkloadDriver &>().release(
+                  std::declval<Router &>(),
+                  std::declval<const ProfilingTransactionContext &>())),
+              ProfilingWorkloadStepResult>);
 static_assert(noexcept(std::declval<ProfilingWorkloadDriver &>().release(
     std::declval<Router &>(),
     std::declval<const ProfilingTransactionContext &>())));
@@ -772,15 +783,19 @@ private:
 
 class CountingDriver final : public ProfilingWorkloadDriver {
 public:
-    void run(Router &,
-             const ProfilingTransactionContext &,
-             const ProfilingCancellationCheck &) override {
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &) override {
         ++run_calls;
+        return ProfilingWorkloadStepResult::success();
     }
 
-    void release(Router &,
-                 const ProfilingTransactionContext &) noexcept override {
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
         ++release_calls;
+        return ProfilingWorkloadStepResult::success();
     }
 
     std::size_t run_calls = 0;
@@ -828,9 +843,10 @@ public:
     explicit CoordinatedDriver(DynamicIntervalSource &source)
         : source_(source) {}
 
-    void run(Router &router,
-             const ProfilingTransactionContext &context,
-             const ProfilingCancellationCheck &should_abort) override {
+    ProfilingWorkloadStepResult run(
+        Router &router,
+        const ProfilingTransactionContext &context,
+        const ProfilingCancellationCheck &should_abort) override {
         ++run_calls;
         run_thread = std::this_thread::get_id();
         run_thread_token = current_thread_token();
@@ -838,10 +854,16 @@ public:
         transaction_id = context.profiling_transaction_id;
         source_.publish_workload();
         aborted_during_run = should_abort && should_abort();
+        if (aborted_during_run) {
+            return ProfilingWorkloadStepResult::cancelled(
+                "profiling workload was cancelled");
+        }
+        return ProfilingWorkloadStepResult::success();
     }
 
-    void release(Router &router,
-                 const ProfilingTransactionContext &context) noexcept override {
+    ProfilingWorkloadStepResult release(
+        Router &router,
+        const ProfilingTransactionContext &context) noexcept override {
         ++release_calls;
         release_thread = std::this_thread::get_id();
         release_thread_token = current_thread_token();
@@ -851,7 +873,10 @@ public:
             source_.publish_release();
         } catch (...) {
             release_failed = true;
+            return ProfilingWorkloadStepResult::failed(
+                "profiling workload release failed");
         }
+        return ProfilingWorkloadStepResult::success();
     }
 
     DynamicIntervalSource &source_;
@@ -885,9 +910,10 @@ public:
           publish_release_(publish_release),
           caller_cancelled_(caller_cancelled) {}
 
-    void run(Router &,
-             const ProfilingTransactionContext &,
-             const ProfilingCancellationCheck &) override {
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &) override {
         ++run_calls;
         source_.publish_workload();
         if (outcome_ == DriverRunOutcome::Cancel && caller_cancelled_) {
@@ -896,17 +922,29 @@ public:
         if (outcome_ == DriverRunOutcome::Throw) {
             throw std::runtime_error("adversarial workload failure");
         }
+        if (outcome_ == DriverRunOutcome::Cancel) {
+            return ProfilingWorkloadStepResult::cancelled(
+                "adversarial workload cancelled");
+        }
+        return ProfilingWorkloadStepResult::success();
     }
 
-    void release(Router &,
-                 const ProfilingTransactionContext &) noexcept override {
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
         ++release_calls;
-        if (!publish_release_) return;
+        if (!publish_release_) {
+            return ProfilingWorkloadStepResult::ambiguous(
+                "workload release was not verified");
+        }
         try {
             source_.publish_release();
         } catch (...) {
             release_failed = true;
+            return ProfilingWorkloadStepResult::failed(
+                "workload release failed");
         }
+        return ProfilingWorkloadStepResult::success();
     }
 
     DynamicIntervalSource &source_;
@@ -916,6 +954,67 @@ public:
     std::size_t run_calls = 0;
     std::size_t release_calls = 0;
     bool release_failed = false;
+};
+
+ProfilingWorkloadStepResult reported_step_result(
+    ProfilingWorkloadStepStatus status,
+    std::string diagnostic) {
+    switch (status) {
+    case ProfilingWorkloadStepStatus::Succeeded:
+        return ProfilingWorkloadStepResult::success();
+    case ProfilingWorkloadStepStatus::Cancelled:
+        return ProfilingWorkloadStepResult::cancelled(
+            std::move(diagnostic));
+    case ProfilingWorkloadStepStatus::Failed:
+        return ProfilingWorkloadStepResult::failed(std::move(diagnostic));
+    case ProfilingWorkloadStepStatus::Ambiguous:
+        return ProfilingWorkloadStepResult::ambiguous(
+            std::move(diagnostic));
+    default:
+        return ProfilingWorkloadStepResult::ambiguous(
+            "workload step returned an unknown result");
+    }
+}
+
+class ReportingDriver final : public ProfilingWorkloadDriver {
+public:
+    ReportingDriver(DynamicIntervalSource &source,
+                    ProfilingWorkloadStepStatus run_status,
+                    ProfilingWorkloadStepStatus release_status)
+        : source_(source), run_status_(run_status),
+          release_status_(release_status) {}
+
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &) override {
+        ++run_calls;
+        source_.publish_workload();
+        return reported_step_result(run_status_, "model load failed");
+    }
+
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+        try {
+            source_.publish_release();
+        } catch (...) {
+            return ProfilingWorkloadStepResult::failed(
+                "workload release transition failed");
+        }
+        return reported_step_result(
+            release_status_,
+            release_status_ == ProfilingWorkloadStepStatus::Ambiguous
+                ? "workload release outcome is ambiguous"
+                : "workload release failed");
+    }
+
+    DynamicIntervalSource &source_;
+    ProfilingWorkloadStepStatus run_status_;
+    ProfilingWorkloadStepStatus release_status_;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
 };
 
 void require_empty_capture(TestState &state,
@@ -1429,6 +1528,79 @@ void test_workload_failure_and_cancellation_close_the_interval(
         "caller cancellation releases once, finishes once, joins the observer, and returns no live token");
 }
 
+void test_reported_workload_results_gate_phase_evidence(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    const auto bounded_failure = ProfilingWorkloadStepResult::failed(
+        std::string(max_local_overlay_diagnostic_bytes + 64, 'x'));
+    state.require(
+        bounded_failure.status() == ProfilingWorkloadStepStatus::Failed &&
+            !bounded_failure.succeeded() &&
+            bounded_failure.diagnostic().size() <=
+                max_local_overlay_diagnostic_bytes,
+        "workload step results retain an explicit state and bounded diagnostic");
+
+    auto load_clock = std::make_shared<SharedCaptureClock>();
+    DynamicIntervalSource load_source(derivation_contract, load_clock);
+    ReportingDriver load_driver(
+        load_source, ProfilingWorkloadStepStatus::Failed,
+        ProfilingWorkloadStepStatus::Succeeded);
+    ProfilingCaptureAuthority load_authority(
+        derivation_contract, load_source, schedule(load_clock));
+    const auto load_capture = load_authority.capture(
+        router, transaction_context, load_driver, [] { return false; });
+    require_empty_capture(
+        state, load_capture,
+        "a reported load failure publishes no phase-evidence candidate");
+    state.require(
+        load_driver.run_calls == 1 && load_driver.release_calls == 1 &&
+            load_source.finish_calls() == 1 && !load_source.active() &&
+            load_source.observer_thread_exited(),
+        "a reported load failure still releases, drains, and joins exactly once");
+
+    auto ambiguous_clock = std::make_shared<SharedCaptureClock>();
+    DynamicIntervalSource ambiguous_source(
+        derivation_contract, ambiguous_clock);
+    ReportingDriver ambiguous_driver(
+        ambiguous_source, ProfilingWorkloadStepStatus::Succeeded,
+        ProfilingWorkloadStepStatus::Ambiguous);
+    ProfilingCaptureAuthority ambiguous_authority(
+        derivation_contract, ambiguous_source, schedule(ambiguous_clock));
+    const auto ambiguous_capture = ambiguous_authority.capture(
+        router, transaction_context, ambiguous_driver,
+        [] { return false; });
+    require_empty_capture(
+        state, ambiguous_capture,
+        "an ambiguous release publishes no phase-evidence candidate");
+    state.require(
+        ambiguous_driver.run_calls == 1 &&
+            ambiguous_driver.release_calls == 1 &&
+            ambiguous_source.finish_calls() == 1 &&
+            !ambiguous_source.active() &&
+            ambiguous_source.observer_thread_exited(),
+        "an ambiguous release still drains and joins exactly once");
+
+    auto failed_clock = std::make_shared<SharedCaptureClock>();
+    DynamicIntervalSource failed_source(derivation_contract, failed_clock);
+    ReportingDriver failed_driver(
+        failed_source, ProfilingWorkloadStepStatus::Succeeded,
+        ProfilingWorkloadStepStatus::Failed);
+    ProfilingCaptureAuthority failed_authority(
+        derivation_contract, failed_source, schedule(failed_clock));
+    const auto failed_capture = failed_authority.capture(
+        router, transaction_context, failed_driver, [] { return false; });
+    require_empty_capture(
+        state, failed_capture,
+        "a failed release publishes no phase-evidence candidate");
+    state.require(
+        failed_driver.run_calls == 1 && failed_driver.release_calls == 1 &&
+            failed_source.finish_calls() == 1 && !failed_source.active() &&
+            failed_source.observer_thread_exited(),
+        "a failed release still drains and joins exactly once");
+}
+
 void test_predispatch_abort_never_enters_workload_ownership(
     TestState &state,
     Router &router) {
@@ -1677,6 +1849,7 @@ int main() {
             state, router);
         test_workload_failure_and_cancellation_close_the_interval(
             state, router);
+        test_reported_workload_results_gate_phase_evidence(state, router);
         test_predispatch_abort_never_enters_workload_ownership(
             state, router);
         test_release_settling_abort_closes_owned_workload(state, router);

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -41,6 +42,12 @@ static_assert(std::is_same_v<
 static_assert(noexcept(std::declval<ProfilingWorkloadDriver &>().release(
     std::declval<Router &>(),
     std::declval<const ProfilingTransactionContext &>())));
+static_assert(noexcept(
+    ProfilingWorkloadStepResult::cancelled(std::string_view{})));
+static_assert(noexcept(
+    ProfilingWorkloadStepResult::failed(std::string_view{})));
+static_assert(noexcept(
+    ProfilingWorkloadStepResult::ambiguous(std::string_view{})));
 
 struct TestState {
     std::atomic<bool> ok{true};

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -1208,13 +1208,23 @@ public:
     std::size_t release_calls = 0;
 };
 
-class ObserverFailureCancellationDriver final
-    : public ProfilingWorkloadDriver {
+class ObserverFailureReportingDriver final : public ProfilingWorkloadDriver {
 public:
-    ObserverFailureCancellationDriver(
+    ObserverFailureReportingDriver(
         DynamicIntervalSource &source,
-        std::atomic<bool> &caller_cancelled)
-        : source_(source), caller_cancelled_(caller_cancelled) {}
+        std::atomic<bool> &caller_cancelled,
+        ProfilingWorkloadStepStatus run_status,
+        std::string_view run_diagnostic,
+        ProfilingWorkloadStepStatus release_status,
+        std::string_view release_diagnostic,
+        bool observe_abort,
+        bool cancel_caller)
+        : source_(source), caller_cancelled_(caller_cancelled),
+          run_status_(run_status), run_diagnostic_(run_diagnostic),
+          release_status_(release_status),
+          release_diagnostic_(release_diagnostic),
+          observe_abort_(observe_abort),
+          cancel_caller_(cancel_caller) {}
 
     ProfilingWorkloadStepResult run(
         Router &,
@@ -1222,22 +1232,35 @@ public:
         const ProfilingCancellationCheck &should_abort) override {
         ++run_calls;
         source_.publish_workload();
-        while (!should_abort || !should_abort()) {
-            std::this_thread::yield();
+        if (observe_abort_) {
+            while (!should_abort || !should_abort()) {
+                std::this_thread::yield();
+            }
+        } else {
+            while (source_.active()) std::this_thread::yield();
         }
-        caller_cancelled_.store(true, std::memory_order_release);
-        return ProfilingWorkloadStepResult::success();
+        if (cancel_caller_) {
+            caller_cancelled_.store(true, std::memory_order_release);
+        }
+        return reported_step_result(run_status_, run_diagnostic_);
     }
 
     ProfilingWorkloadStepResult release(
         Router &,
         const ProfilingTransactionContext &) noexcept override {
         ++release_calls;
-        return ProfilingWorkloadStepResult::success();
+        return reported_step_result(
+            release_status_, release_diagnostic_);
     }
 
     DynamicIntervalSource &source_;
     std::atomic<bool> &caller_cancelled_;
+    ProfilingWorkloadStepStatus run_status_;
+    std::string_view run_diagnostic_;
+    ProfilingWorkloadStepStatus release_status_;
+    std::string_view release_diagnostic_;
+    bool observe_abort_;
+    bool cancel_caller_;
     std::size_t run_calls = 0;
     std::size_t release_calls = 0;
 };
@@ -1956,23 +1979,95 @@ void test_boundary_cancellation_preserves_release_ambiguity(
         "workload-boundary cancellation preserves release ambiguity and cleans up exactly once");
 }
 
-void test_observer_status_precedes_caller_cancellation(
+void test_observer_and_workload_diagnostic_precedence(
     TestState &state,
     Router &router) {
     const auto derivation_contract = contract();
     const auto transaction_context = context(derivation_contract);
     struct ObserverStatusCase {
         ProfilingIntervalSourceError error;
+        ProfilingWorkloadStepStatus run_status;
+        std::string_view run_diagnostic;
+        ProfilingWorkloadStepStatus release_status;
+        std::string_view release_diagnostic;
+        bool observe_abort;
+        bool cancel_caller;
         std::string_view expected_diagnostic;
         const char *message;
     };
-    const std::array<ObserverStatusCase, 2> observer_status_cases{{
+    const std::array<ObserverStatusCase, 8> observer_status_cases{{
         {ProfilingIntervalSourceError::Failed,
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         true,
+         true,
          "dynamic workload observation failed",
          "an actionable observer failure remains specific when cancellation follows"},
         {ProfilingIntervalSourceError::Cancelled,
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         true,
+         true,
          "profiling interval capture cancelled",
          "an observer cancellation retains the canonical cancellation diagnostic"},
+        {ProfilingIntervalSourceError::Failed,
+         ProfilingWorkloadStepStatus::Cancelled,
+         "workload stopped after observer abort",
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         true,
+         false,
+         "dynamic workload observation failed",
+         "a causal observer failure precedes a cooperative workload cancellation"},
+        {ProfilingIntervalSourceError::Failed,
+         ProfilingWorkloadStepStatus::Failed,
+         "workload failed after observer abort",
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         true,
+         false,
+         "dynamic workload observation failed",
+         "a causal observer failure precedes a cooperative workload failure"},
+        {ProfilingIntervalSourceError::Failed,
+         ProfilingWorkloadStepStatus::Failed,
+         "workload failed after observer abort",
+         ProfilingWorkloadStepStatus::Ambiguous,
+         "workload release remained ambiguous",
+         true,
+         false,
+         "workload release remained ambiguous",
+         "release ambiguity precedes a causal observer failure"},
+        {ProfilingIntervalSourceError::Cancelled,
+         ProfilingWorkloadStepStatus::Cancelled,
+         "workload observed cancellation",
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         true,
+         false,
+         "workload observed cancellation",
+         "a non-actionable observer cancellation retains workload precedence"},
+        {ProfilingIntervalSourceError::Failed,
+         ProfilingWorkloadStepStatus::Failed,
+         "independent workload failure",
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         false,
+         false,
+         "independent workload failure",
+         "an unobserved concurrent observer failure retains workload precedence"},
+        {ProfilingIntervalSourceError::Failed,
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         false,
+         true,
+         "profiling interval capture cancelled",
+         "an unobserved concurrent observer failure retains caller cancellation precedence"},
     }};
 
     for (const auto &observer_status_case : observer_status_cases) {
@@ -1982,7 +2077,13 @@ void test_observer_status_precedes_caller_cancellation(
         auto shared_clock = std::make_shared<SharedCaptureClock>();
         DynamicIntervalSource source(
             derivation_contract, shared_clock, std::move(scenario));
-        ObserverFailureCancellationDriver driver(source, caller_cancelled);
+        ObserverFailureReportingDriver driver(
+            source, caller_cancelled, observer_status_case.run_status,
+            observer_status_case.run_diagnostic,
+            observer_status_case.release_status,
+            observer_status_case.release_diagnostic,
+            observer_status_case.observe_abort,
+            observer_status_case.cancel_caller);
         ProfilingCaptureAuthority authority(
             derivation_contract, source, schedule(shared_clock));
 
@@ -1995,7 +2096,8 @@ void test_observer_status_precedes_caller_cancellation(
             state, captured,
             "an observer rejection followed by cancellation publishes no phase-evidence candidate");
         state.require(
-            caller_cancelled.load(std::memory_order_acquire) &&
+            caller_cancelled.load(std::memory_order_acquire) ==
+                    observer_status_case.cancel_caller &&
                 captured.diagnostic ==
                     observer_status_case.expected_diagnostic &&
                 driver.run_calls == 1 && driver.release_calls == 1 &&
@@ -2258,7 +2360,7 @@ int main() {
             state, router);
         test_boundary_cancellation_preserves_release_ambiguity(
             state, router);
-        test_observer_status_precedes_caller_cancellation(state, router);
+        test_observer_and_workload_diagnostic_precedence(state, router);
         test_predispatch_abort_never_enters_workload_ownership(
             state, router);
         test_release_settling_abort_closes_owned_workload(state, router);

--- a/test/cpp/test_residency_profiling_capture_authority.cpp
+++ b/test/cpp/test_residency_profiling_capture_authority.cpp
@@ -423,6 +423,7 @@ struct DynamicIntervalScenario {
     };
     std::vector<DynamicFrameReading> release_events = {{100, 100}};
     std::shared_ptr<ReleaseSettleProbe> release_settle_probe;
+    std::shared_ptr<std::atomic<bool>> stall_reads_until_abort;
     std::optional<DynamicFrameReading> release_stability_event;
     std::optional<DynamicFrameReading> final_drain_event;
     bool throw_on_finish = false;
@@ -498,6 +499,17 @@ public:
                 ProfilingIntervalSourceError::Cancelled,
                 after_event_watermark,
                 "dynamic read cancelled");
+        }
+        while (scenario_.stall_reads_until_abort &&
+               scenario_.stall_reads_until_abort->load(
+                   std::memory_order_acquire)) {
+            if (should_abort && should_abort()) {
+                return failure_batch(
+                    ProfilingIntervalSourceError::Cancelled,
+                    after_event_watermark,
+                    "dynamic stalled read cancelled");
+            }
+            std::this_thread::yield();
         }
         std::lock_guard<std::mutex> lock(mutex_);
         ++read_calls_;
@@ -965,18 +977,16 @@ public:
 
 ProfilingWorkloadStepResult reported_step_result(
     ProfilingWorkloadStepStatus status,
-    std::string diagnostic) {
+    std::string_view diagnostic) noexcept {
     switch (status) {
     case ProfilingWorkloadStepStatus::Succeeded:
         return ProfilingWorkloadStepResult::success();
     case ProfilingWorkloadStepStatus::Cancelled:
-        return ProfilingWorkloadStepResult::cancelled(
-            std::move(diagnostic));
+        return ProfilingWorkloadStepResult::cancelled(diagnostic);
     case ProfilingWorkloadStepStatus::Failed:
-        return ProfilingWorkloadStepResult::failed(std::move(diagnostic));
+        return ProfilingWorkloadStepResult::failed(diagnostic);
     case ProfilingWorkloadStepStatus::Ambiguous:
-        return ProfilingWorkloadStepResult::ambiguous(
-            std::move(diagnostic));
+        return ProfilingWorkloadStepResult::ambiguous(diagnostic);
     default:
         return ProfilingWorkloadStepResult::ambiguous(
             "workload step returned an unknown result");
@@ -1020,6 +1030,167 @@ public:
     DynamicIntervalSource &source_;
     ProfilingWorkloadStepStatus run_status_;
     ProfilingWorkloadStepStatus release_status_;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+};
+
+enum class PretransitionFailureStep {
+    Run,
+    Release,
+};
+
+class PretransitionFailureDriver final : public ProfilingWorkloadDriver {
+public:
+    explicit PretransitionFailureDriver(
+        DynamicIntervalSource &source,
+        std::shared_ptr<std::atomic<bool>> stall_reads_until_abort,
+        PretransitionFailureStep failure_step)
+        : source_(source),
+          stall_reads_until_abort_(std::move(stall_reads_until_abort)),
+          failure_step_(failure_step) {}
+
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &) override {
+        ++run_calls;
+        if (failure_step_ == PretransitionFailureStep::Release) {
+            source_.publish_workload();
+            return ProfilingWorkloadStepResult::success();
+        }
+        stall_reads_until_abort_->store(true, std::memory_order_release);
+        return ProfilingWorkloadStepResult::failed(
+            "model load failed before the workload transition");
+    }
+
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+        if (failure_step_ == PretransitionFailureStep::Release) {
+            stall_reads_until_abort_->store(
+                true, std::memory_order_release);
+            return ProfilingWorkloadStepResult::failed(
+                "model release failed before the release transition");
+        }
+        return ProfilingWorkloadStepResult::success();
+    }
+
+    DynamicIntervalSource &source_;
+    std::shared_ptr<std::atomic<bool>> stall_reads_until_abort_;
+    PretransitionFailureStep failure_step_;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+};
+
+class WorkloadBoundaryCancellation {
+public:
+    explicit WorkloadBoundaryCancellation(std::thread::id owner_thread)
+        : owner_thread_(owner_thread) {}
+
+    void arm() noexcept {
+        state_.store(State::Armed, std::memory_order_release);
+    }
+
+    bool should_abort() noexcept {
+        auto observed = state_.load(std::memory_order_acquire);
+        if (observed == State::Armed &&
+            std::this_thread::get_id() == owner_thread_) {
+            state_.compare_exchange_strong(
+                observed, State::OwnerCheckPassed,
+                std::memory_order_acq_rel);
+            return false;
+        }
+        if (observed == State::OwnerCheckPassed &&
+            std::this_thread::get_id() != owner_thread_) {
+            state_.store(State::Cancelled, std::memory_order_release);
+            return true;
+        }
+        return observed == State::Cancelled;
+    }
+
+    bool cancelled() const noexcept {
+        return state_.load(std::memory_order_acquire) == State::Cancelled;
+    }
+
+private:
+    enum class State {
+        Disarmed,
+        Armed,
+        OwnerCheckPassed,
+        Cancelled,
+    };
+
+    std::thread::id owner_thread_;
+    std::atomic<State> state_{State::Disarmed};
+};
+
+class BoundaryCancellationDriver final : public ProfilingWorkloadDriver {
+public:
+    BoundaryCancellationDriver(
+        DynamicIntervalSource &source,
+        WorkloadBoundaryCancellation &cancellation)
+        : source_(source), cancellation_(cancellation) {}
+
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &) override {
+        ++run_calls;
+        source_.publish_workload();
+        cancellation_.arm();
+        return ProfilingWorkloadStepResult::success();
+    }
+
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+        return ProfilingWorkloadStepResult::ambiguous(
+            "workload release remained ambiguous after boundary cancellation");
+    }
+
+    DynamicIntervalSource &source_;
+    WorkloadBoundaryCancellation &cancellation_;
+    std::size_t run_calls = 0;
+    std::size_t release_calls = 0;
+};
+
+class DiagnosticPolicyDriver final : public ProfilingWorkloadDriver {
+public:
+    DiagnosticPolicyDriver(
+        std::atomic<bool> &caller_cancelled,
+        ProfilingWorkloadStepStatus run_status,
+        std::string_view run_diagnostic,
+        ProfilingWorkloadStepStatus release_status,
+        std::string_view release_diagnostic)
+        : caller_cancelled_(caller_cancelled), run_status_(run_status),
+          run_diagnostic_(run_diagnostic),
+          release_status_(release_status),
+          release_diagnostic_(release_diagnostic) {}
+
+    ProfilingWorkloadStepResult run(
+        Router &,
+        const ProfilingTransactionContext &,
+        const ProfilingCancellationCheck &) override {
+        ++run_calls;
+        caller_cancelled_.store(true, std::memory_order_release);
+        return reported_step_result(run_status_, run_diagnostic_);
+    }
+
+    ProfilingWorkloadStepResult release(
+        Router &,
+        const ProfilingTransactionContext &) noexcept override {
+        ++release_calls;
+        return reported_step_result(
+            release_status_, release_diagnostic_);
+    }
+
+    std::atomic<bool> &caller_cancelled_;
+    ProfilingWorkloadStepStatus run_status_;
+    std::string_view run_diagnostic_;
+    ProfilingWorkloadStepStatus release_status_;
+    std::string_view release_diagnostic_;
     std::size_t run_calls = 0;
     std::size_t release_calls = 0;
 };
@@ -1499,7 +1670,9 @@ void test_workload_failure_and_cancellation_close_the_interval(
         throwing_capture,
         "a workload exception publishes no lifecycle attestations");
     state.require(
-        throwing_driver.run_calls == 1 &&
+        throwing_capture.diagnostic ==
+                "profiling workload threw before reporting a result" &&
+            throwing_driver.run_calls == 1 &&
             throwing_driver.release_calls == 1 &&
             !throwing_driver.release_failed &&
             throwing_source.finish_calls() == 1 &&
@@ -1526,6 +1699,8 @@ void test_workload_failure_and_cancellation_close_the_interval(
         "caller cancellation publishes no lifecycle attestations");
     state.require(
         caller_cancelled.load(std::memory_order_acquire) &&
+            cancelled_capture.diagnostic ==
+                "workload release was not verified" &&
             cancelled_driver.run_calls == 1 &&
             cancelled_driver.release_calls == 1 &&
             !cancelled_driver.release_failed &&
@@ -1606,6 +1781,132 @@ void test_reported_workload_results_gate_phase_evidence(
                 source.observer_thread_exited(),
             reported_result_case.cleanup_message);
     }
+
+    struct DiagnosticPolicyCase {
+        ProfilingWorkloadStepStatus run_status;
+        std::string_view run_diagnostic;
+        ProfilingWorkloadStepStatus release_status;
+        std::string_view release_diagnostic;
+        std::string_view expected_diagnostic;
+    };
+    const std::array<DiagnosticPolicyCase, 5> diagnostic_policy_cases{{
+        {ProfilingWorkloadStepStatus::Failed,
+         "model load failed",
+         ProfilingWorkloadStepStatus::Ambiguous,
+         "workload release remained ambiguous",
+         "workload release remained ambiguous"},
+        {ProfilingWorkloadStepStatus::Failed,
+         "model load failed",
+         ProfilingWorkloadStepStatus::Ambiguous,
+         {},
+         "profiling workload release was not verified"},
+        {ProfilingWorkloadStepStatus::Failed,
+         "model load failed",
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         "model load failed"},
+        {ProfilingWorkloadStepStatus::Ambiguous,
+         {},
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         "profiling workload did not complete"},
+        {ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         ProfilingWorkloadStepStatus::Succeeded,
+         {},
+         "profiling interval capture cancelled"},
+    }};
+
+    for (const auto &diagnostic_policy_case : diagnostic_policy_cases) {
+        std::atomic<bool> caller_cancelled{false};
+        auto shared_clock = std::make_shared<SharedCaptureClock>();
+        DynamicIntervalSource source(derivation_contract, shared_clock);
+        DiagnosticPolicyDriver driver(
+            caller_cancelled, diagnostic_policy_case.run_status,
+            diagnostic_policy_case.run_diagnostic,
+            diagnostic_policy_case.release_status,
+            diagnostic_policy_case.release_diagnostic);
+        ProfilingCaptureAuthority authority(
+            derivation_contract, source, schedule(shared_clock));
+        const auto captured = authority.capture(
+            router, transaction_context, driver, [&] {
+                return caller_cancelled.load(std::memory_order_acquire);
+            });
+        require_empty_capture(
+            state, captured,
+            "a rejected diagnostic-policy case publishes no phase-evidence candidate");
+        state.require(
+            caller_cancelled.load(std::memory_order_acquire) &&
+                captured.diagnostic ==
+                    diagnostic_policy_case.expected_diagnostic &&
+                driver.run_calls == 1 && driver.release_calls == 1 &&
+                source.finish_calls() == 1 && !source.active() &&
+                source.observer_thread_exited(),
+            "diagnostic policy preserves release, workload, and cancellation precedence with exact cleanup");
+    }
+}
+
+void test_reported_step_failure_stops_before_boundary_wait(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    for (const auto failure_step : {
+             PretransitionFailureStep::Run,
+             PretransitionFailureStep::Release,
+         }) {
+        auto stalled_reads = std::make_shared<std::atomic<bool>>(false);
+        DynamicIntervalScenario scenario;
+        scenario.stall_reads_until_abort = stalled_reads;
+        auto shared_clock = std::make_shared<SharedCaptureClock>();
+        DynamicIntervalSource source(
+            derivation_contract, shared_clock, std::move(scenario));
+        PretransitionFailureDriver driver(
+            source, stalled_reads, failure_step);
+        ProfilingCaptureAuthority authority(
+            derivation_contract, source, schedule(shared_clock));
+
+        const auto captured = authority.capture(
+            router, transaction_context, driver, [] { return false; });
+
+        require_empty_capture(
+            state, captured,
+            "a pre-transition step failure publishes no phase-evidence candidate");
+        state.require(
+            driver.run_calls == 1 && driver.release_calls == 1 &&
+                source.finish_calls() == 1 && !source.active() &&
+                source.observer_thread_exited(),
+            "a pre-transition step failure stops observation and cleans up without waiting for a phase boundary");
+    }
+}
+
+void test_boundary_cancellation_preserves_release_ambiguity(
+    TestState &state,
+    Router &router) {
+    const auto derivation_contract = contract();
+    const auto transaction_context = context(derivation_contract);
+    auto shared_clock = std::make_shared<SharedCaptureClock>();
+    DynamicIntervalSource source(derivation_contract, shared_clock);
+    WorkloadBoundaryCancellation cancellation(std::this_thread::get_id());
+    BoundaryCancellationDriver driver(source, cancellation);
+    ProfilingCaptureAuthority authority(
+        derivation_contract, source, schedule(shared_clock));
+
+    const auto captured = authority.capture(
+        router, transaction_context, driver,
+        [&cancellation] { return cancellation.should_abort(); });
+
+    require_empty_capture(
+        state, captured,
+        "workload-boundary cancellation publishes no phase-evidence candidate");
+    state.require(
+        cancellation.cancelled() &&
+            captured.diagnostic ==
+                "workload release remained ambiguous after boundary cancellation" &&
+            driver.run_calls == 1 && driver.release_calls == 1 &&
+            source.finish_calls() == 1 && !source.active() &&
+            source.observer_thread_exited(),
+        "workload-boundary cancellation preserves release ambiguity and cleans up exactly once");
 }
 
 void test_predispatch_abort_never_enters_workload_ownership(
@@ -1857,6 +2158,10 @@ int main() {
         test_workload_failure_and_cancellation_close_the_interval(
             state, router);
         test_reported_workload_results_gate_phase_evidence(state, router);
+        test_reported_step_failure_stops_before_boundary_wait(
+            state, router);
+        test_boundary_cancellation_preserves_release_ambiguity(
+            state, router);
         test_predispatch_abort_never_enters_workload_ownership(
             state, router);
         test_release_settling_abort_closes_owned_workload(state, router);


### PR DESCRIPTION
<details>
<summary><picture><img alt="DIFF" src="https://img.shields.io/badge/DIFF-57606A?style=for-the-badge" height="16"></picture>&nbsp;<picture><img alt="IMPL: 190 additions, 26 deletions" src="https://img.shields.io/badge/IMPL-%2B190%20%E2%88%9226-0969DA?style=flat" height="16"></picture> <picture><img alt="TEST: 701 additions, 17 deletions" src="https://img.shields.io/badge/TEST-%2B701%20%E2%88%9217-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 3 touched" src="https://img.shields.io/badge/FILES-3-5F6B78?style=flat" height="16"></picture></summary>

- <picture><img alt="IMPL: 190 additions, 26 deletions" src="https://img.shields.io/badge/IMPL-%2B190%20%E2%88%9226-0969DA?style=flat" height="16"></picture> <picture><img alt="FILES: 2 implementation files" src="https://img.shields.io/badge/FILES-2-5F6B78?style=flat" height="16"></picture>
  - [`src/cpp/include/lemon/residency/profiling_capture_authority.h`](https://github.com/nisavid/lemonade/pull/142/files#diff-617192056e27f076873c0e13dc040302fbe930c339c58412aed1a7c3eaa2d61c) <picture><img alt="43 additions, 2 deletions" title="43 additions, 2 deletions" src="https://img.shields.io/badge/%2B43-%E2%88%922-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
  - [`src/cpp/server/residency/profiling_capture_authority.cpp`](https://github.com/nisavid/lemonade/pull/142/files#diff-f0ac99c0765754cbc9f5840c333b8a67227585342d46ee4181d3fc6c326237de) <picture><img alt="147 additions, 24 deletions" title="147 additions, 24 deletions" src="https://img.shields.io/badge/%2B147-%E2%88%9224-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>
- <picture><img alt="TEST: 701 additions, 17 deletions" src="https://img.shields.io/badge/TEST-%2B701%20%E2%88%9217-6F5F9A?style=flat" height="16"></picture> <picture><img alt="FILES: 1 test file" src="https://img.shields.io/badge/FILES-1-5F6B78?style=flat" height="16"></picture>
  - [`test/cpp/test_residency_profiling_capture_authority.cpp`](https://github.com/nisavid/lemonade/pull/142/files#diff-10b4b46d03d885bcf37b6c5b8997561a96a3506bf11a1df56f0cc1c5a89dc966) <picture><img alt="701 additions, 17 deletions" title="701 additions, 17 deletions" src="https://img.shields.io/badge/%2B701-%E2%88%9217-CF222E?style=flat&labelColor=1A7F37" height="16"></picture>

</details>

## Summary

Teach the profiling capture authority to treat workload run and release outcomes as typed evidence gates. A cancelled, failed, ambiguous, or thrown step now rejects capture before phase-boundary waits while still completing release, stop, finish, and join cleanup exactly once.

Refs #120. This dependency-safe slice does not complete differential GTT calibration or durable local-overlay activation.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

- Add bounded, allocation-free diagnostics for typed workload step outcomes, including the `noexcept` release path.
- Centralize failure-diagnostic precedence and fail closed before waiting for transitions a rejected step may never publish.
- Preserve actionable observer failures when they trigger workload abort or caller cancellation follows, without making independent workload or cancellation diagnostics race-dependent.
- Cover every non-success placement, cleanup ordering, cancellation boundary, UTF-8 truncation, exception, and diagnostic-precedence case.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build build-debug --target test_residency_profiling_capture_authority` — passed.
- `ctest --test-dir build-debug -R '^ResidencyProfilingCaptureAuthority$' --repeat until-fail:5 --output-on-failure` — passed 5 consecutive runs.
- `ctest --test-dir build-debug -R '^ResidencyProfiling(CaptureAuthority|Transaction|Provider|Interval)$' --output-on-failure` — passed 4/4 tests.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiling workload steps now report explicit outcomes: succeeded, cancelled, failed, or ambiguous.
  * Failure results include concise, UTF-8-safe diagnostic details to aid troubleshooting.
* **Bug Fixes**
  * Improved reporting for workload release failures and execution exceptions.
  * Cancellation and cleanup outcomes are now handled consistently.
  * Diagnostic selection is more reliable when multiple failure details are available.
* **Tests**
  * Expanded coverage for outcome reporting, cancellation, cleanup, diagnostics, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->